### PR TITLE
Add Stokes sphere flow benchmarks

### DIFF
--- a/benchmarks/_benchmark_cases.py
+++ b/benchmarks/_benchmark_cases.py
@@ -1,11 +1,14 @@
+import logging
 import numpy as np
 from scipy.spatial import Delaunay
 import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d.art3d import Poly3DCollection
-from ._benchmark_classes import GeometryBenchmarkBase
+from ._benchmark_classes import GeometryBenchmarkBase, FlowBenchmarkBase
 import pandas as pd
 # benchmarks/_benchmark_cases.py
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 # Generic “just a mesh” case
 class MshCase(GeometryBenchmarkBase):
@@ -271,3 +274,1757 @@ class SphereBenchmark(GeometryBenchmarkBase):
         self.area_analytical = 4 * np.pi * r**2
         self.volume_analytical = (4/3) * np.pi * r**3
         self.H_analytical = np.full(len(self.points), 1 / r)
+
+
+def _configure_background_mesh_field(model, entity_kind, entity_tags, size_min, size_max,
+                                     dist_min, dist_max):
+    """
+    Create a simple distance-threshold background field around an entity set.
+
+    This keeps the obstacle boundary well-resolved while allowing coarser cells
+    away from the sphere.
+    """
+    if not entity_tags:
+        return
+
+    distance = model.mesh.field.add("Distance")
+    key = "CurvesList" if entity_kind == "curve" else "FacesList"
+    model.mesh.field.setNumbers(distance, key, list(entity_tags))
+
+    threshold = model.mesh.field.add("Threshold")
+    model.mesh.field.setNumber(threshold, "InField", distance)
+    model.mesh.field.setNumber(threshold, "SizeMin", float(size_min))
+    model.mesh.field.setNumber(threshold, "SizeMax", float(size_max))
+    model.mesh.field.setNumber(threshold, "DistMin", float(dist_min))
+    model.mesh.field.setNumber(threshold, "DistMax", float(dist_max))
+    model.mesh.field.setAsBackgroundMesh(threshold)
+
+
+def _safe_set_gmsh_option(gmsh_module, name, value):
+    """Set a Gmsh numeric option, ignoring unsupported-option errors."""
+    try:
+        gmsh_module.option.setNumber(str(name), float(value))
+    except Exception:
+        pass
+
+
+def _generate_stokes_sphere_mesh_3d(path, sphere_radius, outer_radius,
+                                    mesh_size_inner, mesh_size_outer,
+                                    mesh_order=2,
+                                    symm_nonobtuse=False,
+                                    equal_edge=False):
+    """
+    Generate a quadratic tetrahedral shell mesh: outer sphere minus inner sphere.
+    """
+    try:
+        import gmsh
+    except ImportError as exc:
+        raise ImportError("gmsh is required to generate the 3D Stokes sphere mesh") from exc
+
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    gmsh.initialize()
+    try:
+        _safe_set_gmsh_option(gmsh, "General.Terminal", 1)
+        gmsh.model.add("stokes_sphere_3d")
+        occ = gmsh.model.occ
+
+        outer = occ.addSphere(0.0, 0.0, 0.0, float(outer_radius))
+        inner = occ.addSphere(0.0, 0.0, 0.0, float(sphere_radius))
+        shell, _ = occ.cut([(3, outer)], [(3, inner)], removeObject=True, removeTool=True)
+        occ.synchronize()
+
+        vol_tags = [tag for dim, tag in shell if dim == 3]
+        gmsh.model.addPhysicalGroup(3, vol_tags, FlowBenchmarkBase.volume_physical_id)
+
+        boundary = gmsh.model.getBoundary(shell, oriented=False, recursive=False)
+        inner_surfaces = []
+        outer_surfaces = []
+        for _, tag in boundary:
+            bbox = gmsh.model.getBoundingBox(2, tag)
+            radius_guess = max(abs(v) for v in bbox)
+            if abs(radius_guess - sphere_radius) <= abs(radius_guess - outer_radius):
+                inner_surfaces.append(tag)
+            else:
+                outer_surfaces.append(tag)
+
+        gmsh.model.addPhysicalGroup(2, inner_surfaces, FlowBenchmarkBase.obstacle_physical_id)
+        gmsh.model.addPhysicalGroup(2, outer_surfaces, FlowBenchmarkBase.outer_boundary_physical_id)
+
+        # Keep independent inner/outer size control for all variants so boundary
+        # element counts can be aligned across benchmark cases.
+        _safe_set_gmsh_option(gmsh, "Mesh.CharacteristicLengthMin", float(mesh_size_inner))
+        _safe_set_gmsh_option(gmsh, "Mesh.CharacteristicLengthMax", float(mesh_size_outer))
+        _safe_set_gmsh_option(gmsh, "Mesh.ElementOrder", int(mesh_order))
+        if symm_nonobtuse:
+            # Deterministic + quality-focused meshing controls.
+            _safe_set_gmsh_option(gmsh, "Mesh.RandomFactor", 0.0)
+            _safe_set_gmsh_option(gmsh, "Mesh.RandomFactor3D", 0.0)
+            _safe_set_gmsh_option(gmsh, "Mesh.Algorithm", 6)
+            _safe_set_gmsh_option(gmsh, "Mesh.Algorithm3D", 10)
+            _safe_set_gmsh_option(gmsh, "Mesh.Optimize", 1)
+            _safe_set_gmsh_option(gmsh, "Mesh.OptimizeNetgen", 1)
+            _safe_set_gmsh_option(gmsh, "Mesh.OptimizeThreshold", 0.35)
+            _safe_set_gmsh_option(gmsh, "Mesh.Smoothing", 100)
+        if equal_edge:
+            # Favor near-equal local edge lengths while preserving boundary
+            # count matching via the same inner/outer sizing field.
+            _safe_set_gmsh_option(gmsh, "Mesh.Algorithm", 6)
+            _safe_set_gmsh_option(gmsh, "Mesh.Algorithm3D", 10)
+            _safe_set_gmsh_option(gmsh, "Mesh.Optimize", 1)
+            _safe_set_gmsh_option(gmsh, "Mesh.OptimizeNetgen", 1)
+            _safe_set_gmsh_option(gmsh, "Mesh.Smoothing", 80)
+
+        _configure_background_mesh_field(
+            gmsh.model,
+            entity_kind="surface",
+            entity_tags=inner_surfaces,
+            size_min=mesh_size_inner,
+            size_max=mesh_size_outer,
+            dist_min=0.25 * sphere_radius,
+            dist_max=max(outer_radius - sphere_radius, mesh_size_outer),
+        )
+
+        gmsh.model.mesh.generate(3)
+        if mesh_order > 1:
+            gmsh.model.mesh.setOrder(int(mesh_order))
+        gmsh.write(str(path))
+    finally:
+        gmsh.finalize()
+
+    return str(path)
+
+
+def _generate_stokes_sphere_mesh_2d(path, sphere_radius, outer_radius,
+                                    mesh_size_inner, mesh_size_outer,
+                                    mesh_order=2,
+                                    symm_nonobtuse=False):
+    """
+    Generate a quadratic axisymmetric meridional mesh on the half-annulus
+    ``{(rho, z): a <= sqrt(rho^2 + z^2) <= R, rho >= 0}``.
+    """
+    try:
+        import gmsh
+    except ImportError as exc:
+        raise ImportError("gmsh is required to generate the 2D Stokes sphere mesh") from exc
+
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    gmsh.initialize()
+    try:
+        _safe_set_gmsh_option(gmsh, "General.Terminal", 1)
+        gmsh.model.add("stokes_sphere_2d_axisymmetric")
+        occ = gmsh.model.occ
+
+        outer = occ.addDisk(0.0, 0.0, 0.0, float(outer_radius), float(outer_radius))
+        inner = occ.addDisk(0.0, 0.0, 0.0, float(sphere_radius), float(sphere_radius))
+        annulus, _ = occ.cut([(2, outer)], [(2, inner)], removeObject=True, removeTool=True)
+
+        half_plane = occ.addRectangle(0.0, -float(outer_radius), 0.0,
+                                      float(outer_radius), 2.0 * float(outer_radius))
+        half_shell, _ = occ.intersect(annulus, [(2, half_plane)],
+                                      removeObject=True, removeTool=True)
+        occ.synchronize()
+
+        surf_tags = [tag for dim, tag in half_shell if dim == 2]
+        gmsh.model.addPhysicalGroup(2, surf_tags, FlowBenchmarkBase.volume_physical_id)
+
+        boundary = gmsh.model.getBoundary(half_shell, oriented=False, recursive=False)
+        inner_curves = []
+        outer_curves = []
+        axis_curves = []
+        axis_tol = max(1.0e-8, 1.0e-6 * float(outer_radius))
+        for _, tag in boundary:
+            xmin, ymin, _, xmax, ymax, _ = gmsh.model.getBoundingBox(1, tag)
+            if max(abs(xmin), abs(xmax)) <= axis_tol:
+                axis_curves.append(tag)
+                continue
+
+            radius_guess = max(abs(xmin), abs(xmax), abs(ymin), abs(ymax))
+            if abs(radius_guess - sphere_radius) <= abs(radius_guess - outer_radius):
+                inner_curves.append(tag)
+            else:
+                outer_curves.append(tag)
+
+        gmsh.model.addPhysicalGroup(1, inner_curves, FlowBenchmarkBase.obstacle_physical_id)
+        gmsh.model.addPhysicalGroup(1, outer_curves, FlowBenchmarkBase.outer_boundary_physical_id)
+        if axis_curves:
+            gmsh.model.addPhysicalGroup(1, axis_curves, FlowBenchmarkBase.axis_physical_id)
+
+        _safe_set_gmsh_option(gmsh, "Mesh.CharacteristicLengthMin", float(mesh_size_inner))
+        _safe_set_gmsh_option(gmsh, "Mesh.CharacteristicLengthMax", float(mesh_size_outer))
+        _safe_set_gmsh_option(gmsh, "Mesh.ElementOrder", int(mesh_order))
+        if symm_nonobtuse:
+            # Deterministic + quality-focused 2D controls (best-effort).
+            _safe_set_gmsh_option(gmsh, "Mesh.RandomFactor", 0.0)
+            _safe_set_gmsh_option(gmsh, "Mesh.Algorithm", 6)
+            _safe_set_gmsh_option(gmsh, "Mesh.Optimize", 1)
+            _safe_set_gmsh_option(gmsh, "Mesh.OptimizeNetgen", 1)
+            _safe_set_gmsh_option(gmsh, "Mesh.OptimizeThreshold", 0.35)
+            _safe_set_gmsh_option(gmsh, "Mesh.Smoothing", 100)
+        _configure_background_mesh_field(
+            gmsh.model,
+            entity_kind="curve",
+            entity_tags=inner_curves,
+            size_min=mesh_size_inner,
+            size_max=mesh_size_outer,
+            dist_min=0.15 * sphere_radius,
+            dist_max=max(outer_radius - sphere_radius, mesh_size_outer),
+        )
+
+        gmsh.model.mesh.generate(2)
+        if mesh_order > 1:
+            gmsh.model.mesh.setOrder(int(mesh_order))
+        gmsh.write(str(path))
+    finally:
+        gmsh.finalize()
+
+    return str(path)
+
+
+def _build_hc_seed_points(dim, bounds, refine_level):
+    """
+    Build an independently generated simplicial seed cloud with hyperct.
+    """
+    try:
+        from hyperct import Complex
+    except ImportError as exc:
+        raise ImportError("hyperct is required for HC-generated Stokes meshes") from exc
+
+    HC_seed = Complex(dim, domain=bounds)
+    HC_seed.triangulate()
+    for _ in range(max(int(refine_level), 0)):
+        HC_seed.refine_all()
+
+    points = np.array([np.asarray(v.x_a, dtype=float) for v in HC_seed.V], dtype=float)
+    if points.ndim != 2 or points.shape[1] != dim:
+        raise ValueError("Failed to build HC seed points with expected shape")
+    return points
+
+
+def _fibonacci_sphere_points(n_points, radius):
+    if n_points <= 0:
+        return np.empty((0, 3), dtype=float)
+    if n_points == 1:
+        return np.array([[0.0, 0.0, float(radius)]], dtype=float)
+
+    k = np.arange(n_points, dtype=float)
+    z = 1.0 - 2.0 * k / (n_points - 1.0)
+    golden = np.pi * (3.0 - np.sqrt(5.0))
+    theta = golden * k
+    r_xy = np.sqrt(np.clip(1.0 - z * z, 0.0, None))
+    x = r_xy * np.cos(theta)
+    y = r_xy * np.sin(theta)
+    pts = np.column_stack([x, y, z])
+    return float(radius) * pts
+
+
+def _symmetric_sphere_points(n_points, radius):
+    """
+    Deterministic sphere samples with exact central pairing ``x <-> -x``.
+    """
+    n_points = int(max(n_points, 0))
+    if n_points == 0:
+        return np.empty((0, 3), dtype=float)
+    if n_points == 1:
+        return np.array([[0.0, 0.0, float(radius)]], dtype=float)
+
+    n_half = max(1, n_points // 2)
+    base = _fibonacci_sphere_points(n_half, radius)
+    paired = np.vstack([base, -base])
+    if n_points % 2 == 1:
+        paired = np.vstack([paired, np.array([[0.0, 0.0, float(radius)]], dtype=float)])
+    return paired[:n_points]
+
+
+def _symmetrize_points_origin(points, dim=3):
+    """
+    Enforce central symmetry by adding mirrored points ``-x``.
+    """
+    points = np.asarray(points, dtype=float)
+    if points.size == 0:
+        return points
+    if dim == 2:
+        mirrored = np.column_stack([points[:, 0], -points[:, 1]])
+    else:
+        mirrored = -points
+    return _unique_rows(np.vstack([points, mirrored]), decimals=12)
+
+
+def _triangle_max_angle_deg(a, b, c):
+    def _ang(u, v):
+        nu = float(np.linalg.norm(u))
+        nv = float(np.linalg.norm(v))
+        if nu < 1.0e-30 or nv < 1.0e-30:
+            return 0.0
+        return float(np.degrees(np.arccos(np.clip(np.dot(u, v) / (nu * nv), -1.0, 1.0))))
+
+    A = _ang(b - a, c - a)
+    B = _ang(a - b, c - b)
+    C = _ang(a - c, b - c)
+    return max(A, B, C)
+
+
+def _tetra_max_face_angle_deg(points, tet):
+    i0, i1, i2, i3 = [int(v) for v in tet[:4]]
+    p0, p1, p2, p3 = points[i0], points[i1], points[i2], points[i3]
+    return max(
+        _triangle_max_angle_deg(p0, p1, p2),
+        _triangle_max_angle_deg(p0, p1, p3),
+        _triangle_max_angle_deg(p0, p2, p3),
+        _triangle_max_angle_deg(p1, p2, p3),
+    )
+
+
+def _augment_points_nonobtuse_shell_3d(points, sphere_radius, outer_radius,
+                                       angle_threshold_deg=120.0, max_new_points=1024,
+                                       iterations=1):
+    """
+    Heuristic obtuse-angle reduction by inserting mirrored Steiner points in
+    high-angle tetrahedra. This is a best-effort quality improvement, not a
+    strict non-obtuse guarantee.
+    """
+    points = np.asarray(points, dtype=float)
+    if points.size == 0:
+        return points
+
+    radial_gap = float(outer_radius) - float(sphere_radius)
+    inner_safe = float(sphere_radius) + 0.08 * radial_gap
+    outer_safe = float(outer_radius) - 0.08 * radial_gap
+
+    for _ in range(max(int(iterations), 0)):
+        try:
+            tri = Delaunay(points)
+        except Exception:
+            break
+        simplices = np.asarray(tri.simplices, dtype=np.int64)
+        if simplices.size == 0:
+            break
+
+        centroids = np.mean(points[simplices], axis=1)
+        rr = np.linalg.norm(centroids[:, :3], axis=1)
+        keep = (rr >= float(sphere_radius) * (1.0 - 1.0e-8)) & (rr <= float(outer_radius) * (1.0 + 1.0e-8))
+        simplices = simplices[keep]
+        centroids = centroids[keep]
+        if simplices.size == 0:
+            break
+
+        bad = []
+        for idx, tet in enumerate(simplices):
+            max_face_ang = _tetra_max_face_angle_deg(points, tet)
+            if max_face_ang > float(angle_threshold_deg):
+                bad.append((max_face_ang, idx))
+        if not bad:
+            break
+
+        bad.sort(reverse=True)
+        new_pts = []
+        for _, idx in bad:
+            c = centroids[idx]
+            r = float(np.linalg.norm(c))
+            if r < inner_safe or r > outer_safe:
+                continue
+            new_pts.append(c)
+            if len(new_pts) >= int(max_new_points // 2):
+                break
+
+        if not new_pts:
+            break
+
+        new_pts = np.asarray(new_pts, dtype=float)
+        points = _unique_rows(np.vstack([points, new_pts, -new_pts]), decimals=12)
+
+    return points
+
+
+def _augment_points_nonobtuse_shell_2d(points, sphere_radius, outer_radius,
+                                       angle_threshold_deg=118.0, max_new_points=512,
+                                       iterations=1):
+    """
+    Best-effort obtuse-angle reduction in the 2D half-annulus by inserting
+    mirrored Steiner points in high-angle triangles.
+    """
+    points = np.asarray(points, dtype=float)
+    if points.size == 0:
+        return points
+
+    radial_gap = float(outer_radius) - float(sphere_radius)
+    inner_safe = float(sphere_radius) + 0.06 * radial_gap
+    outer_safe = float(outer_radius) - 0.06 * radial_gap
+
+    for _ in range(max(int(iterations), 0)):
+        try:
+            tri = Delaunay(points)
+        except Exception:
+            break
+
+        simplices = np.asarray(tri.simplices, dtype=np.int64)
+        if simplices.size == 0:
+            break
+
+        centroids = np.mean(points[simplices], axis=1)
+        rr = _radius_values(centroids, dim=2)
+        keep = (
+            (rr >= float(sphere_radius) * (1.0 - 1.0e-8))
+            & (rr <= float(outer_radius) * (1.0 + 1.0e-8))
+            & (centroids[:, 0] >= -1.0e-10)
+        )
+        simplices = simplices[keep]
+        centroids = centroids[keep]
+        if simplices.size == 0:
+            break
+
+        bad = []
+        for idx, tri_ids in enumerate(simplices):
+            a, b, c = points[int(tri_ids[0])], points[int(tri_ids[1])], points[int(tri_ids[2])]
+            max_ang = _triangle_max_angle_deg(a, b, c)
+            if max_ang > float(angle_threshold_deg):
+                bad.append((max_ang, idx))
+        if not bad:
+            break
+
+        bad.sort(reverse=True)
+        new_pts = []
+        for _, idx in bad:
+            c = centroids[idx]
+            r = float(np.linalg.norm(c))
+            if c[0] < 0.0 or r < inner_safe or r > outer_safe:
+                continue
+
+            cm = np.array([max(float(c[0]), 0.0), -float(c[1])], dtype=float)
+            rm = float(np.linalg.norm(cm))
+            if cm[0] < 0.0 or rm < inner_safe or rm > outer_safe:
+                continue
+
+            new_pts.append(np.array([max(float(c[0]), 0.0), float(c[1])], dtype=float))
+            new_pts.append(cm)
+            if len(new_pts) >= int(max_new_points):
+                break
+
+        if not new_pts:
+            break
+
+        points = _unique_rows(np.vstack([points, np.asarray(new_pts, dtype=float)]), decimals=12)
+
+    return points
+
+
+def _unique_rows(points, decimals=12):
+    rounded = np.round(np.asarray(points, dtype=float), decimals=decimals)
+    _, idx = np.unique(rounded, axis=0, return_index=True)
+    return np.asarray(points, dtype=float)[np.sort(idx)]
+
+
+def _radius_values(points, dim):
+    points = np.asarray(points, dtype=float)
+    if dim == 2:
+        return np.sqrt(points[:, 0] ** 2 + points[:, 1] ** 2)
+    return np.linalg.norm(points[:, :3], axis=1)
+
+
+def _boundary_facets_from_simplices(simplices, dim):
+    simplices = np.asarray(simplices, dtype=np.int64)
+    if simplices.size == 0:
+        n_nodes = 2 if dim == 2 else 3
+        return np.empty((0, n_nodes), dtype=np.int64)
+
+    if dim == 2:
+        local_facets = ((0, 1), (1, 2), (2, 0))
+    else:
+        local_facets = ((0, 1, 2), (0, 1, 3), (0, 2, 3), (1, 2, 3))
+
+    counts = {}
+    for simplex in simplices:
+        for lf in local_facets:
+            key = tuple(sorted(int(simplex[i]) for i in lf))
+            counts[key] = counts.get(key, 0) + 1
+
+    boundary = [facet for facet, count in counts.items() if count == 1]
+    if not boundary:
+        n_nodes = 2 if dim == 2 else 3
+        return np.empty((0, n_nodes), dtype=np.int64)
+    return np.asarray(boundary, dtype=np.int64)
+
+
+def _classify_shell_boundary_elements(points, facets, dim, sphere_radius, outer_radius):
+    points = np.asarray(points, dtype=float)
+    facets = np.asarray(facets, dtype=np.int64)
+
+    if facets.size == 0:
+        return (
+            np.empty((0, 2 if dim == 2 else 3), dtype=np.int64),
+            np.empty((0, 2 if dim == 2 else 3), dtype=np.int64),
+            np.empty((0, 2), dtype=np.int64) if dim == 2 else np.empty((0, 0), dtype=np.int64),
+        )
+
+    axis_tol = max(1.0e-8, 1.0e-6 * float(outer_radius))
+    radial_gap = abs(float(outer_radius) - float(sphere_radius))
+    inner_band = max(1.0e-6, 0.05 * radial_gap, 0.02 * float(sphere_radius))
+    outer_band = max(1.0e-6, 0.05 * radial_gap, 0.02 * float(outer_radius))
+    inner = []
+    outer = []
+    axis = []
+
+    for facet in facets:
+        node_ids = np.asarray(facet, dtype=np.int64)
+        nodes = points[node_ids]
+
+        if dim == 2 and np.max(np.abs(nodes[:, 0])) <= axis_tol:
+            axis.append(node_ids)
+            continue
+
+        r_mean = float(np.mean(_radius_values(nodes, dim)))
+        if abs(r_mean - sphere_radius) <= inner_band:
+            inner.append(node_ids)
+        elif abs(r_mean - outer_radius) <= outer_band:
+            outer.append(node_ids)
+
+    n_nodes = 2 if dim == 2 else 3
+    inner = np.asarray(inner, dtype=np.int64) if inner else np.empty((0, n_nodes), dtype=np.int64)
+    outer = np.asarray(outer, dtype=np.int64) if outer else np.empty((0, n_nodes), dtype=np.int64)
+    if dim == 2:
+        axis = np.asarray(axis, dtype=np.int64) if axis else np.empty((0, 2), dtype=np.int64)
+    else:
+        axis = np.empty((0, 0), dtype=np.int64)
+    return inner, outer, axis
+
+
+def _generate_stokes_sphere_hc_mesh(dim, sphere_radius, outer_radius, hc_refine=2,
+                                    hc_inner_samples=None, hc_outer_samples=None,
+                                    symm_nonobtuse=False,
+                                    equal_edge=False):
+    """
+    Generate a shell/annulus mesh independently from hyperct seed points.
+
+    This path does not rely on Gmsh.  It uses:
+    1. hyperct to generate/refine a simplicial seed cloud,
+    2. geometric shell filtering in the target domain,
+    3. scipy Delaunay to reconstruct simplex cells in that filtered cloud.
+
+    When ``symm_nonobtuse=True``, the generator enforces central symmetry on
+    sample points and applies a best-effort obtuse-angle reduction heuristic.
+    When ``equal_edge=True``, the generator uses quasi-uniform spherical layers
+    to favor near-equal edge lengths (near-equilateral behavior).
+    """
+    if dim == 2:
+        bounds = [(0.0, float(outer_radius)), (-float(outer_radius), float(outer_radius))]
+        n_inner = int(hc_inner_samples) if hc_inner_samples is not None else max(32, 16 * (2 ** max(hc_refine - 1, 0)))
+        n_outer = int(hc_outer_samples) if hc_outer_samples is not None else max(48, 24 * (2 ** max(hc_refine - 1, 0)))
+    else:
+        bounds = [(-float(outer_radius), float(outer_radius))] * 3
+        n_inner = int(hc_inner_samples) if hc_inner_samples is not None else max(96, 64 * (2 ** max(hc_refine - 1, 0)))
+        n_outer = int(hc_outer_samples) if hc_outer_samples is not None else max(128, 96 * (2 ** max(hc_refine - 1, 0)))
+
+    if dim == 3 and equal_edge:
+        # Build quasi-uniform radial shells with near-equal spacing.
+        h_outer = np.sqrt(4.0 * np.pi * float(outer_radius) ** 2 / max(float(n_outer), 1.0))
+        h_inner = np.sqrt(4.0 * np.pi * float(sphere_radius) ** 2 / max(float(n_inner), 1.0))
+        target_h = max(1.0e-6, 0.5 * (h_outer + h_inner))
+        n_layers = max(3, int(np.ceil((float(outer_radius) - float(sphere_radius)) / target_h)) + 1)
+        radii = np.linspace(float(sphere_radius), float(outer_radius), n_layers)
+
+        layer_points = []
+        for li, r in enumerate(radii):
+            n_layer = max(64, int(round(4.0 * np.pi * float(r) ** 2 / max(target_h**2, 1.0e-12))))
+            if n_layer % 2 == 1:
+                n_layer += 1
+            if symm_nonobtuse:
+                pts = _symmetric_sphere_points(n_layer, r)
+            else:
+                pts = _fibonacci_sphere_points(n_layer, r)
+            # Rotate each layer to avoid radial alignment artifacts.
+            ang = (li + 1) * np.pi * (3.0 - np.sqrt(5.0))
+            c, s = np.cos(ang), np.sin(ang)
+            rot = np.array([[c, -s, 0.0], [s, c, 0.0], [0.0, 0.0, 1.0]], dtype=float)
+            pts = pts @ rot.T
+            layer_points.append(pts)
+        seed_points = np.vstack(layer_points)
+    else:
+        seed_points = _build_hc_seed_points(dim, bounds, hc_refine)
+        if symm_nonobtuse:
+            seed_points = _symmetrize_points_origin(seed_points, dim=dim)
+
+    if dim == 2:
+        phi_in = np.linspace(0.0, np.pi, n_inner)
+        phi_out = np.linspace(0.0, np.pi, n_outer)
+        inner_pts = np.column_stack([
+            float(sphere_radius) * np.sin(phi_in),
+            float(sphere_radius) * np.cos(phi_in),
+        ])
+        outer_pts = np.column_stack([
+            float(outer_radius) * np.sin(phi_out),
+            float(outer_radius) * np.cos(phi_out),
+        ])
+        # Add one interior guard ring near each curved boundary to avoid
+        # boundary fan/sliver triangles from unconstrained Delaunay.
+        radial_gap = float(outer_radius) - float(sphere_radius)
+        inner_guard_r = min(
+            float(sphere_radius) + max(0.03 * radial_gap, 0.04 * float(sphere_radius)),
+            0.5 * (float(sphere_radius) + float(outer_radius)),
+        )
+        outer_guard_r = max(
+            float(outer_radius) - max(0.03 * radial_gap, 0.04 * float(outer_radius)),
+            0.5 * (float(sphere_radius) + float(outer_radius)),
+        )
+        inner_guard_pts = np.column_stack([
+            inner_guard_r * np.sin(phi_in),
+            inner_guard_r * np.cos(phi_in),
+        ])
+        outer_guard_pts = np.column_stack([
+            outer_guard_r * np.sin(phi_out),
+            outer_guard_r * np.cos(phi_out),
+        ])
+        # Remove HC seed points in the near-boundary strips: those zones are
+        # represented by the explicit boundary and guard-ring samples.
+        seed_r = _radius_values(seed_points, dim=2)
+        seed_keep = (
+            (seed_r >= inner_guard_r + 1.0e-12)
+            & (seed_r <= outer_guard_r - 1.0e-12)
+            & (seed_points[:, 0] >= -1.0e-10)
+        )
+        seed_points = seed_points[seed_keep]
+    else:
+        if symm_nonobtuse:
+            inner_pts = _symmetric_sphere_points(n_inner, sphere_radius)
+            outer_pts = _symmetric_sphere_points(n_outer, outer_radius)
+        else:
+            inner_pts = _fibonacci_sphere_points(n_inner, sphere_radius)
+            outer_pts = _fibonacci_sphere_points(n_outer, outer_radius)
+        inner_guard_pts = np.empty((0, 3), dtype=float)
+        outer_guard_pts = np.empty((0, 3), dtype=float)
+
+    points = np.vstack([seed_points, inner_pts, outer_pts, inner_guard_pts, outer_guard_pts])
+    radii = _radius_values(points, dim)
+    tol = 1.0e-10
+    mask = (
+        (radii >= float(sphere_radius) * (1.0 - tol))
+        & (radii <= float(outer_radius) * (1.0 + tol))
+    )
+    if dim == 2:
+        mask &= points[:, 0] >= -1.0e-10
+
+    points = _unique_rows(points[mask], decimals=12)
+    if symm_nonobtuse:
+        if dim == 2:
+            points = _augment_points_nonobtuse_shell_2d(
+                points,
+                sphere_radius=sphere_radius,
+                outer_radius=outer_radius,
+                angle_threshold_deg=116.0,
+                max_new_points=768,
+                iterations=1,
+            )
+        else:
+            points = _augment_points_nonobtuse_shell_3d(
+                points,
+                sphere_radius=sphere_radius,
+                outer_radius=outer_radius,
+                angle_threshold_deg=118.0,
+                max_new_points=1024,
+                iterations=1,
+            )
+        points = _unique_rows(points, decimals=12)
+    if len(points) <= (dim + 1):
+        raise ValueError("Not enough points to triangulate HC-generated shell mesh")
+
+    tri = Delaunay(points)
+    simplices = np.asarray(tri.simplices, dtype=np.int64)
+    simplex_points = points[simplices]
+    centroids = np.mean(simplex_points, axis=1)
+    centroid_r = _radius_values(centroids, dim)
+    keep = (
+        centroid_r >= float(sphere_radius) * (1.0 - 1.0e-8)
+    ) & (
+        centroid_r <= float(outer_radius) * (1.0 + 1.0e-8)
+    )
+
+    if dim == 2:
+        keep &= centroids[:, 0] >= -1.0e-8
+
+    simplices = simplices[keep]
+    if simplices.size == 0:
+        raise ValueError("HC-generated shell triangulation produced no valid simplices")
+
+    facets = _boundary_facets_from_simplices(simplices, dim)
+    obstacle, outer_boundary, axis = _classify_shell_boundary_elements(
+        points,
+        facets,
+        dim=dim,
+        sphere_radius=sphere_radius,
+        outer_radius=outer_radius,
+    )
+
+    return points, simplices, obstacle, outer_boundary, axis
+
+
+class _StokesSphereBenchmarkBase(FlowBenchmarkBase):
+    """
+    Shared analytical field for creeping flow past a sphere.
+
+    The 3D case uses the full spherical shell domain.  The 2D case is the
+    axisymmetric meridional reduction in ``(rho, z)`` and integrates the
+    traction with the usual ``2*pi*rho`` weight, so it still validates the
+    3D Stokes drag on a sphere.
+    """
+
+    def __init__(self, workdir, mesh_name, mesh_size_inner=None, mesh_size_outer=None,
+                 remesh=False, **kwargs):
+        super().__init__(**kwargs)
+        self.workdir = str(workdir)
+        self._workdir_path = Path(self.workdir)
+        self.mesh_name = mesh_name
+        self.remesh = bool(remesh)
+        self.mesh_size_inner = float(
+            mesh_size_inner if mesh_size_inner is not None else 0.20 * self.sphere_radius
+        )
+        self.mesh_size_outer = float(
+            mesh_size_outer if mesh_size_outer is not None else 0.75 * self.sphere_radius
+        )
+
+    def _resolved_flow_speed(self):
+        if self.flow_speed is None:
+            if abs(self.mu) < 1.0e-30:
+                raise ZeroDivisionError("mu must be non-zero when inferring flow_speed from gravity")
+            self.flow_speed = (
+                2.0 * self.density_difference * self.gravity * self.sphere_radius**2
+            ) / (9.0 * self.mu)
+        return self.flow_speed
+
+    def analytical_values(self):
+        U = self._resolved_flow_speed()
+        a = self.sphere_radius
+        drag = 6.0 * np.pi * self.mu * a * U
+        gravity = (4.0 / 3.0) * np.pi * a**3 * self.density_difference * self.gravity
+
+        self.drag_force_analytical = float(drag)
+        self.gravity_force_analytical = float(gravity)
+        self.force_vector_analytical = np.zeros(self.vector_dim, dtype=float)
+        self.force_vector_analytical[self.flow_axis] = float(drag)
+
+    def _spherical_components(self, x):
+        x = np.asarray(x, dtype=float)[: self.vector_dim]
+        rel = x - self.center
+
+        if self.vector_dim == 2:
+            rho = rel[0]
+            z = rel[1]
+        else:
+            rho = float(np.linalg.norm(rel[:2]))
+            z = rel[2]
+
+        r = float(np.sqrt(rho**2 + z**2))
+        if r < 1.0e-14:
+            raise ValueError("The Stokes sphere analytical field is undefined at the origin")
+
+        sin_theta = rho / r
+        cos_theta = z / r
+        U = self._resolved_flow_speed()
+        a = self.sphere_radius
+
+        u_r = U * cos_theta * (1.0 - 1.5 * a / r + 0.5 * (a**3) / (r**3))
+        u_theta = -U * sin_theta * (1.0 - 0.75 * a / r - 0.25 * (a**3) / (r**3))
+        p = -1.5 * self.mu * U * a * cos_theta / (r**2)
+        return rel, rho, z, r, sin_theta, cos_theta, u_r, u_theta, p
+
+    def analytical_pressure(self, x):
+        return self._spherical_components(x)[-1]
+
+    def analytical_velocity(self, x):
+        rel, rho, _, _, sin_theta, cos_theta, u_r, u_theta, _ = self._spherical_components(x)
+        u_rho = u_r * sin_theta + u_theta * cos_theta
+        u_z = u_r * cos_theta - u_theta * sin_theta
+
+        if self.vector_dim == 2:
+            return np.array([u_rho, u_z], dtype=float)
+
+        out = np.zeros(3, dtype=float)
+        if rho > 1.0e-14:
+            out[0] = u_rho * rel[0] / rho
+            out[1] = u_rho * rel[1] / rho
+        out[2] = u_z
+        return out
+
+    def analytical_pressure_cartesian_3d(self, x):
+        x = np.asarray(x, dtype=float)[:3]
+        rho = float(np.linalg.norm(x[:2]))
+        z = float(x[2])
+        r = float(np.sqrt(rho**2 + z**2))
+        if r < 1.0e-14:
+            raise ValueError("The Stokes sphere analytical field is undefined at the origin")
+
+        U = self._resolved_flow_speed()
+        return -1.5 * self.mu * U * self.sphere_radius * z / (r**3)
+
+    def analytical_velocity_cartesian_3d(self, x):
+        x = np.asarray(x, dtype=float)[:3]
+        rho = float(np.linalg.norm(x[:2]))
+        z = float(x[2])
+        r = float(np.sqrt(rho**2 + z**2))
+        if r < 1.0e-14:
+            raise ValueError("The Stokes sphere analytical field is undefined at the origin")
+
+        sin_theta = rho / r
+        cos_theta = z / r
+        U = self._resolved_flow_speed()
+        a = self.sphere_radius
+
+        u_r = U * cos_theta * (1.0 - 1.5 * a / r + 0.5 * (a**3) / (r**3))
+        u_theta = -U * sin_theta * (1.0 - 0.75 * a / r - 0.25 * (a**3) / (r**3))
+        u_rho = u_r * sin_theta + u_theta * cos_theta
+        u_z = u_r * cos_theta - u_theta * sin_theta
+
+        out = np.zeros(3, dtype=float)
+        if rho > 1.0e-14:
+            out[0] = u_rho * x[0] / rho
+            out[1] = u_rho * x[1] / rho
+        out[2] = u_z
+        return out
+
+    def _axisymmetric_cauchy_stress(self, x_meridian):
+        from ddgclib.operators.stress import cauchy_stress
+
+        x_meridian = np.asarray(x_meridian, dtype=float)[:2]
+        x3 = np.array([x_meridian[0], 0.0, x_meridian[1]], dtype=float)
+        h = self.fd_step * max(self.sphere_radius, 1.0)
+
+        du = np.zeros((3, 3), dtype=float)
+        for j in range(3):
+            dx = np.zeros(3, dtype=float)
+            dx[j] = h
+            u_plus = self.analytical_velocity_cartesian_3d(x3 + dx)
+            u_minus = self.analytical_velocity_cartesian_3d(x3 - dx)
+            du[:, j] = (u_plus - u_minus) / (2.0 * h)
+
+        p = self.analytical_pressure_cartesian_3d(x3)
+        return cauchy_stress(p=p, du=du, mu=self.mu, dim=3)
+
+    def _axisymmetric_cauchy_stress_reference(self, x_meridian):
+        from ddgclib.operators.stress import cauchy_stress
+
+        x_meridian = np.asarray(x_meridian, dtype=float)[:2]
+        x3 = np.array([x_meridian[0], 0.0, x_meridian[1]], dtype=float)
+        h = self.fd_step * max(self.sphere_radius, 1.0)
+
+        du = np.zeros((3, 3), dtype=float)
+        for j in range(3):
+            dx = np.zeros(3, dtype=float)
+            dx[j] = h
+            u_p2 = self.analytical_velocity_cartesian_3d(x3 + 2.0 * dx)
+            u_p1 = self.analytical_velocity_cartesian_3d(x3 + 1.0 * dx)
+            u_m1 = self.analytical_velocity_cartesian_3d(x3 - 1.0 * dx)
+            u_m2 = self.analytical_velocity_cartesian_3d(x3 - 2.0 * dx)
+            du[:, j] = (-u_p2 + 8.0 * u_p1 - 8.0 * u_m1 + u_m2) / (12.0 * h)
+
+        p = self.analytical_pressure_cartesian_3d(x3)
+        return cauchy_stress(p=p, du=du, mu=self.mu, dim=3)
+
+    def _integrate_axisymmetric_obstacle_force(self):
+        """
+        Integrate the full 3D Cartesian traction on the meridian contour.
+
+        The 2D benchmark stores meridional coordinates ``(rho, z)``, but the
+        Stokes stress itself is a 3D tensor.  Evaluating the full Cartesian
+        stress on the meridian avoids treating cylindrical basis components as
+        if they were planar Cartesian components.
+        """
+        force = np.zeros(2, dtype=float)
+        s_q, w_q = self._line_quadrature()
+
+        for elem in self.obstacle_elements:
+            node_ids = np.asarray(elem, dtype=np.int64)
+            nodes = self.points[node_ids, :2]
+            use_arc_param = False
+            theta_a = 0.0
+            theta_b = 0.0
+            arc_radius = float(self.sphere_radius)
+
+            # For linear HC boundary facets, nodes lie on the sphere but the
+            # segment is a chord. Parameterize by polar angle to integrate on
+            # the actual spherical arc (geometry-consistent traction integral).
+            if len(node_ids) == 2:
+                rel0 = nodes[0] - self.center[:2]
+                rel1 = nodes[1] - self.center[:2]
+                r0 = float(np.linalg.norm(rel0))
+                r1 = float(np.linalg.norm(rel1))
+                tol_r = max(1.0e-8, 1.0e-6 * arc_radius)
+                if abs(r0 - arc_radius) <= tol_r and abs(r1 - arc_radius) <= tol_r:
+                    t0 = float(np.arctan2(rel0[0], rel0[1]))
+                    t1 = float(np.arctan2(rel1[0], rel1[1]))
+                    theta_a, theta_b = sorted((t0, t1))
+                    use_arc_param = True
+
+            for s, w in zip(s_q, w_q):
+                N_lump = None
+                if use_arc_param:
+                    N_lump, _ = self._line_shape_functions(s, 2)
+                    theta = 0.5 * ((1.0 - s) * theta_a + (1.0 + s) * theta_b)
+                    dtheta_ds = 0.5 * (theta_b - theta_a)
+                    x = self.center[:2] + arc_radius * np.array(
+                        [np.sin(theta), np.cos(theta)],
+                        dtype=float,
+                    )
+                    jac = arc_radius * abs(dtheta_ds)
+                else:
+                    N, dN = self._line_shape_functions(s, len(node_ids))
+                    N_lump = N
+                    x = np.tensordot(N, nodes, axes=(0, 0))
+                    dx_ds = np.tensordot(dN, nodes, axes=(0, 0))
+                    jac = np.linalg.norm(dx_ds)
+
+                if jac < 1.0e-14:
+                    continue
+
+                rho = max(float(x[0]), 0.0)
+                if rho < 1.0e-14:
+                    continue
+
+                x3 = np.array([x[0], 0.0, x[1]], dtype=float)
+                normal3 = x3 / np.linalg.norm(x3)
+                sigma = self._axisymmetric_cauchy_stress(x)
+                sigma_ref = self._axisymmetric_cauchy_stress_reference(x)
+                traction3 = sigma @ normal3
+                traction3_ref = sigma_ref @ normal3
+                weight = 2.0 * np.pi * rho * jac * w
+
+                force[0] += traction3[0] * weight
+                force[1] += traction3[2] * weight
+                self.accumulate_vertex_drag_lumped_contribution(
+                    node_ids=node_ids[: len(N_lump)],
+                    shape_values=N_lump,
+                    drag_computed=float(traction3[2] * weight),
+                    drag_reference=float(traction3_ref[2] * weight),
+                )
+
+        return force
+
+    def _integrate_3d_obstacle_force(self):
+        """
+        Integrate traction on the obstacle in 3D.
+
+        When obstacle element nodes lie on the sphere (linear or high-order),
+        quadrature points are mapped onto the true spherical surface and the
+        surface Jacobian is evaluated through this spherical projection.
+        This keeps HC and Gmsh traction integration geometrically consistent.
+        """
+        force = np.zeros(self.vector_dim, dtype=float)
+        center3 = np.asarray(self.center[:3], dtype=float)
+        sphere_r = float(self.sphere_radius)
+
+        for elem in self.obstacle_elements:
+            node_ids = np.asarray(elem, dtype=np.int64)
+            nodes = self.points[node_ids, : self.vector_dim]
+            n_nodes = len(node_ids)
+
+            use_sphere_param = False
+            u_nodes = None
+            rel_nodes = nodes - center3
+            rr = np.linalg.norm(rel_nodes, axis=1)
+            tol_r = max(1.0e-8, 1.0e-6 * sphere_r)
+            if np.all(np.abs(rr - sphere_r) <= tol_r):
+                safe_rr = np.maximum(rr, 1.0e-14)
+                u_nodes = rel_nodes / safe_rr[:, None]
+                use_sphere_param = True
+
+            for xi, eta, w in self._triangle_quadrature():
+                N, dN_dxi, dN_deta = self._triangle_shape_functions(xi, eta, n_nodes)
+                if use_sphere_param:
+                    q = np.tensordot(N, u_nodes, axes=(0, 0))
+                    q_norm = np.linalg.norm(q)
+                    if q_norm < 1.0e-14:
+                        continue
+
+                    dq_dxi = np.tensordot(dN_dxi, u_nodes, axes=(0, 0))
+                    dq_deta = np.tensordot(dN_deta, u_nodes, axes=(0, 0))
+
+                    proj = np.eye(3, dtype=float) - np.outer(q, q) / (q_norm**2)
+                    dx_dxi = sphere_r * (proj @ dq_dxi) / q_norm
+                    dx_deta = sphere_r * (proj @ dq_deta) / q_norm
+                    x = center3 + sphere_r * q / q_norm
+                else:
+                    x = np.tensordot(N, nodes, axes=(0, 0))
+                    dx_dxi = np.tensordot(dN_dxi, nodes, axes=(0, 0))
+                    dx_deta = np.tensordot(dN_deta, nodes, axes=(0, 0))
+
+                jac_vec = np.cross(dx_dxi, dx_deta)
+                jac = np.linalg.norm(jac_vec)
+                if jac < 1.0e-14:
+                    continue
+
+                sigma = self.cauchy_stress_tensor(x)
+                sigma_ref = self.cauchy_stress_tensor_reference(x)
+                normal = self.obstacle_normal(x)
+                traction = sigma @ normal
+                traction_ref = sigma_ref @ normal
+                force += traction * (jac * w)
+                self.accumulate_vertex_drag_lumped_contribution(
+                    node_ids=node_ids[: len(N)],
+                    shape_values=N,
+                    drag_computed=float(np.dot(traction, self.flow_direction) * (jac * w)),
+                    drag_reference=float(np.dot(traction_ref, self.flow_direction) * (jac * w)),
+                )
+
+        return force
+
+    def run(self):
+        self.run_benchmark()
+        return self
+
+
+class StokesSphereBenchmark2D(_StokesSphereBenchmarkBase):
+    """
+    Axisymmetric meridional Stokes benchmark for a sphere.
+
+    This is the 2D ``(rho, z)`` representation of the 3D creeping-flow
+    solution, with a quadratic Lagrange line mesh on the semicircular
+    obstacle boundary.
+    """
+
+    def __init__(self, sphere_radius=1.0, outer_radius=6.0,
+                 mu=1.0, density_difference=1.0, gravity=1.0,
+                 flow_speed=None, workdir="benchmarks_out/stokes_sphere_2d",
+                 mesh_name="stokes_sphere_2d_axisymmetric.msh",
+                 mesh_size_inner=None, mesh_size_outer=None,
+                 remesh=False, method=None, complex_dtype="vv",
+                 symm_nonobtuse=False, **kwargs):
+        super().__init__(
+            name="StokesSphere2D",
+            method=method,
+            complex_dtype=complex_dtype,
+            dim=2,
+            mu=mu,
+            sphere_radius=sphere_radius,
+            outer_radius=outer_radius,
+            density_difference=density_difference,
+            gravity=gravity,
+            flow_speed=flow_speed,
+            workdir=workdir,
+            mesh_name=mesh_name,
+            mesh_size_inner=mesh_size_inner,
+            mesh_size_outer=mesh_size_outer,
+            remesh=remesh,
+            **kwargs,
+        )
+        self.symm_nonobtuse = bool(symm_nonobtuse)
+
+    def generate_mesh(self):
+        self._workdir_path.mkdir(parents=True, exist_ok=True)
+        mesh_path = self._workdir_path / self.mesh_name
+        if self.remesh or not mesh_path.exists():
+            _generate_stokes_sphere_mesh_2d(
+                mesh_path,
+                sphere_radius=self.sphere_radius,
+                outer_radius=self.outer_radius,
+                mesh_size_inner=self.mesh_size_inner,
+                mesh_size_outer=self.mesh_size_outer,
+                mesh_order=self.mesh_order,
+                symm_nonobtuse=self.symm_nonobtuse,
+            )
+        self.mesh_path = str(mesh_path)
+
+
+class StokesSphereBenchmark3D(_StokesSphereBenchmarkBase):
+    """
+    Full 3D Stokes benchmark on a spherical shell.
+
+    The obstacle boundary is meshed with quadratic triangles so the drag
+    integral uses a true Lagrange surface instead of a piecewise-linear
+    approximation.
+    """
+
+    def __init__(self, sphere_radius=1.0, outer_radius=6.0,
+                 mu=1.0, density_difference=1.0, gravity=1.0,
+                 flow_speed=None, workdir="benchmarks_out/stokes_sphere_3d",
+                 mesh_name="stokes_sphere_3d.msh",
+                 mesh_size_inner=None, mesh_size_outer=None,
+                 remesh=False, method=None, complex_dtype="vv",
+                 symm_nonobtuse=False, equal_edge=False, **kwargs):
+        super().__init__(
+            name="StokesSphere3D",
+            method=method,
+            complex_dtype=complex_dtype,
+            dim=3,
+            mu=mu,
+            sphere_radius=sphere_radius,
+            outer_radius=outer_radius,
+            density_difference=density_difference,
+            gravity=gravity,
+            flow_speed=flow_speed,
+            workdir=workdir,
+            mesh_name=mesh_name,
+            mesh_size_inner=mesh_size_inner,
+            mesh_size_outer=mesh_size_outer,
+            remesh=remesh,
+            **kwargs,
+        )
+        self.symm_nonobtuse = bool(symm_nonobtuse)
+        self.equal_edge = bool(equal_edge)
+
+    def generate_mesh(self):
+        self._workdir_path.mkdir(parents=True, exist_ok=True)
+        mesh_path = self._workdir_path / self.mesh_name
+        if self.remesh or not mesh_path.exists():
+            _generate_stokes_sphere_mesh_3d(
+                mesh_path,
+                sphere_radius=self.sphere_radius,
+                outer_radius=self.outer_radius,
+                mesh_size_inner=self.mesh_size_inner,
+                mesh_size_outer=self.mesh_size_outer,
+                mesh_order=self.mesh_order,
+                symm_nonobtuse=self.symm_nonobtuse,
+                equal_edge=self.equal_edge,
+            )
+        self.mesh_path = str(mesh_path)
+
+
+class _StokesSphereBenchmarkBaseHC(_StokesSphereBenchmarkBase):
+    """
+    HC-native Stokes benchmark: mesh generation independent from Gmsh.
+    """
+
+    def __init__(self, hc_refine=None, hc_inner_samples=None, hc_outer_samples=None,
+                 symm_nonobtuse=False, equal_edge=False, **kwargs):
+        super().__init__(**kwargs)
+        default_refine = 3 if self.dim == 2 else 2
+        self.hc_refine = int(hc_refine if hc_refine is not None else default_refine)
+        self.hc_inner_samples = hc_inner_samples
+        self.hc_outer_samples = hc_outer_samples
+        self.symm_nonobtuse = bool(symm_nonobtuse)
+        self.equal_edge = bool(equal_edge)
+
+    def generate_mesh(self):
+        # Kept for parity with the Gmsh path; no on-disk mesh is required here.
+        self.mesh_path = f"hc://stokes_sphere_{self.dim}d_ref{self.hc_refine}"
+
+    def load_mesh(self):
+        points, simplices, obstacle, outer_boundary, axis = _generate_stokes_sphere_hc_mesh(
+            dim=self.dim,
+            sphere_radius=self.sphere_radius,
+            outer_radius=self.outer_radius,
+            hc_refine=self.hc_refine,
+            hc_inner_samples=self.hc_inner_samples,
+            hc_outer_samples=self.hc_outer_samples,
+            symm_nonobtuse=self.symm_nonobtuse,
+            equal_edge=self.equal_edge,
+        )
+        self.points = np.asarray(points, dtype=float)
+        self.high_order_volume_cells = np.asarray(simplices, dtype=np.int64)
+        self.volume_cells = np.asarray(simplices, dtype=np.int64)
+        self.obstacle_elements = np.asarray(obstacle, dtype=np.int64)
+        self.outer_boundary_elements = np.asarray(outer_boundary, dtype=np.int64)
+        self.axis_elements = np.asarray(axis, dtype=np.int64) if self.dim == 2 else np.empty((0, 0), dtype=np.int64)
+        self._update_boundary_bookkeeping()
+        self.mesh_metadata["mesh_source"] = "hc"
+        self.mesh_metadata["hc_refine"] = int(self.hc_refine)
+        if self.symm_nonobtuse and self.equal_edge:
+            variant = "symm_nonobtuse_equal_edge"
+        elif self.symm_nonobtuse:
+            variant = "symm_nonobtuse"
+        elif self.equal_edge:
+            variant = "equal_edge"
+        else:
+            variant = "default"
+        self.mesh_metadata["mesh_variant"] = variant
+
+
+class StokesSphereBenchmark2DHC(_StokesSphereBenchmarkBaseHC):
+    def __init__(self, sphere_radius=1.0, outer_radius=6.0,
+                 mu=1.0, density_difference=1.0, gravity=1.0,
+                 flow_speed=None, workdir="benchmarks_out/stokes_sphere_2d_hc",
+                 mesh_name="stokes_sphere_2d_hc",
+                 hc_refine=3, hc_inner_samples=None, hc_outer_samples=None,
+                 method=None, complex_dtype="vv", **kwargs):
+        super().__init__(
+            name="StokesSphere2DHC",
+            method=method,
+            complex_dtype=complex_dtype,
+            dim=2,
+            mu=mu,
+            sphere_radius=sphere_radius,
+            outer_radius=outer_radius,
+            density_difference=density_difference,
+            gravity=gravity,
+            flow_speed=flow_speed,
+            workdir=workdir,
+            mesh_name=mesh_name,
+            remesh=False,
+            hc_refine=hc_refine,
+            hc_inner_samples=hc_inner_samples,
+            hc_outer_samples=hc_outer_samples,
+            **kwargs,
+        )
+
+
+class StokesSphereBenchmark2DSymmNonobtuse(StokesSphereBenchmark2D):
+    def __init__(self, **kwargs):
+        kwargs.setdefault("workdir", "benchmarks_out/stokes_sphere_2d_symm_nonobtuse")
+        kwargs.setdefault("mesh_name", "stokes_sphere_2d_symm_nonobtuse.msh")
+        kwargs.setdefault("symm_nonobtuse", True)
+        super().__init__(**kwargs)
+        self.name = "StokesSphere2D_SymmNonobtuse_Gmsh"
+
+
+class StokesSphereBenchmark2DHCSymmNonobtuse(StokesSphereBenchmark2DHC):
+    def __init__(self, **kwargs):
+        kwargs.setdefault("workdir", "benchmarks_out/stokes_sphere_2d_hc_symm_nonobtuse")
+        kwargs.setdefault("mesh_name", "stokes_sphere_2d_hc_symm_nonobtuse")
+        kwargs.setdefault("symm_nonobtuse", True)
+        super().__init__(**kwargs)
+        self.name = "StokesSphere2D_SymmNonobtuse_HC"
+
+
+class StokesSphereBenchmark3DHC(_StokesSphereBenchmarkBaseHC):
+    def __init__(self, sphere_radius=1.0, outer_radius=6.0,
+                 mu=1.0, density_difference=1.0, gravity=1.0,
+                 flow_speed=None, workdir="benchmarks_out/stokes_sphere_3d_hc",
+                 mesh_name="stokes_sphere_3d_hc",
+                 hc_refine=2, hc_inner_samples=None, hc_outer_samples=None,
+                 method=None, complex_dtype="vv", **kwargs):
+        super().__init__(
+            name="StokesSphere3DHC",
+            method=method,
+            complex_dtype=complex_dtype,
+            dim=3,
+            mu=mu,
+            sphere_radius=sphere_radius,
+            outer_radius=outer_radius,
+            density_difference=density_difference,
+            gravity=gravity,
+            flow_speed=flow_speed,
+            workdir=workdir,
+            mesh_name=mesh_name,
+            remesh=False,
+            hc_refine=hc_refine,
+            hc_inner_samples=hc_inner_samples,
+            hc_outer_samples=hc_outer_samples,
+            **kwargs,
+        )
+
+
+class StokesSphereBenchmark3DSymmNonobtuse(StokesSphereBenchmark3D):
+    def __init__(self, **kwargs):
+        kwargs.setdefault("workdir", "benchmarks_out/stokes_sphere_3d_symm_nonobtuse")
+        kwargs.setdefault("mesh_name", "stokes_sphere_3d_symm_nonobtuse.msh")
+        kwargs.setdefault("symm_nonobtuse", True)
+        super().__init__(**kwargs)
+        self.name = "StokesSphere3D_SymmNonobtuse_Gmsh"
+
+
+class StokesSphereBenchmark3DHCSymmNonobtuse(StokesSphereBenchmark3DHC):
+    def __init__(self, **kwargs):
+        kwargs.setdefault("workdir", "benchmarks_out/stokes_sphere_3d_hc_symm_nonobtuse")
+        kwargs.setdefault("mesh_name", "stokes_sphere_3d_hc_symm_nonobtuse")
+        kwargs.setdefault("symm_nonobtuse", True)
+        super().__init__(**kwargs)
+        self.name = "StokesSphere3D_SymmNonobtuse_HC"
+
+
+class StokesSphereBenchmark3DEqualEdge(StokesSphereBenchmark3D):
+    def __init__(self, **kwargs):
+        kwargs.setdefault("workdir", "benchmarks_out/stokes_sphere_3d_equal_edge")
+        kwargs.setdefault("mesh_name", "stokes_sphere_3d_equal_edge.msh")
+        kwargs.setdefault("equal_edge", True)
+        super().__init__(**kwargs)
+        self.name = "StokesSphere3D_EqualEdge_Gmsh"
+
+
+class StokesSphereBenchmark3DHCEqualEdge(StokesSphereBenchmark3DHC):
+    def __init__(self, **kwargs):
+        kwargs.setdefault("workdir", "benchmarks_out/stokes_sphere_3d_hc_equal_edge")
+        kwargs.setdefault("mesh_name", "stokes_sphere_3d_hc_equal_edge")
+        kwargs.setdefault("equal_edge", True)
+        super().__init__(**kwargs)
+        self.name = "StokesSphere3D_EqualEdge_HC"
+
+
+def _integrate_obstacle_force_ddg_2d(bench):
+    """
+    DDG-based traction integration on the axisymmetric obstacle curve.
+
+    DDG nodal gradients are reconstructed on obstacle endpoint nodes and
+    linearly interpolated along each obstacle segment. The resulting traction
+    is integrated with axisymmetric weight ``2*pi*rho``.
+    """
+    if bench.HC is None:
+        raise RuntimeError("DDG complex is unavailable; cannot run DDG-based traction integration")
+
+    try:
+        from ddgclib.operators.stress import cauchy_stress, velocity_difference_tensor_pointwise
+    except Exception as exc:
+        raise RuntimeError(f"Failed to import DDG stress operators: {exc}") from exc
+
+    ddg_index_map = getattr(bench, "ddg_index_map", {})
+    ddg_vertices = getattr(bench, "ddg_vertices", [])
+    if not ddg_index_map or not ddg_vertices:
+        raise RuntimeError("DDG vertex mapping is missing")
+
+    obstacle = np.asarray(bench.obstacle_elements, dtype=np.int64)
+    if obstacle.size == 0:
+        raise RuntimeError("Obstacle boundary elements are missing")
+
+    # Use obstacle endpoints only for consistency with simplicial DDG nodes.
+    edge_ids = obstacle[:, :2]
+    node_ids = np.unique(edge_ids.ravel())
+
+    du_nodes = {}
+    p_nodes = {}
+    missing_nodes = 0
+    failed_nodes = 0
+    for node_id in node_ids:
+        local_idx = ddg_index_map.get(int(node_id))
+        if local_idx is None:
+            missing_nodes += 1
+            continue
+        v = ddg_vertices[local_idx]
+        try:
+            du = velocity_difference_tensor_pointwise(v, bench.HC, dim=2)
+        except Exception:
+            failed_nodes += 1
+            continue
+        du_nodes[int(node_id)] = np.asarray(du, dtype=float)
+        p_nodes[int(node_id)] = float(v.p)
+
+    if missing_nodes > 0:
+        logger.warning("%s: %d obstacle DDG nodes were not mapped to HC vertices", bench.name, missing_nodes)
+    if failed_nodes > 0:
+        logger.warning("%s: velocity_difference_tensor_pointwise failed on %d obstacle nodes", bench.name, failed_nodes)
+    if not du_nodes:
+        raise RuntimeError("No DDG gradients were available on obstacle nodes")
+
+    force = np.zeros(2, dtype=float)
+    center2 = np.asarray(bench.center[:2], dtype=float)
+    sphere_r = float(bench.sphere_radius)
+    skipped_elements = 0
+    s_q, w_q = bench._line_quadrature()
+
+    for elem in obstacle:
+        line_ids = np.asarray(elem[:2], dtype=np.int64)
+        if not all(int(nid) in du_nodes for nid in line_ids):
+            skipped_elements += 1
+            continue
+
+        nodes = bench.points[line_ids, :2]
+        du_elem = np.stack([du_nodes[int(nid)] for nid in line_ids], axis=0)
+        p_elem = np.asarray([p_nodes[int(nid)] for nid in line_ids], dtype=float)
+
+        use_arc_param = False
+        theta_a = 0.0
+        theta_b = 0.0
+        rel0 = nodes[0] - center2
+        rel1 = nodes[1] - center2
+        r0 = float(np.linalg.norm(rel0))
+        r1 = float(np.linalg.norm(rel1))
+        tol_r = max(1.0e-8, 1.0e-6 * sphere_r)
+        if abs(r0 - sphere_r) <= tol_r and abs(r1 - sphere_r) <= tol_r:
+            t0 = float(np.arctan2(rel0[0], rel0[1]))
+            t1 = float(np.arctan2(rel1[0], rel1[1]))
+            theta_a, theta_b = sorted((t0, t1))
+            use_arc_param = True
+
+        for s, w in zip(s_q, w_q):
+            # Endpoint interpolation for DDG nodal data.
+            N_edge, dN_edge = bench._line_shape_functions(s, 2)
+
+            if use_arc_param:
+                theta = 0.5 * ((1.0 - s) * theta_a + (1.0 + s) * theta_b)
+                dtheta_ds = 0.5 * (theta_b - theta_a)
+                x = center2 + sphere_r * np.array(
+                    [np.sin(theta), np.cos(theta)],
+                    dtype=float,
+                )
+                jac = sphere_r * abs(dtheta_ds)
+            else:
+                x = np.tensordot(N_edge, nodes, axes=(0, 0))
+                dx_ds = np.tensordot(dN_edge, nodes, axes=(0, 0))
+                jac = np.linalg.norm(dx_ds)
+
+            if jac < 1.0e-14:
+                continue
+
+            rho = max(float(x[0]), 0.0)
+            if rho < 1.0e-14:
+                continue
+
+            du_q = np.tensordot(N_edge, du_elem, axes=(0, 0))
+            p_q = float(np.dot(N_edge, p_elem))
+            sigma = cauchy_stress(p=p_q, du=du_q, mu=bench.mu, dim=2)
+            # DDG 2D branch evaluates a 2D traction (rho-z plane), so the
+            # reference stress must use the same 2x2 operator shape.
+            sigma_ref = bench.cauchy_stress_tensor_reference(x)
+            normal = bench.obstacle_normal(x)
+            traction = sigma @ normal
+            traction_ref = sigma_ref @ normal
+            force += traction * (2.0 * np.pi * rho * jac * w)
+            bench.accumulate_vertex_drag_lumped_contribution(
+                node_ids=line_ids,
+                shape_values=N_edge,
+                drag_computed=float(traction[1] * (2.0 * np.pi * rho * jac * w)),
+                drag_reference=float(traction_ref[1] * (2.0 * np.pi * rho * jac * w)),
+            )
+
+    if skipped_elements > 0:
+        logger.warning("%s: skipped %d obstacle elements without DDG nodal data", bench.name, skipped_elements)
+
+    return force
+
+
+def _integrate_obstacle_force_ddg_3d(bench):
+    """
+    DDG-based traction integration on the spherical obstacle.
+
+    The velocity gradient is reconstructed at obstacle corner vertices with
+    ``velocity_difference_tensor_pointwise`` from :mod:`ddgclib.operators.stress`,
+    then interpolated on each boundary triangle and integrated as
+    ``sigma(du_ddg, p) · n``.
+    """
+    if bench.HC is None:
+        raise RuntimeError("DDG complex is unavailable; cannot run DDG-based traction integration")
+
+    try:
+        from ddgclib.operators.stress import cauchy_stress, velocity_difference_tensor_pointwise
+    except Exception as exc:
+        raise RuntimeError(f"Failed to import DDG stress operators: {exc}") from exc
+
+    ddg_index_map = getattr(bench, "ddg_index_map", {})
+    ddg_vertices = getattr(bench, "ddg_vertices", [])
+    if not ddg_index_map or not ddg_vertices:
+        raise RuntimeError("DDG vertex mapping is missing")
+
+    obstacle = np.asarray(bench.obstacle_elements, dtype=np.int64)
+    if obstacle.size == 0:
+        raise RuntimeError("Obstacle boundary elements are missing")
+
+    # Use only triangle corner nodes for DDG reconstruction consistency with
+    # the simplicial backbone used by compute_vd.
+    corner_ids = obstacle[:, :3]
+    node_ids = np.unique(corner_ids.ravel())
+
+    du_nodes = {}
+    p_nodes = {}
+    missing_nodes = 0
+    failed_nodes = 0
+    for node_id in node_ids:
+        local_idx = ddg_index_map.get(int(node_id))
+        if local_idx is None:
+            missing_nodes += 1
+            continue
+        v = ddg_vertices[local_idx]
+        try:
+            du = velocity_difference_tensor_pointwise(v, bench.HC, dim=3)
+        except Exception:
+            failed_nodes += 1
+            continue
+        du_nodes[int(node_id)] = np.asarray(du, dtype=float)
+        p_nodes[int(node_id)] = float(v.p)
+
+    if missing_nodes > 0:
+        logger.warning("%s: %d obstacle DDG nodes were not mapped to HC vertices", bench.name, missing_nodes)
+    if failed_nodes > 0:
+        logger.warning("%s: velocity_difference_tensor_pointwise failed on %d obstacle nodes", bench.name, failed_nodes)
+    if not du_nodes:
+        raise RuntimeError("No DDG gradients were available on obstacle nodes")
+
+    force = np.zeros(3, dtype=float)
+    center3 = np.asarray(bench.center[:3], dtype=float)
+    sphere_r = float(bench.sphere_radius)
+    skipped_elements = 0
+
+    for elem in obstacle:
+        tri_ids = np.asarray(elem[:3], dtype=np.int64)
+        if not all(int(nid) in du_nodes for nid in tri_ids):
+            skipped_elements += 1
+            continue
+
+        nodes = bench.points[tri_ids, :3]
+
+        use_sphere_param = False
+        rel_nodes = nodes - center3
+        rr = np.linalg.norm(rel_nodes, axis=1)
+        tol_r = max(1.0e-8, 1.0e-6 * sphere_r)
+        if np.all(np.abs(rr - sphere_r) <= tol_r):
+            u_nodes = rel_nodes / rr[:, None]
+            use_sphere_param = True
+        else:
+            u_nodes = None
+
+        du_elem = np.stack([du_nodes[int(nid)] for nid in tri_ids], axis=0)
+        p_elem = np.asarray([p_nodes[int(nid)] for nid in tri_ids], dtype=float)
+
+        for xi, eta, w in bench._triangle_quadrature():
+            N, dN_dxi, dN_deta = bench._triangle_shape_functions(xi, eta, 3)
+            if use_sphere_param:
+                q = np.tensordot(N, u_nodes, axes=(0, 0))
+                q_norm = np.linalg.norm(q)
+                if q_norm < 1.0e-14:
+                    continue
+
+                dq_dxi = np.tensordot(dN_dxi, u_nodes, axes=(0, 0))
+                dq_deta = np.tensordot(dN_deta, u_nodes, axes=(0, 0))
+                proj = np.eye(3, dtype=float) - np.outer(q, q) / (q_norm**2)
+                dx_dxi = sphere_r * (proj @ dq_dxi) / q_norm
+                dx_deta = sphere_r * (proj @ dq_deta) / q_norm
+                x = center3 + sphere_r * q / q_norm
+            else:
+                x = np.tensordot(N, nodes, axes=(0, 0))
+                dx_dxi = np.tensordot(dN_dxi, nodes, axes=(0, 0))
+                dx_deta = np.tensordot(dN_deta, nodes, axes=(0, 0))
+
+            jac_vec = np.cross(dx_dxi, dx_deta)
+            jac = np.linalg.norm(jac_vec)
+            if jac < 1.0e-14:
+                continue
+
+            du_q = np.tensordot(N, du_elem, axes=(0, 0))
+            p_q = float(np.dot(N, p_elem))
+            sigma = cauchy_stress(p=p_q, du=du_q, mu=bench.mu, dim=3)
+            sigma_ref = bench.cauchy_stress_tensor_reference(x)
+            normal = bench.obstacle_normal(x)
+            traction = sigma @ normal
+            traction_ref = sigma_ref @ normal
+            force += traction * (jac * w)
+            bench.accumulate_vertex_drag_lumped_contribution(
+                node_ids=tri_ids,
+                shape_values=N,
+                drag_computed=float(np.dot(traction, bench.flow_direction) * (jac * w)),
+                drag_reference=float(np.dot(traction_ref, bench.flow_direction) * (jac * w)),
+            )
+
+    if skipped_elements > 0:
+        logger.warning("%s: skipped %d obstacle elements without DDG nodal data", bench.name, skipped_elements)
+
+    return force
+
+
+class StokesSphereBenchmark2DDDG(StokesSphereBenchmark2D):
+    """
+    2D axisymmetric Stokes benchmark using DDG gradient reconstruction in
+    stress evaluation on the Gmsh mesh.
+    """
+
+    def __init__(self, **kwargs):
+        kwargs.setdefault("ddg_enabled", True)
+        super().__init__(**kwargs)
+        self.name = "StokesSphere2D_DDG_Gmsh"
+        self.ddg_residuals_enabled = False
+
+    def run_benchmark(self):
+        self.generate_mesh()
+        self.load_mesh()
+        self.analytical_values()
+        self.reset_vertex_drag_lumped_error_stats()
+        self.build_ddg_complex()
+
+        if self.HC is None:
+            self.force_vector_computed = np.full(self.vector_dim, np.nan, dtype=float)
+            self.drag_force_computed = np.nan
+            self.force_error_abs = np.nan
+            self.force_error_rel = np.nan
+            self.finalize_vertex_drag_lumped_error_stats()
+            return
+
+        try:
+            self.force_vector_computed = _integrate_obstacle_force_ddg_2d(self)
+        except Exception as exc:
+            logger.warning("%s: DDG obstacle integration failed (%s)", self.name, exc)
+            self.force_vector_computed = np.full(self.vector_dim, np.nan, dtype=float)
+            self.drag_force_computed = np.nan
+            self.force_error_abs = np.nan
+            self.force_error_rel = np.nan
+            self.finalize_vertex_drag_lumped_error_stats()
+            return
+
+        self.drag_force_computed = float(np.dot(self.force_vector_computed, self.flow_direction))
+        self.force_error_abs = float(abs(self.drag_force_computed - self.drag_force_analytical))
+        if abs(self.drag_force_analytical) > 1.0e-30:
+            self.force_error_rel = self.force_error_abs / abs(self.drag_force_analytical)
+        self.finalize_vertex_drag_lumped_error_stats()
+
+
+class StokesSphereBenchmark2DHCDDG(StokesSphereBenchmark2DHC):
+    """
+    2D axisymmetric Stokes benchmark using DDG gradient reconstruction in
+    stress evaluation on the HC-native mesh.
+    """
+
+    def __init__(self, **kwargs):
+        kwargs.setdefault("ddg_enabled", True)
+        super().__init__(**kwargs)
+        self.name = "StokesSphere2D_DDG_HC"
+        self.ddg_residuals_enabled = False
+
+    def run_benchmark(self):
+        self.generate_mesh()
+        self.load_mesh()
+        self.analytical_values()
+        self.reset_vertex_drag_lumped_error_stats()
+        self.build_ddg_complex()
+
+        if self.HC is None:
+            self.force_vector_computed = np.full(self.vector_dim, np.nan, dtype=float)
+            self.drag_force_computed = np.nan
+            self.force_error_abs = np.nan
+            self.force_error_rel = np.nan
+            self.finalize_vertex_drag_lumped_error_stats()
+            return
+
+        try:
+            self.force_vector_computed = _integrate_obstacle_force_ddg_2d(self)
+        except Exception as exc:
+            logger.warning("%s: DDG obstacle integration failed (%s)", self.name, exc)
+            self.force_vector_computed = np.full(self.vector_dim, np.nan, dtype=float)
+            self.drag_force_computed = np.nan
+            self.force_error_abs = np.nan
+            self.force_error_rel = np.nan
+            self.finalize_vertex_drag_lumped_error_stats()
+            return
+
+        self.drag_force_computed = float(np.dot(self.force_vector_computed, self.flow_direction))
+        self.force_error_abs = float(abs(self.drag_force_computed - self.drag_force_analytical))
+        if abs(self.drag_force_analytical) > 1.0e-30:
+            self.force_error_rel = self.force_error_abs / abs(self.drag_force_analytical)
+        self.finalize_vertex_drag_lumped_error_stats()
+
+
+class StokesSphereBenchmark2DDDGSymmNonobtuse(StokesSphereBenchmark2DDDG):
+    def __init__(self, **kwargs):
+        kwargs.setdefault("workdir", "benchmarks_out/stokes_sphere_2d_symm_nonobtuse")
+        kwargs.setdefault("mesh_name", "stokes_sphere_2d_symm_nonobtuse.msh")
+        kwargs.setdefault("symm_nonobtuse", True)
+        super().__init__(**kwargs)
+        self.name = "StokesSphere2D_DDG_SymmNonobtuse_Gmsh"
+
+
+class StokesSphereBenchmark2DHCDDGSymmNonobtuse(StokesSphereBenchmark2DHCDDG):
+    def __init__(self, **kwargs):
+        kwargs.setdefault("workdir", "benchmarks_out/stokes_sphere_2d_hc_symm_nonobtuse")
+        kwargs.setdefault("mesh_name", "stokes_sphere_2d_hc_symm_nonobtuse")
+        kwargs.setdefault("symm_nonobtuse", True)
+        super().__init__(**kwargs)
+        self.name = "StokesSphere2D_DDG_SymmNonobtuse_HC"
+
+
+class StokesSphereBenchmark3DDDG(StokesSphereBenchmark3D):
+    """
+    3D Stokes benchmark using DDG gradient reconstruction in stress evaluation
+    on the Gmsh mesh.
+    """
+
+    def __init__(self, **kwargs):
+        kwargs.setdefault("ddg_enabled", True)
+        super().__init__(**kwargs)
+        self.name = "StokesSphere3D_DDG_Gmsh"
+        self.ddg_residuals_enabled = False
+
+    def run_benchmark(self):
+        self.generate_mesh()
+        self.load_mesh()
+        self.analytical_values()
+        self.reset_vertex_drag_lumped_error_stats()
+        self.build_ddg_complex()
+
+        if self.HC is None:
+            self.force_vector_computed = np.full(self.vector_dim, np.nan, dtype=float)
+            self.drag_force_computed = np.nan
+            self.force_error_abs = np.nan
+            self.force_error_rel = np.nan
+            self.finalize_vertex_drag_lumped_error_stats()
+            return
+
+        try:
+            self.force_vector_computed = _integrate_obstacle_force_ddg_3d(self)
+        except Exception as exc:
+            logger.warning("%s: DDG obstacle integration failed (%s)", self.name, exc)
+            self.force_vector_computed = np.full(self.vector_dim, np.nan, dtype=float)
+            self.drag_force_computed = np.nan
+            self.force_error_abs = np.nan
+            self.force_error_rel = np.nan
+            self.finalize_vertex_drag_lumped_error_stats()
+            return
+
+        self.drag_force_computed = float(np.dot(self.force_vector_computed, self.flow_direction))
+        self.force_error_abs = float(abs(self.drag_force_computed - self.drag_force_analytical))
+        if abs(self.drag_force_analytical) > 1.0e-30:
+            self.force_error_rel = self.force_error_abs / abs(self.drag_force_analytical)
+        self.finalize_vertex_drag_lumped_error_stats()
+
+
+class StokesSphereBenchmark3DHCDDG(StokesSphereBenchmark3DHC):
+    """
+    3D Stokes benchmark using DDG gradient reconstruction in stress evaluation
+    on the HC-native mesh.
+    """
+
+    def __init__(self, **kwargs):
+        kwargs.setdefault("ddg_enabled", True)
+        super().__init__(**kwargs)
+        self.name = "StokesSphere3D_DDG_HC"
+        self.ddg_residuals_enabled = False
+
+    def run_benchmark(self):
+        self.generate_mesh()
+        self.load_mesh()
+        self.analytical_values()
+        self.reset_vertex_drag_lumped_error_stats()
+        self.build_ddg_complex()
+
+        if self.HC is None:
+            self.force_vector_computed = np.full(self.vector_dim, np.nan, dtype=float)
+            self.drag_force_computed = np.nan
+            self.force_error_abs = np.nan
+            self.force_error_rel = np.nan
+            self.finalize_vertex_drag_lumped_error_stats()
+            return
+
+        try:
+            self.force_vector_computed = _integrate_obstacle_force_ddg_3d(self)
+        except Exception as exc:
+            logger.warning("%s: DDG obstacle integration failed (%s)", self.name, exc)
+            self.force_vector_computed = np.full(self.vector_dim, np.nan, dtype=float)
+            self.drag_force_computed = np.nan
+            self.force_error_abs = np.nan
+            self.force_error_rel = np.nan
+            self.finalize_vertex_drag_lumped_error_stats()
+            return
+
+        self.drag_force_computed = float(np.dot(self.force_vector_computed, self.flow_direction))
+        self.force_error_abs = float(abs(self.drag_force_computed - self.drag_force_analytical))
+        if abs(self.drag_force_analytical) > 1.0e-30:
+            self.force_error_rel = self.force_error_abs / abs(self.drag_force_analytical)
+        self.finalize_vertex_drag_lumped_error_stats()
+
+
+class StokesSphereBenchmark3DDDGSymmNonobtuse(StokesSphereBenchmark3DDDG):
+    def __init__(self, **kwargs):
+        kwargs.setdefault("workdir", "benchmarks_out/stokes_sphere_3d_symm_nonobtuse")
+        kwargs.setdefault("mesh_name", "stokes_sphere_3d_symm_nonobtuse.msh")
+        kwargs.setdefault("symm_nonobtuse", True)
+        super().__init__(**kwargs)
+        self.name = "StokesSphere3D_DDG_SymmNonobtuse_Gmsh"
+
+
+class StokesSphereBenchmark3DHCDDGSymmNonobtuse(StokesSphereBenchmark3DHCDDG):
+    def __init__(self, **kwargs):
+        kwargs.setdefault("workdir", "benchmarks_out/stokes_sphere_3d_hc_symm_nonobtuse")
+        kwargs.setdefault("mesh_name", "stokes_sphere_3d_hc_symm_nonobtuse")
+        kwargs.setdefault("symm_nonobtuse", True)
+        super().__init__(**kwargs)
+        self.name = "StokesSphere3D_DDG_SymmNonobtuse_HC"
+
+
+class StokesSphereBenchmark3DDDGEqualEdge(StokesSphereBenchmark3DDDG):
+    def __init__(self, **kwargs):
+        kwargs.setdefault("workdir", "benchmarks_out/stokes_sphere_3d_equal_edge")
+        kwargs.setdefault("mesh_name", "stokes_sphere_3d_equal_edge.msh")
+        kwargs.setdefault("equal_edge", True)
+        super().__init__(**kwargs)
+        self.name = "StokesSphere3D_DDG_EqualEdge_Gmsh"
+
+
+class StokesSphereBenchmark3DHCDDGEqualEdge(StokesSphereBenchmark3DHCDDG):
+    def __init__(self, **kwargs):
+        kwargs.setdefault("workdir", "benchmarks_out/stokes_sphere_3d_hc_equal_edge")
+        kwargs.setdefault("mesh_name", "stokes_sphere_3d_hc_equal_edge")
+        kwargs.setdefault("equal_edge", True)
+        super().__init__(**kwargs)
+        self.name = "StokesSphere3D_DDG_EqualEdge_HC"

--- a/benchmarks/_benchmark_classes.py
+++ b/benchmarks/_benchmark_classes.py
@@ -2,6 +2,8 @@ import logging
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
+from abc import ABC, abstractmethod
+
 import numpy as np
 from ddgclib._method_wrappers import (
     Curvature_i, Curvature_ijk,
@@ -150,3 +152,712 @@ def run_all_benchmarks(benchmark_classes, method=None, complex_dtype="vf"):
         print(f"Benchmark: {bench.name}")
         for k, (v_comp, v_ana) in bench.summary().items():
             print(f"  {k}: computed={v_comp:.6f}, analytical={v_ana:.6f}")
+
+
+class FlowBenchmarkBase(ABC):
+    """
+    Base class for flow benchmarks on curved Gmsh meshes.
+
+    The main use-case is an exact-field validation:
+
+    1. Build or load a volumetric mesh of the fluid domain.
+    2. Keep the obstacle boundary as a high-order Lagrange mesh.
+    3. Evaluate the analytical velocity and pressure fields.
+    4. Integrate the Cauchy traction on the obstacle boundary.
+    5. Compare the integrated force against the analytical drag / gravity.
+
+    When ``hyperct`` is available, the class also constructs a simplicial
+    complex from the low-order simplex backbone and evaluates a DDG stress
+    residual using :mod:`ddgclib.operators.stress`.
+    """
+
+    volume_physical_id = 1
+    obstacle_physical_id = 2
+    outer_boundary_physical_id = 3
+    axis_physical_id = 4
+
+    def __init__(
+        self,
+        name="unnamed_flow",
+        method=None,
+        complex_dtype="vv",
+        dim=3,
+        mu=1.0,
+        sphere_radius=1.0,
+        outer_radius=6.0,
+        density_difference=1.0,
+        gravity=1.0,
+        flow_speed=None,
+        mesh_order=2,
+        fd_step=1.0e-6,
+        ddg_enabled=None,
+    ):
+        if dim not in (2, 3):
+            raise ValueError("FlowBenchmarkBase currently supports dim=2 or dim=3")
+
+        self.name = name
+        self.method = method or {}
+        self.complex_dtype = complex_dtype
+        self.dim = dim
+        self.vector_dim = 2 if dim == 2 else 3
+
+        self.mu = float(mu)
+        self.sphere_radius = float(sphere_radius)
+        self.outer_radius = float(outer_radius)
+        self.density_difference = float(density_difference)
+        self.gravity = float(gravity)
+        self.flow_speed = None if flow_speed is None else float(flow_speed)
+        self.mesh_order = int(mesh_order)
+        self.fd_step = float(fd_step)
+        if ddg_enabled is None:
+            # 3D `hyperct.compute_vd` on large generic tetra meshes can fail
+            # because it reconstructs local dual topology from neighbor
+            # intersections. Keep DDG-on by default for 2D and DDG-off for 3D.
+            self.ddg_enabled = (dim == 2)
+        else:
+            self.ddg_enabled = bool(ddg_enabled)
+
+        self.center = np.zeros(self.vector_dim, dtype=float)
+        self.flow_axis = self.vector_dim - 1
+        self.flow_direction = np.zeros(self.vector_dim, dtype=float)
+        self.flow_direction[self.flow_axis] = 1.0
+
+        self.mesh_path = None
+        self.mesh_metadata = {}
+
+        self.points = None
+        self.high_order_volume_cells = None
+        self.volume_cells = None
+        self.obstacle_elements = None
+        self.outer_boundary_elements = None
+        self.axis_elements = None
+
+        self.boundary_node_ids = set()
+        self.obstacle_node_ids = set()
+        self.outer_boundary_node_ids = set()
+        self.axis_node_ids = set()
+
+        self.HC = None
+        self.bV = set()
+        self.ddg_vertices = []
+        self.ddg_index_map = {}
+        self.ddg_point_indices = np.empty((0,), dtype=np.int64)
+        self.ddg_boundary_local_ids = set()
+
+        self.force_vector_computed = None
+        self.force_vector_analytical = None
+        self.drag_force_computed = np.nan
+        self.drag_force_analytical = np.nan
+        self.gravity_force_analytical = np.nan
+        self.force_error_abs = np.nan
+        self.force_error_rel = np.nan
+
+        self.ddg_residual_median = np.nan
+        self.ddg_residual_max = np.nan
+        self.ddg_residual_count = 0
+        self.ddg_residuals_enabled = True
+
+        self.vertex_drag_rel_error_mean = np.nan
+        self.vertex_drag_rel_error_max = np.nan
+        self.vertex_drag_valid_count = 0
+        self._vertex_drag_computed_by_node = {}
+        self._vertex_drag_reference_by_node = {}
+
+    @abstractmethod
+    def generate_mesh(self):
+        """Create or select ``self.mesh_path``."""
+
+    @abstractmethod
+    def analytical_velocity(self, x):
+        """Return the analytical velocity vector at ``x``."""
+
+    @abstractmethod
+    def analytical_pressure(self, x):
+        """Return the analytical pressure at ``x``."""
+
+    @abstractmethod
+    def analytical_values(self):
+        """Populate analytical drag / gravity reference values."""
+
+    @property
+    def _high_order_volume_cell_types(self):
+        return ("triangle6",) if self.dim == 2 else ("tetra10",)
+
+    @property
+    def _low_order_volume_cell_types(self):
+        return ("triangle",) if self.dim == 2 else ("tetra",)
+
+    @property
+    def _high_order_boundary_cell_types(self):
+        return ("line3",) if self.dim == 2 else ("triangle6",)
+
+    @property
+    def _low_order_boundary_cell_types(self):
+        return ("line",) if self.dim == 2 else ("triangle",)
+
+    @staticmethod
+    def _extract_cell_blocks(mesh, cell_types, physical_id=None):
+        if isinstance(cell_types, str):
+            cell_types = (cell_types,)
+
+        blocks = []
+        physical_blocks = mesh.cell_data.get("gmsh:physical")
+        for idx, block in enumerate(mesh.cells):
+            if block.type not in cell_types:
+                continue
+
+            data = np.asarray(block.data, dtype=np.int64)
+            if data.ndim != 2 or data.size == 0:
+                continue
+
+            if physical_id is not None:
+                if physical_blocks is None or idx >= len(physical_blocks):
+                    continue
+                tags = np.asarray(physical_blocks[idx], dtype=np.int64)
+                data = data[tags == physical_id]
+
+            if data.size:
+                blocks.append(data)
+
+        if not blocks:
+            return np.empty((0, 0), dtype=np.int64)
+        return np.concatenate(blocks, axis=0)
+
+    def _update_boundary_bookkeeping(self):
+        """Refresh boundary-node sets and mesh metadata."""
+        self.obstacle_node_ids = set(np.asarray(self.obstacle_elements, dtype=np.int64).ravel().tolist())
+        self.outer_boundary_node_ids = set(np.asarray(self.outer_boundary_elements, dtype=np.int64).ravel().tolist())
+        self.axis_node_ids = set(np.asarray(self.axis_elements, dtype=np.int64).ravel().tolist())
+        self.boundary_node_ids = (
+            self.obstacle_node_ids | self.outer_boundary_node_ids | self.axis_node_ids
+        )
+
+        self.mesh_metadata = {
+            "n_points": int(len(self.points)) if self.points is not None else 0,
+            "n_volume_cells": int(len(self.volume_cells)) if self.volume_cells is not None else 0,
+            "n_obstacle_elements": int(len(self.obstacle_elements)) if self.obstacle_elements is not None else 0,
+            "n_outer_boundary_elements": int(len(self.outer_boundary_elements))
+            if self.outer_boundary_elements is not None else 0,
+            "n_axis_elements": int(len(self.axis_elements)) if self.axis_elements is not None else 0,
+        }
+
+    def load_mesh(self):
+        """Load the Gmsh mesh and extract the simplex backbone and boundary groups."""
+        if self.mesh_path is None:
+            raise ValueError("generate_mesh() must set self.mesh_path before load_mesh()")
+
+        try:
+            import meshio
+        except ImportError as exc:
+            raise ImportError("meshio is required to load Stokes benchmark meshes") from exc
+
+        mesh = meshio.read(self.mesh_path)
+        points = np.asarray(mesh.points, dtype=float)
+        if points.shape[1] < self.vector_dim:
+            pad = np.zeros((len(points), self.vector_dim - points.shape[1]), dtype=float)
+            points = np.c_[points, pad]
+        self.points = np.asarray(points[:, :self.vector_dim], dtype=float)
+
+        high_order_volume = self._extract_cell_blocks(
+            mesh, self._high_order_volume_cell_types, physical_id=self.volume_physical_id
+        )
+        low_order_volume = self._extract_cell_blocks(
+            mesh, self._low_order_volume_cell_types, physical_id=self.volume_physical_id
+        )
+        if high_order_volume.size:
+            self.high_order_volume_cells = high_order_volume
+            self.volume_cells = np.asarray(
+                high_order_volume[:, : self.vector_dim + 1], dtype=np.int64
+            )
+        else:
+            self.high_order_volume_cells = low_order_volume
+            self.volume_cells = low_order_volume
+
+        obstacle = self._extract_cell_blocks(
+            mesh, self._high_order_boundary_cell_types, physical_id=self.obstacle_physical_id
+        )
+        if not obstacle.size:
+            obstacle = self._extract_cell_blocks(
+                mesh, self._low_order_boundary_cell_types, physical_id=self.obstacle_physical_id
+            )
+        self.obstacle_elements = obstacle
+
+        outer = self._extract_cell_blocks(
+            mesh, self._high_order_boundary_cell_types, physical_id=self.outer_boundary_physical_id
+        )
+        if not outer.size:
+            outer = self._extract_cell_blocks(
+                mesh, self._low_order_boundary_cell_types, physical_id=self.outer_boundary_physical_id
+            )
+        self.outer_boundary_elements = outer
+
+        if self.dim == 2:
+            axis = self._extract_cell_blocks(
+                mesh, self._high_order_boundary_cell_types, physical_id=self.axis_physical_id
+            )
+            if not axis.size:
+                axis = self._extract_cell_blocks(
+                    mesh, self._low_order_boundary_cell_types, physical_id=self.axis_physical_id
+                )
+            self.axis_elements = axis
+        else:
+            self.axis_elements = np.empty((0, 0), dtype=np.int64)
+
+        self._update_boundary_bookkeeping()
+
+    def obstacle_normal(self, x):
+        """Outward unit normal of the sphere, pointing from the solid into the fluid."""
+        vec = np.asarray(x, dtype=float)[: self.vector_dim] - self.center
+        norm = np.linalg.norm(vec)
+        if norm < 1.0e-14:
+            return np.zeros(self.vector_dim, dtype=float)
+        return vec / norm
+
+    def velocity_gradient(self, x):
+        """
+        Finite-difference Jacobian of the analytical velocity field.
+
+        The Stokes benchmark uses this with :func:`ddgclib.operators.stress.cauchy_stress`
+        so the constitutive relation is still evaluated by ddgclib.
+        """
+        x = np.asarray(x, dtype=float)[: self.vector_dim]
+        h = self.fd_step * max(self.sphere_radius, 1.0)
+        grad = np.zeros((self.vector_dim, self.vector_dim), dtype=float)
+
+        for j in range(self.vector_dim):
+            dx = np.zeros(self.vector_dim, dtype=float)
+            dx[j] = h
+            u_plus = np.asarray(self.analytical_velocity(x + dx), dtype=float)
+            u_minus = np.asarray(self.analytical_velocity(x - dx), dtype=float)
+            grad[:, j] = (u_plus - u_minus) / (2.0 * h)
+        return grad
+
+    def cauchy_stress_tensor(self, x):
+        """Pointwise Newtonian Cauchy stress via ddgclib."""
+        from ddgclib.operators.stress import cauchy_stress
+
+        du = self.velocity_gradient(x)
+        p = float(self.analytical_pressure(x))
+        return cauchy_stress(p=p, du=du, mu=self.mu, dim=self.vector_dim)
+
+    def velocity_gradient_reference(self, x):
+        """
+        Higher-order finite-difference Jacobian of the analytical velocity.
+
+        This is used as a reference operator for nodal drag-lumping diagnostics.
+        """
+        x = np.asarray(x, dtype=float)[: self.vector_dim]
+        h = self.fd_step * max(self.sphere_radius, 1.0)
+        grad = np.zeros((self.vector_dim, self.vector_dim), dtype=float)
+
+        for j in range(self.vector_dim):
+            dx = np.zeros(self.vector_dim, dtype=float)
+            dx[j] = h
+            u_p2 = np.asarray(self.analytical_velocity(x + 2.0 * dx), dtype=float)
+            u_p1 = np.asarray(self.analytical_velocity(x + 1.0 * dx), dtype=float)
+            u_m1 = np.asarray(self.analytical_velocity(x - 1.0 * dx), dtype=float)
+            u_m2 = np.asarray(self.analytical_velocity(x - 2.0 * dx), dtype=float)
+            grad[:, j] = (-u_p2 + 8.0 * u_p1 - 8.0 * u_m1 + u_m2) / (12.0 * h)
+        return grad
+
+    def cauchy_stress_tensor_reference(self, x):
+        """Reference Cauchy stress using higher-order analytical-field derivatives."""
+        from ddgclib.operators.stress import cauchy_stress
+
+        du = self.velocity_gradient_reference(x)
+        p = float(self.analytical_pressure(x))
+        return cauchy_stress(p=p, du=du, mu=self.mu, dim=self.vector_dim)
+
+    def reset_vertex_drag_lumped_error_stats(self):
+        self.vertex_drag_rel_error_mean = np.nan
+        self.vertex_drag_rel_error_max = np.nan
+        self.vertex_drag_valid_count = 0
+        self._vertex_drag_computed_by_node = {}
+        self._vertex_drag_reference_by_node = {}
+
+    def accumulate_vertex_drag_lumped_contribution(self, node_ids, shape_values, drag_computed, drag_reference):
+        node_ids = np.asarray(node_ids, dtype=np.int64)
+        shape_values = np.asarray(shape_values, dtype=float)
+        if node_ids.size == 0 or shape_values.size == 0:
+            return
+        if node_ids.size != shape_values.size:
+            return
+
+        d_comp = float(drag_computed)
+        d_ref = float(drag_reference)
+        for nid, Ni in zip(node_ids, shape_values):
+            key = int(nid)
+            w = float(Ni)
+            self._vertex_drag_computed_by_node[key] = self._vertex_drag_computed_by_node.get(key, 0.0) + w * d_comp
+            self._vertex_drag_reference_by_node[key] = self._vertex_drag_reference_by_node.get(key, 0.0) + w * d_ref
+
+    def finalize_vertex_drag_lumped_error_stats(self):
+        keys = sorted(
+            set(self._vertex_drag_computed_by_node.keys())
+            | set(self._vertex_drag_reference_by_node.keys())
+        )
+        if not keys:
+            self.vertex_drag_rel_error_mean = np.nan
+            self.vertex_drag_rel_error_max = np.nan
+            self.vertex_drag_valid_count = 0
+            return
+
+        comp = np.asarray(
+            [self._vertex_drag_computed_by_node.get(k, 0.0) for k in keys],
+            dtype=float,
+        )
+        ref = np.asarray(
+            [self._vertex_drag_reference_by_node.get(k, 0.0) for k in keys],
+            dtype=float,
+        )
+
+        avg_scale = abs(float(self.drag_force_analytical)) / max(len(keys), 1)
+        ref_tol = max(1.0e-30, 1.0e-12 * max(avg_scale, 1.0))
+        valid = np.abs(ref) > ref_tol
+
+        if not np.any(valid):
+            self.vertex_drag_rel_error_mean = np.nan
+            self.vertex_drag_rel_error_max = np.nan
+            self.vertex_drag_valid_count = 0
+            return
+
+        rel = np.abs(comp[valid] - ref[valid]) / np.abs(ref[valid])
+        self.vertex_drag_rel_error_mean = float(np.mean(rel))
+        self.vertex_drag_rel_error_max = float(np.max(rel))
+        self.vertex_drag_valid_count = int(np.count_nonzero(valid))
+
+    @staticmethod
+    def _line_shape_functions(s, n_nodes):
+        if n_nodes == 2:
+            N = np.array([(1.0 - s) * 0.5, (1.0 + s) * 0.5], dtype=float)
+            dN = np.array([-0.5, 0.5], dtype=float)
+            return N, dN
+        if n_nodes == 3:
+            # Gmsh/meshio order line3 nodes as [end0, end1, midpoint].
+            N = np.array(
+                [
+                    0.5 * s * (s - 1.0),
+                    0.5 * s * (s + 1.0),
+                    1.0 - s**2,
+                ],
+                dtype=float,
+            )
+            dN = np.array([s - 0.5, s + 0.5, -2.0 * s], dtype=float)
+            return N, dN
+        raise NotImplementedError(f"Unsupported line element with {n_nodes} nodes")
+
+    @staticmethod
+    def _triangle_shape_functions(xi, eta, n_nodes):
+        zeta = 1.0 - xi - eta
+        if n_nodes == 3:
+            N = np.array([zeta, xi, eta], dtype=float)
+            dN_dxi = np.array([-1.0, 1.0, 0.0], dtype=float)
+            dN_deta = np.array([-1.0, 0.0, 1.0], dtype=float)
+            return N, dN_dxi, dN_deta
+
+        if n_nodes == 6:
+            N = np.array(
+                [
+                    zeta * (2.0 * zeta - 1.0),
+                    xi * (2.0 * xi - 1.0),
+                    eta * (2.0 * eta - 1.0),
+                    4.0 * xi * zeta,
+                    4.0 * xi * eta,
+                    4.0 * eta * zeta,
+                ],
+                dtype=float,
+            )
+            dN_dxi = np.array(
+                [
+                    1.0 - 4.0 * zeta,
+                    4.0 * xi - 1.0,
+                    0.0,
+                    4.0 * (zeta - xi),
+                    4.0 * eta,
+                    -4.0 * eta,
+                ],
+                dtype=float,
+            )
+            dN_deta = np.array(
+                [
+                    1.0 - 4.0 * zeta,
+                    0.0,
+                    4.0 * eta - 1.0,
+                    -4.0 * xi,
+                    4.0 * xi,
+                    4.0 * (zeta - eta),
+                ],
+                dtype=float,
+            )
+            return N, dN_dxi, dN_deta
+
+        raise NotImplementedError(f"Unsupported triangle element with {n_nodes} nodes")
+
+    @staticmethod
+    def _line_quadrature():
+        q = np.sqrt(3.0 / 5.0)
+        return (
+            np.array([-q, 0.0, q], dtype=float),
+            np.array([5.0 / 9.0, 8.0 / 9.0, 5.0 / 9.0], dtype=float),
+        )
+
+    @staticmethod
+    def _triangle_quadrature():
+        return [
+            (1.0 / 3.0, 1.0 / 3.0, 0.112500000000000),
+            (0.470142064105115, 0.470142064105115, 0.066197076394253),
+            (0.470142064105115, 0.059715871789770, 0.066197076394253),
+            (0.059715871789770, 0.470142064105115, 0.066197076394253),
+            (0.101286507323456, 0.101286507323456, 0.0629695902724135),
+            (0.101286507323456, 0.797426985353087, 0.0629695902724135),
+            (0.797426985353087, 0.101286507323456, 0.0629695902724135),
+        ]
+
+    def integrate_obstacle_force(self):
+        """Integrate ``sigma · n`` on the obstacle boundary."""
+        if self.obstacle_elements is None or self.obstacle_elements.size == 0:
+            raise ValueError("Obstacle boundary elements are missing; load_mesh() first")
+
+        if self.dim == 2:
+            return self._integrate_axisymmetric_obstacle_force()
+        if self.dim == 3:
+            return self._integrate_3d_obstacle_force()
+        raise NotImplementedError(f"Unsupported dimension {self.dim}")
+
+    def _integrate_axisymmetric_obstacle_force(self):
+        force = np.zeros(self.vector_dim, dtype=float)
+        s_q, w_q = self._line_quadrature()
+
+        for elem in self.obstacle_elements:
+            node_ids = np.asarray(elem, dtype=np.int64)
+            nodes = self.points[node_ids, : self.vector_dim]
+            for s, w in zip(s_q, w_q):
+                N, dN = self._line_shape_functions(s, len(node_ids))
+                x = np.tensordot(N, nodes, axes=(0, 0))
+                dx_ds = np.tensordot(dN, nodes, axes=(0, 0))
+                jac = np.linalg.norm(dx_ds)
+                if jac < 1.0e-14:
+                    continue
+
+                rho = max(float(x[0] - self.center[0]), 0.0)
+                if rho < 1.0e-14:
+                    continue
+
+                sigma = self.cauchy_stress_tensor(x)
+                normal = self.obstacle_normal(x)
+                traction = sigma @ normal
+                force += traction * (2.0 * np.pi * rho * jac * w)
+
+        return force
+
+    def _integrate_3d_obstacle_force(self):
+        force = np.zeros(self.vector_dim, dtype=float)
+        for elem in self.obstacle_elements:
+            node_ids = np.asarray(elem, dtype=np.int64)
+            nodes = self.points[node_ids, : self.vector_dim]
+            for xi, eta, w in self._triangle_quadrature():
+                N, dN_dxi, dN_deta = self._triangle_shape_functions(xi, eta, len(node_ids))
+                x = np.tensordot(N, nodes, axes=(0, 0))
+                dx_dxi = np.tensordot(dN_dxi, nodes, axes=(0, 0))
+                dx_deta = np.tensordot(dN_deta, nodes, axes=(0, 0))
+                jac_vec = np.cross(dx_dxi, dx_deta)
+                jac = np.linalg.norm(jac_vec)
+                if jac < 1.0e-14:
+                    continue
+
+                sigma = self.cauchy_stress_tensor(x)
+                normal = self.obstacle_normal(x)
+                traction = sigma @ normal
+                force += traction * (jac * w)
+
+        return force
+
+    def build_ddg_complex(self):
+        """
+        Build a low-order ``hyperct.Complex`` from the simplex backbone.
+
+        This is optional.  When ``hyperct`` is unavailable the benchmark still
+        runs and the curved traction integral remains valid.
+        """
+        if self.volume_cells is None or self.volume_cells.size == 0:
+            logger.warning("%s: no volume cells found; skipping DDG complex build", self.name)
+            return
+
+        try:
+            from hyperct import Complex
+            from hyperct.ddg import compute_vd
+        except ImportError as exc:
+            logger.warning("%s: hyperct is unavailable (%s); skipping DDG residuals", self.name, exc)
+            return
+
+        all_coords = np.asarray(self.points[:, : self.vector_dim], dtype=float)
+        simplex_size = self.vector_dim + 1
+        simplices = np.asarray(self.volume_cells, dtype=np.int64)
+        if simplices.ndim != 2 or simplices.shape[0] == 0:
+            logger.warning("%s: no simplices available for DDG build", self.name)
+            return
+
+        simplices = np.asarray(simplices[:, :simplex_size], dtype=np.int64)
+        active_ids = np.unique(simplices.ravel())
+        if active_ids.size == 0:
+            logger.warning("%s: no active vertices in simplices for DDG build", self.name)
+            return
+
+        coords = np.asarray(all_coords[active_ids], dtype=float)
+        index_map = {int(orig): int(local) for local, orig in enumerate(active_ids)}
+
+        def _make_complex():
+            HC_local = Complex(self.vector_dim)
+            verts_local = [HC_local.V[tuple(coord)] for coord in coords]
+            for simplex in simplices:
+                simplex = np.asarray([index_map[int(node)] for node in simplex], dtype=np.int64)
+                for i in range(simplex_size):
+                    for j in range(i + 1, simplex_size):
+                        verts_local[simplex[i]].connect(verts_local[simplex[j]])
+
+            bV_local = set()
+            boundary_local_ids_local = set()
+            for idx, v in enumerate(verts_local):
+                x = coords[idx]
+                v.u = np.asarray(self.analytical_velocity(x), dtype=float)
+                v.p = float(self.analytical_pressure(x))
+                v.m = 1.0
+                orig_idx = int(active_ids[idx])
+                v.boundary = orig_idx in self.boundary_node_ids
+                if v.boundary:
+                    bV_local.add(v)
+                    boundary_local_ids_local.add(idx)
+            return HC_local, verts_local, bV_local, boundary_local_ids_local
+
+        backend_candidates = [None]
+        try:
+            from hyperct._backend import get_backend  # type: ignore
+            backend_candidates.append(get_backend("numpy"))
+        except Exception:
+            pass
+
+        attempts = []
+        for method in ("barycentric", "circumcentric"):
+            for backend in backend_candidates:
+                attempts.append((method, backend))
+
+        HC = None
+        verts = []
+        bV = set()
+        boundary_local_ids = set()
+        fail_msgs = []
+        for method, backend in attempts:
+            HC_try, verts_try, bV_try, boundary_ids_try = _make_complex()
+            kwargs = {"method": method}
+            if backend is not None:
+                kwargs["backend"] = backend
+            backend_name = "default" if backend is None else "numpy"
+            try:
+                compute_vd(HC_try, **kwargs)
+            except TypeError:
+                try:
+                    compute_vd(HC_try, cdist=1.0e-10, **kwargs)
+                except Exception as exc:
+                    fail_msgs.append(f"{method}/{backend_name}: {exc}")
+                    continue
+            except Exception as exc:
+                fail_msgs.append(f"{method}/{backend_name}: {exc}")
+                continue
+
+            HC = HC_try
+            verts = verts_try
+            bV = bV_try
+            boundary_local_ids = boundary_ids_try
+            break
+
+        if HC is None:
+            detail = "; ".join(fail_msgs) if fail_msgs else "unknown error"
+            logger.warning("%s: compute_vd failed (%s); skipping DDG residuals", self.name, detail)
+            return
+
+        self.HC = HC
+        self.bV = bV
+        self.ddg_vertices = verts
+        self.ddg_index_map = index_map
+        self.ddg_point_indices = np.asarray(active_ids, dtype=np.int64)
+        self.ddg_boundary_local_ids = boundary_local_ids
+        if self.ddg_residuals_enabled:
+            self.compute_ddg_residuals()
+
+    def compute_ddg_residuals(self):
+        """Evaluate DDG stress-force residuals on interior vertices."""
+        if self.HC is None:
+            return
+
+        try:
+            from ddgclib.operators.stress import stress_force
+        except Exception as exc:
+            logger.warning("%s: failed to import stress_force (%s)", self.name, exc)
+            return
+
+        boundary_local_ids = getattr(self, "ddg_boundary_local_ids", set())
+        residuals = []
+        fail_count = 0
+        for idx, v in enumerate(self.HC.V):
+            if idx in boundary_local_ids:
+                continue
+            try:
+                F = stress_force(v, dim=self.vector_dim, mu=self.mu, HC=self.HC)
+            except Exception as exc:
+                fail_count += 1
+                if fail_count <= 5:
+                    logger.warning("%s: stress_force failed at vertex %d (%s)", self.name, idx, exc)
+                continue
+            residuals.append(float(np.linalg.norm(F)))
+
+        if fail_count > 5:
+            logger.warning(
+                "%s: stress_force failed at %d additional vertices",
+                self.name,
+                fail_count - 5,
+            )
+
+        if residuals:
+            residuals = np.asarray(residuals, dtype=float)
+            self.ddg_residual_count = int(residuals.size)
+            self.ddg_residual_median = float(np.median(residuals))
+            self.ddg_residual_max = float(np.max(residuals))
+
+    def run_benchmark(self):
+        """Run the flow benchmark end-to-end."""
+        self.generate_mesh()
+        self.load_mesh()
+        self.analytical_values()
+        self.reset_vertex_drag_lumped_error_stats()
+
+        self.force_vector_computed = self.integrate_obstacle_force()
+        self.drag_force_computed = float(np.dot(self.force_vector_computed, self.flow_direction))
+        self.force_error_abs = float(abs(self.drag_force_computed - self.drag_force_analytical))
+
+        if abs(self.drag_force_analytical) > 1.0e-30:
+            self.force_error_rel = self.force_error_abs / abs(self.drag_force_analytical)
+        self.finalize_vertex_drag_lumped_error_stats()
+
+        if self.ddg_enabled:
+            self.build_ddg_complex()
+
+    def summary(self):
+        axes = ("X", "Y", "Z")
+        out = {}
+
+        if self.force_vector_computed is not None and self.force_vector_analytical is not None:
+            for i in range(self.vector_dim):
+                out[f"Force {axes[i]}"] = (
+                    float(self.force_vector_computed[i]),
+                    float(self.force_vector_analytical[i]),
+                )
+
+        out["Drag"] = (float(self.drag_force_computed), float(self.drag_force_analytical))
+        out["Gravity"] = (float(self.drag_force_computed), float(self.gravity_force_analytical))
+        out["Drag Abs Error"] = (float(self.force_error_abs), 0.0)
+        out["Drag Rel Error"] = (float(self.force_error_rel), 0.0)
+        out["vertexDragRelErrorMean"] = (float(self.vertex_drag_rel_error_mean), 0.0)
+        out["vertexDragRelErrorMax"] = (float(self.vertex_drag_rel_error_max), 0.0)
+        out["DDG Residual Median"] = (float(self.ddg_residual_median), 0.0)
+        out["DDG Residual Max"] = (float(self.ddg_residual_max), 0.0)
+        return out

--- a/run_stokes_benchmark_2D.py
+++ b/run_stokes_benchmark_2D.py
@@ -1,0 +1,795 @@
+#!/usr/bin/env python3
+import argparse
+import os
+import tempfile
+from pathlib import Path
+
+import numpy as np
+from PIL import Image, ImageDraw
+
+os.environ["MPLCONFIGDIR"] = str(Path(tempfile.gettempdir()) / "matplotlib")
+os.environ["MPLBACKEND"] = "Agg"
+
+from benchmarks._benchmark_cases import (
+    StokesSphereBenchmark2D,
+    StokesSphereBenchmark2DDDG,
+    StokesSphereBenchmark2DHC,
+    StokesSphereBenchmark2DHCDDG,
+    StokesSphereBenchmark2DHCDDGSymmNonobtuse,
+    StokesSphereBenchmark2DHCSymmNonobtuse,
+    StokesSphereBenchmark2DDDGSymmNonobtuse,
+    StokesSphereBenchmark2DSymmNonobtuse,
+    _generate_stokes_sphere_hc_mesh,
+)
+
+
+def _build_parser():
+    parser = argparse.ArgumentParser(
+        description="Run the 2D axisymmetric Stokes-sphere benchmark.",
+    )
+    parser.add_argument("--sphere-radius", type=float, default=1.0)
+    parser.add_argument("--outer-radius", type=float, default=6.0)
+    parser.add_argument("--mu", type=float, default=1.0)
+    parser.add_argument("--density-difference", type=float, default=1.0)
+    parser.add_argument("--gravity", type=float, default=1.0)
+    parser.add_argument("--flow-speed", type=float, default=None)
+    parser.add_argument("--mesh-size-inner", type=float, default=None)
+    parser.add_argument("--mesh-size-outer", type=float, default=None)
+    parser.add_argument("--mesh-order", type=int, default=2)
+    parser.add_argument(
+        "--mesh-source",
+        type=str,
+        choices=("gmsh", "hc", "both"),
+        default="both",
+        help="Mesh source: gmsh, hc, or both (for side-by-side comparison).",
+    )
+    parser.add_argument(
+        "--workdir",
+        type=str,
+        default="benchmarks_out/stokes_sphere_2d",
+    )
+    parser.add_argument(
+        "--mesh-name",
+        type=str,
+        default="stokes_sphere_2d_axisymmetric.msh",
+    )
+    parser.add_argument(
+        "--remesh",
+        action="store_true",
+        help="Regenerate the Gmsh mesh even if it already exists.",
+    )
+    parser.add_argument("--hc-refine", type=int, default=3)
+    parser.add_argument("--hc-inner-samples", type=int, default=None)
+    parser.add_argument("--hc-outer-samples", type=int, default=None)
+    parser.add_argument(
+        "--auto-match-hc-cells",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="In 'both' mode, auto-tune HC mesh parameters to match Gmsh volume-cell count.",
+    )
+    parser.add_argument(
+        "--auto-match-mode",
+        type=str,
+        choices=("cells", "balanced", "gmsh_style"),
+        default="gmsh_style",
+        help=(
+            "HC auto-match objective in 'both' mode: "
+            "'cells' (match volume cells), "
+            "'balanced' (trade off cells and boundary density), "
+            "'gmsh_style' (match Gmsh boundary density first)."
+        ),
+    )
+    parser.add_argument(
+        "--save-mesh-pngs",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Save mesh snapshots as PNG files.",
+    )
+    parser.add_argument(
+        "--mesh-png-dir",
+        type=str,
+        default=None,
+        help="Directory where mesh PNG files are saved (defaults to <workdir>/mesh_pngs).",
+    )
+    return parser
+
+
+def _format_value(value):
+    if isinstance(value, (float, np.floating)) and np.isnan(value):
+        return "nan"
+    if isinstance(value, (int, float, np.integer, np.floating)):
+        return f"{float(value):.12g}"
+    return str(value)
+
+
+def _print_summary(bench):
+    print(f"Benchmark: {bench.name}")
+    print(f"Mesh: {bench.mesh_path}")
+    print("")
+    meta = getattr(bench, "mesh_metadata", {}) or {}
+    n_obstacle = int(meta.get("n_obstacle_elements", 0))
+    n_outer = int(meta.get("n_outer_boundary_elements", 0))
+    n_cells = int(meta.get("n_volume_cells", 0))
+    print(f"Boundary Elements: obstacle={n_obstacle}, outer={n_outer}, volume_cells={n_cells}")
+    print("")
+    for metric, (computed, analytical) in bench.summary().items():
+        print(
+            f"{metric}: "
+            f"computed={_format_value(computed)}, "
+            f"analytical={_format_value(analytical)}"
+        )
+
+
+def _run_and_print(bench):
+    bench.run_benchmark()
+    _print_summary(bench)
+    return bench
+
+
+def _print_case_header(case_idx, title):
+    print(f"=== Case {int(case_idx)}. {title} ===")
+
+
+def _print_rel_error_by_case(case_entries):
+    print("\n=== Relative Error by Case ===")
+    for idx, (label, bench) in enumerate(case_entries, start=1):
+        if bench is None:
+            value = "not evaluated"
+        else:
+            value = _format_value(getattr(bench, "force_error_rel", np.nan))
+        print(f"Case {idx} ({label}): Drag Rel Error = {value}")
+
+
+def _print_vertex_rel_error_by_case(case_entries):
+    print("\n=== Vertex Drag Relative Error by Case ===")
+    for idx, (label, bench) in enumerate(case_entries, start=1):
+        if bench is None:
+            mean_val = "not evaluated"
+            max_val = "not evaluated"
+        else:
+            mean_val = _format_value(getattr(bench, "vertex_drag_rel_error_mean", np.nan))
+            max_val = _format_value(getattr(bench, "vertex_drag_rel_error_max", np.nan))
+        print(f"Case {idx} ({label}): vertexDragRelErrorMean = {mean_val}, vertexDragRelErrorMax = {max_val}")
+
+
+def _run_case(case_idx, title, benchmark_cls, kwargs):
+    print("" if int(case_idx) > 1 else "")
+    _print_case_header(case_idx, title)
+    try:
+        return _run_and_print(benchmark_cls(**kwargs))
+    except ImportError as exc:
+        print(f"{title} skipped: {exc}")
+        return None
+
+
+def _save_mesh_png(bench, out_path, title):
+    points = np.asarray(bench.points, dtype=float)
+    simplices = np.asarray(bench.volume_cells, dtype=np.int64)
+    if points.ndim != 2 or simplices.ndim != 2 or simplices.shape[1] != 3:
+        return None
+
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    width, height = 1400, 1050
+    margin = 40
+    img = Image.new("RGB", (width, height), color=(255, 255, 255))
+    draw = ImageDraw.Draw(img)
+
+    xy = points[:, :2]
+    x_min, y_min = xy.min(axis=0)
+    x_max, y_max = xy.max(axis=0)
+    dx = max(x_max - x_min, 1.0e-12)
+    dy = max(y_max - y_min, 1.0e-12)
+    scale = min((width - 2 * margin) / dx, (height - 2 * margin) / dy)
+    x_pad = (width - scale * dx) * 0.5
+    y_pad = (height - scale * dy) * 0.5
+
+    def to_px(p):
+        px = x_pad + (float(p[0]) - x_min) * scale
+        py = height - (y_pad + (float(p[1]) - y_min) * scale)
+        return (px, py)
+
+    for tri in simplices:
+        a, b, c = [to_px(points[int(i), :2]) for i in tri]
+        draw.line([a, b], fill=(140, 140, 140), width=1)
+        draw.line([b, c], fill=(140, 140, 140), width=1)
+        draw.line([c, a], fill=(140, 140, 140), width=1)
+
+    def draw_boundary(elements, color, width_px):
+        if elements is None:
+            return
+        arr = np.asarray(elements, dtype=np.int64)
+        if arr.size == 0:
+            return
+        for elem in arr:
+            node_ids = np.asarray(elem, dtype=np.int64)
+            nodes = points[node_ids, :2]
+            if len(node_ids) == 3:
+                # line3 in gmsh/meshio ordering: [end0, end1, midpoint]
+                nodes = nodes[[0, 2, 1]]
+            pts = [to_px(p) for p in nodes]
+            draw.line(pts, fill=color, width=width_px)
+
+    draw_boundary(bench.outer_boundary_elements, color=(42, 157, 143), width_px=2)
+    draw_boundary(bench.obstacle_elements, color=(230, 57, 70), width_px=3)
+    draw_boundary(bench.axis_elements, color=(29, 53, 87), width_px=2)
+    img.save(out_path)
+    return str(out_path)
+
+
+def _default_hc_samples(refine_level):
+    refine_level = int(max(refine_level, 0))
+    n_inner = max(32, 16 * (2 ** max(refine_level - 1, 0)))
+    n_outer = max(48, 24 * (2 ** max(refine_level - 1, 0)))
+    return int(n_inner), int(n_outer)
+
+
+def _default_gmsh_sizes_2d(args):
+    h_inner = args.mesh_size_inner if args.mesh_size_inner is not None else 0.20 * float(args.sphere_radius)
+    h_outer = args.mesh_size_outer if args.mesh_size_outer is not None else 0.75 * float(args.sphere_radius)
+    return float(h_inner), float(h_outer)
+
+
+def _triangle_quality_stats(points, simplices):
+    pts = np.asarray(points, dtype=float)
+    tri = np.asarray(simplices, dtype=np.int64)
+    if tri.ndim != 2 or tri.shape[1] != 3 or tri.size == 0:
+        return 0.0, 0.0
+
+    a = pts[tri[:, 0], :2]
+    b = pts[tri[:, 1], :2]
+    c = pts[tri[:, 2], :2]
+    ab = np.linalg.norm(b - a, axis=1)
+    bc = np.linalg.norm(c - b, axis=1)
+    ca = np.linalg.norm(a - c, axis=1)
+    area2 = np.abs((b[:, 0] - a[:, 0]) * (c[:, 1] - a[:, 1]) - (b[:, 1] - a[:, 1]) * (c[:, 0] - a[:, 0]))
+    quality = (2.0 * np.sqrt(3.0) * area2) / (ab * ab + bc * bc + ca * ca + 1.0e-30)
+    quality = np.asarray(quality, dtype=float)
+    finite = np.isfinite(quality)
+    if not np.any(finite):
+        return 0.0, 0.0
+    quality = quality[finite]
+    return float(np.median(quality)), float(np.min(quality))
+
+
+def _estimate_hc_volume_cells(args, refine_level, inner_samples, outer_samples, symm_nonobtuse=False):
+    points, simplices, obstacle, outer_boundary, _ = _generate_stokes_sphere_hc_mesh(
+        dim=2,
+        sphere_radius=args.sphere_radius,
+        outer_radius=args.outer_radius,
+        hc_refine=int(refine_level),
+        hc_inner_samples=int(inner_samples),
+        hc_outer_samples=int(outer_samples),
+        symm_nonobtuse=bool(symm_nonobtuse),
+    )
+    q_med, q_min = _triangle_quality_stats(points, simplices)
+    return int(simplices.shape[0]), q_med, q_min, int(len(obstacle)), int(len(outer_boundary))
+
+
+def _auto_tune_hc_to_target_cells(
+    args,
+    target_cells,
+    target_obstacle=None,
+    target_outer=None,
+    match_mode="cells",
+    symm_nonobtuse=False,
+):
+    base_ref = int(max(args.hc_refine, 0))
+    if args.hc_inner_samples is None or args.hc_outer_samples is None:
+        base_inner, base_outer = _default_hc_samples(base_ref)
+    else:
+        base_inner = int(args.hc_inner_samples)
+        base_outer = int(args.hc_outer_samples)
+
+    refine_candidates = list(range(max(0, base_ref - 2), base_ref + 3))
+    scale_candidates = [0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 2.0, 3.0, 4.0]
+
+    best = None
+    for refine in refine_candidates:
+        if args.hc_inner_samples is None or args.hc_outer_samples is None:
+            ref_inner, ref_outer = _default_hc_samples(refine)
+        else:
+            ref_inner, ref_outer = base_inner, base_outer
+
+        inner_candidates = {max(8, int(round(ref_inner * s_in))) for s_in in scale_candidates}
+        outer_candidates = {max(12, int(round(ref_outer * s_out))) for s_out in scale_candidates}
+        if target_obstacle is not None and target_outer is not None and match_mode in ("balanced", "gmsh_style"):
+            inner_target = max(8, int(target_obstacle) + 1)
+            outer_target = max(12, int(target_outer) + 1)
+            for f in (0.75, 1.0, 1.25, 1.5, 2.0, 2.5, 3.0):
+                inner_candidates.add(max(8, int(round(inner_target * f))))
+                outer_candidates.add(max(12, int(round(outer_target * f))))
+
+        for inner in sorted(inner_candidates):
+            for outer in sorted(outer_candidates):
+                if outer < inner:
+                    continue
+                try:
+                    n_cells, q_med, q_min, n_obstacle, n_outer = _estimate_hc_volume_cells(
+                        args,
+                        refine,
+                        inner,
+                        outer,
+                        symm_nonobtuse=symm_nonobtuse,
+                    )
+                except Exception:
+                    continue
+
+                err = abs(n_cells - target_cells)
+                quality_class = 0 if (q_med >= 0.60 and q_min >= 0.04) else 1
+                cell_scale_class = 0 if err <= max(50, int(0.25 * target_cells)) else 1
+                if target_obstacle is None or target_outer is None:
+                    err_boundary = 0
+                    objective = (err,)
+                else:
+                    err_boundary = abs(int(n_obstacle) - int(target_obstacle)) + abs(int(n_outer) - int(target_outer))
+                    if match_mode == "gmsh_style":
+                        objective = (err_boundary, err)
+                    elif match_mode == "balanced":
+                        objective = (3 * err_boundary + err, err_boundary, err)
+                    else:
+                        objective = (err, err_boundary)
+
+                candidate = (
+                    quality_class,
+                    cell_scale_class,
+                    *objective,
+                    -q_med,
+                    -q_min,
+                    n_cells,
+                    n_obstacle,
+                    n_outer,
+                    refine,
+                    inner,
+                    outer,
+                )
+                if best is None or candidate < best:
+                    best = candidate
+
+    if best is None:
+        return None
+
+    quality_class = int(best[0])
+    neg_q_med = float(best[-8])
+    neg_q_min = float(best[-7])
+    n_cells = int(best[-6])
+    n_obstacle = int(best[-5])
+    n_outer = int(best[-4])
+    refine = int(best[-3])
+    inner = int(best[-2])
+    outer = int(best[-1])
+    err = abs(n_cells - int(target_cells))
+    err_boundary = None
+    if target_obstacle is not None and target_outer is not None:
+        err_boundary = abs(n_obstacle - int(target_obstacle)) + abs(n_outer - int(target_outer))
+    return {
+        "hc_refine": refine,
+        "hc_inner_samples": inner,
+        "hc_outer_samples": outer,
+        "n_cells": n_cells,
+        "target_cells": int(target_cells),
+        "abs_error": int(err),
+        "n_obstacle": n_obstacle,
+        "n_outer": n_outer,
+        "target_obstacle": None if target_obstacle is None else int(target_obstacle),
+        "target_outer": None if target_outer is None else int(target_outer),
+        "boundary_abs_error": None if err_boundary is None else int(err_boundary),
+        "quality_class": int(quality_class),
+        "quality_median": float(-neg_q_med),
+        "quality_min": float(-neg_q_min),
+    }
+
+
+def _probe_mesh_metadata(benchmark_cls, kwargs):
+    probe = benchmark_cls(**kwargs)
+    probe.generate_mesh()
+    probe.load_mesh()
+    return dict(getattr(probe, "mesh_metadata", {}) or {})
+
+
+def _auto_tune_gmsh_to_target_boundaries_2d(
+    args,
+    benchmark_cls,
+    base_kwargs,
+    target_obstacle,
+    target_outer,
+    max_iter=3,
+):
+    target_obstacle = int(target_obstacle) if target_obstacle is not None else 0
+    target_outer = int(target_outer) if target_outer is not None else 0
+    if target_obstacle <= 0 or target_outer <= 0:
+        return None
+
+    kwargs = dict(base_kwargs)
+    kwargs["remesh"] = True
+    inner0, outer0 = _default_gmsh_sizes_2d(args)
+    if kwargs.get("mesh_size_inner") is not None:
+        inner0 = float(kwargs["mesh_size_inner"])
+    if kwargs.get("mesh_size_outer") is not None:
+        outer0 = float(kwargs["mesh_size_outer"])
+    inner = float(inner0)
+    outer = float(max(outer0, inner))
+
+    min_h = 0.02 * float(args.sphere_radius)
+    max_h = 2.0 * float(args.outer_radius)
+    best = None
+    stagnant_iters = 0
+    prev_counts = None
+
+    for _ in range(max(int(max_iter), 1)):
+        kwargs["mesh_size_inner"] = float(inner)
+        kwargs["mesh_size_outer"] = float(outer)
+        try:
+            meta = _probe_mesh_metadata(benchmark_cls, kwargs)
+        except Exception:
+            break
+
+        n_obstacle = int(meta.get("n_obstacle_elements", 0))
+        n_outer = int(meta.get("n_outer_boundary_elements", 0))
+        n_cells = int(meta.get("n_volume_cells", 0))
+        err_obstacle = abs(n_obstacle - target_obstacle)
+        err_outer = abs(n_outer - target_outer)
+        err_sum = err_obstacle + err_outer
+        candidate = (
+            int(err_sum),
+            int(err_obstacle),
+            int(err_outer),
+            float(inner),
+            float(outer),
+            int(n_obstacle),
+            int(n_outer),
+            int(n_cells),
+        )
+        if best is None or candidate < best:
+            best = candidate
+        if err_sum == 0:
+            break
+
+        current_counts = (int(n_obstacle), int(n_outer))
+        if prev_counts is not None and current_counts == prev_counts:
+            stagnant_iters += 1
+        else:
+            stagnant_iters = 0
+        prev_counts = current_counts
+        if stagnant_iters >= 1:
+            break
+
+        ratio_inner = max(float(n_obstacle), 1.0) / max(float(target_obstacle), 1.0)
+        ratio_outer = max(float(n_outer), 1.0) / max(float(target_outer), 1.0)
+        inner = float(np.clip(inner * np.sqrt(ratio_inner), min_h, max_h))
+        outer = float(np.clip(outer * np.sqrt(ratio_outer), min_h, max_h))
+        if outer < inner:
+            outer = inner
+
+    if best is None:
+        return None
+
+    tuned_kwargs = dict(base_kwargs)
+    tuned_kwargs["mesh_size_inner"] = float(best[3])
+    tuned_kwargs["mesh_size_outer"] = float(best[4])
+    tuned_kwargs["remesh"] = True
+    return {
+        "kwargs": tuned_kwargs,
+        "mesh_size_inner": float(best[3]),
+        "mesh_size_outer": float(best[4]),
+        "n_obstacle": int(best[5]),
+        "n_outer": int(best[6]),
+        "n_cells": int(best[7]),
+        "target_obstacle": int(target_obstacle),
+        "target_outer": int(target_outer),
+        "boundary_abs_error": int(best[0]),
+    }
+
+
+def main():
+    args = _build_parser().parse_args()
+    gmsh_kwargs = dict(
+        sphere_radius=args.sphere_radius,
+        outer_radius=args.outer_radius,
+        mu=args.mu,
+        density_difference=args.density_difference,
+        gravity=args.gravity,
+        flow_speed=args.flow_speed,
+        mesh_size_inner=args.mesh_size_inner,
+        mesh_size_outer=args.mesh_size_outer,
+        mesh_order=args.mesh_order,
+        workdir=args.workdir,
+        mesh_name=args.mesh_name,
+        remesh=args.remesh,
+    )
+    hc_kwargs = dict(
+        sphere_radius=args.sphere_radius,
+        outer_radius=args.outer_radius,
+        mu=args.mu,
+        density_difference=args.density_difference,
+        gravity=args.gravity,
+        flow_speed=args.flow_speed,
+        workdir=f"{args.workdir}_hc",
+        hc_refine=args.hc_refine,
+        hc_inner_samples=args.hc_inner_samples,
+        hc_outer_samples=args.hc_outer_samples,
+    )
+    gmsh_symm_kwargs = dict(
+        sphere_radius=args.sphere_radius,
+        outer_radius=args.outer_radius,
+        mu=args.mu,
+        density_difference=args.density_difference,
+        gravity=args.gravity,
+        flow_speed=args.flow_speed,
+        mesh_size_inner=args.mesh_size_inner,
+        mesh_size_outer=args.mesh_size_outer,
+        mesh_order=args.mesh_order,
+        workdir=f"{args.workdir}_symm_nonobtuse",
+        mesh_name="stokes_sphere_2d_symm_nonobtuse.msh",
+        remesh=args.remesh,
+        symm_nonobtuse=True,
+    )
+    hc_symm_kwargs = dict(
+        sphere_radius=args.sphere_radius,
+        outer_radius=args.outer_radius,
+        mu=args.mu,
+        density_difference=args.density_difference,
+        gravity=args.gravity,
+        flow_speed=args.flow_speed,
+        workdir=f"{args.workdir}_hc_symm_nonobtuse",
+        hc_refine=args.hc_refine,
+        hc_inner_samples=args.hc_inner_samples,
+        hc_outer_samples=args.hc_outer_samples,
+        symm_nonobtuse=True,
+    )
+    png_dir = Path(args.mesh_png_dir) if args.mesh_png_dir else (Path(args.workdir) / "mesh_pngs")
+
+    if args.mesh_source == "gmsh":
+        gmsh_bench = _run_case(1, "Gmsh Unsymm+Obtuse Finite-Difference Operator Benchmark", StokesSphereBenchmark2D, gmsh_kwargs)
+        gmsh_ddg_bench = _run_case(2, "Gmsh Unsymm+Obtuse DDG Operator Benchmark", StokesSphereBenchmark2DDDG, gmsh_kwargs)
+        gmsh_symm_bench = _run_case(
+            3,
+            "Gmsh Symm+Nonobtuse Finite-Difference Operator Benchmark",
+            StokesSphereBenchmark2DSymmNonobtuse,
+            gmsh_symm_kwargs,
+        )
+        gmsh_symm_ddg_bench = _run_case(
+            4,
+            "Gmsh Symm+Nonobtuse DDG Operator Benchmark",
+            StokesSphereBenchmark2DDDGSymmNonobtuse,
+            gmsh_symm_kwargs,
+        )
+        if args.save_mesh_pngs:
+            if gmsh_bench is not None:
+                png = _save_mesh_png(gmsh_bench, png_dir / "stokes_2d_gmsh_mesh.png", "StokesSphere2D (Gmsh)")
+                if png is not None:
+                    print(f"Mesh PNG (Case 1): {png}")
+            if gmsh_symm_bench is not None:
+                png = _save_mesh_png(
+                    gmsh_symm_bench,
+                    png_dir / "stokes_2d_gmsh_symm_nonobtuse_mesh.png",
+                    "StokesSphere2D Symm+Nonobtuse (Gmsh)",
+                )
+                if png is not None:
+                    print(f"Mesh PNG (Case 3): {png}")
+        _print_rel_error_by_case([
+            ("Gmsh Unsymm+Obtuse Finite-Difference Operator Benchmark", gmsh_bench),
+            ("Gmsh Unsymm+Obtuse DDG Operator Benchmark", gmsh_ddg_bench),
+            ("Gmsh Symm+Nonobtuse Finite-Difference Operator Benchmark", gmsh_symm_bench),
+            ("Gmsh Symm+Nonobtuse DDG Operator Benchmark", gmsh_symm_ddg_bench),
+        ])
+        _print_vertex_rel_error_by_case([
+            ("Gmsh Unsymm+Obtuse Finite-Difference Operator Benchmark", gmsh_bench),
+            ("Gmsh Unsymm+Obtuse DDG Operator Benchmark", gmsh_ddg_bench),
+            ("Gmsh Symm+Nonobtuse Finite-Difference Operator Benchmark", gmsh_symm_bench),
+            ("Gmsh Symm+Nonobtuse DDG Operator Benchmark", gmsh_symm_ddg_bench),
+        ])
+        return
+
+    if args.mesh_source == "hc":
+        hc_bench = _run_case(1, "HC Unsymm+Obtuse Finite-Difference Operator Benchmark", StokesSphereBenchmark2DHC, hc_kwargs)
+        hc_ddg_bench = _run_case(2, "HC Unsymm+Obtuse DDG Operator Benchmark", StokesSphereBenchmark2DHCDDG, hc_kwargs)
+        hc_symm_bench = _run_case(
+            3,
+            "HC Symm+Nonobtuse Finite-Difference Operator Benchmark",
+            StokesSphereBenchmark2DHCSymmNonobtuse,
+            hc_symm_kwargs,
+        )
+        hc_symm_ddg_bench = _run_case(
+            4,
+            "HC Symm+Nonobtuse DDG Operator Benchmark",
+            StokesSphereBenchmark2DHCDDGSymmNonobtuse,
+            hc_symm_kwargs,
+        )
+        if args.save_mesh_pngs:
+            if hc_bench is not None:
+                png = _save_mesh_png(hc_bench, png_dir / "stokes_2d_hc_mesh.png", "StokesSphere2DHC (HC)")
+                if png is not None:
+                    print(f"Mesh PNG (Case 1): {png}")
+            if hc_symm_bench is not None:
+                png = _save_mesh_png(
+                    hc_symm_bench,
+                    png_dir / "stokes_2d_hc_symm_nonobtuse_mesh.png",
+                    "StokesSphere2D Symm+Nonobtuse (HC)",
+                )
+                if png is not None:
+                    print(f"Mesh PNG (Case 3): {png}")
+        _print_rel_error_by_case([
+            ("HC Unsymm+Obtuse Finite-Difference Operator Benchmark", hc_bench),
+            ("HC Unsymm+Obtuse DDG Operator Benchmark", hc_ddg_bench),
+            ("HC Symm+Nonobtuse Finite-Difference Operator Benchmark", hc_symm_bench),
+            ("HC Symm+Nonobtuse DDG Operator Benchmark", hc_symm_ddg_bench),
+        ])
+        _print_vertex_rel_error_by_case([
+            ("HC Unsymm+Obtuse Finite-Difference Operator Benchmark", hc_bench),
+            ("HC Unsymm+Obtuse DDG Operator Benchmark", hc_ddg_bench),
+            ("HC Symm+Nonobtuse Finite-Difference Operator Benchmark", hc_symm_bench),
+            ("HC Symm+Nonobtuse DDG Operator Benchmark", hc_symm_ddg_bench),
+        ])
+        return
+
+    gmsh_bench = _run_case(1, "Gmsh Unsymm+Obtuse Finite-Difference Operator Benchmark", StokesSphereBenchmark2D, gmsh_kwargs)
+    global_target_cells = None
+    global_target_obstacle = None
+    global_target_outer = None
+    if gmsh_bench is not None:
+        global_target_cells = int(gmsh_bench.mesh_metadata.get("n_volume_cells", 0))
+        global_target_obstacle = int(gmsh_bench.mesh_metadata.get("n_obstacle_elements", 0))
+        global_target_outer = int(gmsh_bench.mesh_metadata.get("n_outer_boundary_elements", 0))
+
+    if gmsh_bench is not None and args.auto_match_hc_cells:
+        tuned = _auto_tune_hc_to_target_cells(
+            args,
+            global_target_cells,
+            target_obstacle=global_target_obstacle,
+            target_outer=global_target_outer,
+            match_mode=args.auto_match_mode,
+            symm_nonobtuse=False,
+        )
+        if tuned is not None:
+            hc_kwargs["hc_refine"] = tuned["hc_refine"]
+            hc_kwargs["hc_inner_samples"] = tuned["hc_inner_samples"]
+            hc_kwargs["hc_outer_samples"] = tuned["hc_outer_samples"]
+            print(
+                "\nHC auto-match: "
+                f"mode={args.auto_match_mode}, "
+                f"target_cells={tuned['target_cells']}, "
+                f"chosen_cells={tuned['n_cells']}, "
+                f"hc_refine={tuned['hc_refine']}, "
+                f"hc_inner_samples={tuned['hc_inner_samples']}, "
+                f"hc_outer_samples={tuned['hc_outer_samples']}, "
+                f"target_obstacle={_format_value(tuned['target_obstacle'])}, "
+                f"chosen_obstacle={tuned['n_obstacle']}, "
+                f"target_outer={_format_value(tuned['target_outer'])}, "
+                f"chosen_outer={tuned['n_outer']}, "
+                f"quality_median={_format_value(tuned['quality_median'])}, "
+                f"quality_min={_format_value(tuned['quality_min'])}"
+            )
+        else:
+            print("\nHC auto-match skipped: no valid HC candidate mesh was produced.")
+
+    hc_bench = _run_case(2, "HC Unsymm+Obtuse Finite-Difference Operator Benchmark", StokesSphereBenchmark2DHC, hc_kwargs)
+    gmsh_ddg_bench = _run_case(3, "Gmsh Unsymm+Obtuse DDG Operator Benchmark", StokesSphereBenchmark2DDDG, gmsh_kwargs)
+    hc_ddg_bench = _run_case(4, "HC Unsymm+Obtuse DDG Operator Benchmark", StokesSphereBenchmark2DHCDDG, hc_kwargs)
+
+    if global_target_obstacle is not None and global_target_outer is not None and args.auto_match_hc_cells:
+        print("\nGmsh auto-match (symm_nonobtuse): tuning to global boundary target ...")
+        tuned_gmsh_symm = _auto_tune_gmsh_to_target_boundaries_2d(
+            args,
+            StokesSphereBenchmark2DSymmNonobtuse,
+            gmsh_symm_kwargs,
+            target_obstacle=global_target_obstacle,
+            target_outer=global_target_outer,
+        )
+        if tuned_gmsh_symm is not None:
+            gmsh_symm_kwargs = tuned_gmsh_symm["kwargs"]
+            print(
+                "\nGmsh auto-match (symm_nonobtuse): "
+                f"target_obstacle={tuned_gmsh_symm['target_obstacle']}, "
+                f"chosen_obstacle={tuned_gmsh_symm['n_obstacle']}, "
+                f"target_outer={tuned_gmsh_symm['target_outer']}, "
+                f"chosen_outer={tuned_gmsh_symm['n_outer']}, "
+                f"mesh_size_inner={tuned_gmsh_symm['mesh_size_inner']:.6g}, "
+                f"mesh_size_outer={tuned_gmsh_symm['mesh_size_outer']:.6g}"
+            )
+        else:
+            print("\nGmsh auto-match (symm_nonobtuse) skipped: no valid candidate mesh was produced.")
+
+    gmsh_symm_bench = _run_case(
+        5,
+        "Gmsh Symm+Nonobtuse Finite-Difference Operator Benchmark",
+        StokesSphereBenchmark2DSymmNonobtuse,
+        gmsh_symm_kwargs,
+    )
+
+    if gmsh_symm_bench is not None and args.auto_match_hc_cells and global_target_cells is not None:
+        tuned_symm = _auto_tune_hc_to_target_cells(
+            args,
+            global_target_cells,
+            target_obstacle=global_target_obstacle,
+            target_outer=global_target_outer,
+            match_mode=args.auto_match_mode,
+            symm_nonobtuse=True,
+        )
+        if tuned_symm is not None:
+            hc_symm_kwargs["hc_refine"] = tuned_symm["hc_refine"]
+            hc_symm_kwargs["hc_inner_samples"] = tuned_symm["hc_inner_samples"]
+            hc_symm_kwargs["hc_outer_samples"] = tuned_symm["hc_outer_samples"]
+            print(
+                "\nHC auto-match (symm_nonobtuse): "
+                f"mode={args.auto_match_mode}, "
+                f"target_cells={tuned_symm['target_cells']}, "
+                f"chosen_cells={tuned_symm['n_cells']}, "
+                f"hc_refine={tuned_symm['hc_refine']}, "
+                f"hc_inner_samples={tuned_symm['hc_inner_samples']}, "
+                f"hc_outer_samples={tuned_symm['hc_outer_samples']}, "
+                f"target_obstacle={_format_value(tuned_symm['target_obstacle'])}, "
+                f"chosen_obstacle={tuned_symm['n_obstacle']}, "
+                f"target_outer={_format_value(tuned_symm['target_outer'])}, "
+                f"chosen_outer={tuned_symm['n_outer']}, "
+                f"quality_median={_format_value(tuned_symm['quality_median'])}, "
+                f"quality_min={_format_value(tuned_symm['quality_min'])}"
+            )
+        else:
+            print("\nHC auto-match (symm_nonobtuse) skipped: no valid HC candidate mesh was produced.")
+
+    hc_symm_bench = _run_case(
+        6,
+        "HC Symm+Nonobtuse Finite-Difference Operator Benchmark",
+        StokesSphereBenchmark2DHCSymmNonobtuse,
+        hc_symm_kwargs,
+    )
+    gmsh_symm_ddg_bench = _run_case(
+        7,
+        "Gmsh Symm+Nonobtuse DDG Operator Benchmark",
+        StokesSphereBenchmark2DDDGSymmNonobtuse,
+        gmsh_symm_kwargs,
+    )
+    hc_symm_ddg_bench = _run_case(
+        8,
+        "HC Symm+Nonobtuse DDG Operator Benchmark",
+        StokesSphereBenchmark2DHCDDGSymmNonobtuse,
+        hc_symm_kwargs,
+    )
+
+    if args.save_mesh_pngs:
+        png_entries = []
+        if gmsh_bench is not None:
+            png_entries.append(("Case 1", _save_mesh_png(gmsh_bench, png_dir / "stokes_2d_gmsh_mesh.png", "StokesSphere2D (Gmsh)")))
+        if hc_bench is not None:
+            png_entries.append(("Case 2", _save_mesh_png(hc_bench, png_dir / "stokes_2d_hc_mesh.png", "StokesSphere2DHC (HC)")))
+        if gmsh_symm_bench is not None:
+            png_entries.append(("Case 5", _save_mesh_png(
+                gmsh_symm_bench,
+                png_dir / "stokes_2d_gmsh_symm_nonobtuse_mesh.png",
+                "StokesSphere2D Symm+Nonobtuse (Gmsh)",
+            )))
+        if hc_symm_bench is not None:
+            png_entries.append(("Case 6", _save_mesh_png(
+                hc_symm_bench,
+                png_dir / "stokes_2d_hc_symm_nonobtuse_mesh.png",
+                "StokesSphere2D Symm+Nonobtuse (HC)",
+            )))
+        for label, png_path in png_entries:
+            if png_path is not None:
+                print(f"Mesh PNG ({label}): {png_path}")
+
+    _print_rel_error_by_case([
+        ("Gmsh Unsymm+Obtuse Finite-Difference Operator Benchmark", gmsh_bench),
+        ("HC Unsymm+Obtuse Finite-Difference Operator Benchmark", hc_bench),
+        ("Gmsh Unsymm+Obtuse DDG Operator Benchmark", gmsh_ddg_bench),
+        ("HC Unsymm+Obtuse DDG Operator Benchmark", hc_ddg_bench),
+        ("Gmsh Symm+Nonobtuse Finite-Difference Operator Benchmark", gmsh_symm_bench),
+        ("HC Symm+Nonobtuse Finite-Difference Operator Benchmark", hc_symm_bench),
+        ("Gmsh Symm+Nonobtuse DDG Operator Benchmark", gmsh_symm_ddg_bench),
+        ("HC Symm+Nonobtuse DDG Operator Benchmark", hc_symm_ddg_bench),
+    ])
+    _print_vertex_rel_error_by_case([
+        ("Gmsh Unsymm+Obtuse Finite-Difference Operator Benchmark", gmsh_bench),
+        ("HC Unsymm+Obtuse Finite-Difference Operator Benchmark", hc_bench),
+        ("Gmsh Unsymm+Obtuse DDG Operator Benchmark", gmsh_ddg_bench),
+        ("HC Unsymm+Obtuse DDG Operator Benchmark", hc_ddg_bench),
+        ("Gmsh Symm+Nonobtuse Finite-Difference Operator Benchmark", gmsh_symm_bench),
+        ("HC Symm+Nonobtuse Finite-Difference Operator Benchmark", hc_symm_bench),
+        ("Gmsh Symm+Nonobtuse DDG Operator Benchmark", gmsh_symm_ddg_bench),
+        ("HC Symm+Nonobtuse DDG Operator Benchmark", hc_symm_ddg_bench),
+    ])
+
+
+if __name__ == "__main__":
+    main()

--- a/run_stokes_benchmark_3D.py
+++ b/run_stokes_benchmark_3D.py
@@ -1,0 +1,887 @@
+#!/usr/bin/env python3
+import argparse
+import os
+import tempfile
+from pathlib import Path
+
+import numpy as np
+from PIL import Image, ImageDraw
+
+os.environ.setdefault(
+    "MPLCONFIGDIR",
+    str(Path(tempfile.gettempdir()) / "matplotlib"),
+)
+
+from benchmarks._benchmark_cases import (
+    StokesSphereBenchmark3D,
+    StokesSphereBenchmark3DDDG,
+    StokesSphereBenchmark3DHC,
+    StokesSphereBenchmark3DHCSymmNonobtuse,
+    StokesSphereBenchmark3DHCDDG,
+    StokesSphereBenchmark3DHCDDGSymmNonobtuse,
+    StokesSphereBenchmark3DSymmNonobtuse,
+    StokesSphereBenchmark3DDDGSymmNonobtuse,
+    _generate_stokes_sphere_hc_mesh,
+)
+
+
+def _build_parser():
+    parser = argparse.ArgumentParser(
+        description="Run the 3D Stokes-sphere benchmark.",
+    )
+    parser.add_argument("--sphere-radius", type=float, default=1.0)
+    parser.add_argument("--outer-radius", type=float, default=6.0)
+    parser.add_argument("--mu", type=float, default=1.0)
+    parser.add_argument("--density-difference", type=float, default=1.0)
+    parser.add_argument("--gravity", type=float, default=1.0)
+    parser.add_argument("--flow-speed", type=float, default=None)
+    parser.add_argument("--mesh-size-inner", type=float, default=None)
+    parser.add_argument("--mesh-size-outer", type=float, default=None)
+    parser.add_argument("--mesh-order", type=int, default=2)
+    parser.add_argument(
+        "--mesh-source",
+        type=str,
+        choices=("gmsh", "hc", "both"),
+        default="both",
+        help="Mesh source: gmsh, hc, or both (for side-by-side comparison).",
+    )
+    parser.add_argument(
+        "--workdir",
+        type=str,
+        default="benchmarks_out/stokes_sphere_3d",
+    )
+    parser.add_argument(
+        "--mesh-name",
+        type=str,
+        default="stokes_sphere_3d.msh",
+    )
+    parser.add_argument(
+        "--remesh",
+        action="store_true",
+        help="Regenerate the Gmsh mesh even if it already exists.",
+    )
+    parser.add_argument("--hc-refine", type=int, default=2)
+    parser.add_argument("--hc-inner-samples", type=int, default=None)
+    parser.add_argument("--hc-outer-samples", type=int, default=None)
+    parser.add_argument(
+        "--auto-match-hc-cells",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="In 'both' mode, auto-tune HC mesh parameters to match Gmsh 3D volume-cell count.",
+    )
+    parser.add_argument(
+        "--auto-match-mode",
+        type=str,
+        choices=("surface", "cells", "balanced"),
+        default="surface",
+        help=(
+            "HC auto-match objective in 'both' mode: "
+            "'surface' (match obstacle/outer surface density first), "
+            "'cells' (match 3D volume cells first), "
+            "'balanced' (trade off surface and volume matching)."
+        ),
+    )
+    parser.add_argument(
+        "--save-mesh-pngs",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Save mesh snapshots as PNG files.",
+    )
+    parser.add_argument(
+        "--mesh-png-dir",
+        type=str,
+        default=None,
+        help="Directory where mesh PNG files are saved (defaults to <workdir>/mesh_pngs).",
+    )
+    return parser
+
+
+def _format_value(value):
+    if isinstance(value, (float, np.floating)) and np.isnan(value):
+        return "nan"
+    if isinstance(value, (int, float, np.integer, np.floating)):
+        return f"{float(value):.12g}"
+    return str(value)
+
+
+def _print_summary(bench):
+    print(f"Benchmark: {bench.name}")
+    print(f"Mesh: {bench.mesh_path}")
+    print("")
+    meta = getattr(bench, "mesh_metadata", {}) or {}
+    n_obstacle = int(meta.get("n_obstacle_elements", 0))
+    n_outer = int(meta.get("n_outer_boundary_elements", 0))
+    n_cells = int(meta.get("n_volume_cells", 0))
+    print(f"Boundary Elements: obstacle={n_obstacle}, outer={n_outer}, volume_cells={n_cells}")
+    print("")
+    for metric, (computed, analytical) in bench.summary().items():
+        print(
+            f"{metric}: "
+            f"computed={_format_value(computed)}, "
+            f"analytical={_format_value(analytical)}"
+        )
+
+
+def _run_and_print(bench):
+    bench.run_benchmark()
+    _print_summary(bench)
+    return bench
+
+
+def _print_case_header(case_idx, title):
+    print(f"=== Case {int(case_idx)}. {title} ===")
+
+
+def _print_rel_error_by_case(case_entries):
+    """
+    Print drag relative error for each available benchmark case.
+
+    Parameters
+    ----------
+    case_entries : list[tuple[str, object]]
+        Items of ``(label, benchmark_or_None)``.
+    """
+    print("\n=== Relative Error by Case ===")
+    for idx, (label, bench) in enumerate(case_entries, start=1):
+        if bench is None:
+            value = "not evaluated"
+        else:
+            value = _format_value(getattr(bench, "force_error_rel", np.nan))
+        print(f"Case {idx} ({label}): Drag Rel Error = {value}")
+
+
+def _print_vertex_rel_error_by_case(case_entries):
+    print("\n=== Vertex Drag Relative Error by Case ===")
+    for idx, (label, bench) in enumerate(case_entries, start=1):
+        if bench is None:
+            mean_val = "not evaluated"
+            max_val = "not evaluated"
+        else:
+            mean_val = _format_value(getattr(bench, "vertex_drag_rel_error_mean", np.nan))
+            max_val = _format_value(getattr(bench, "vertex_drag_rel_error_max", np.nan))
+        print(f"Case {idx} ({label}): vertexDragRelErrorMean = {mean_val}, vertexDragRelErrorMax = {max_val}")
+
+
+def _run_case(case_idx, title, benchmark_cls, kwargs):
+    print("" if int(case_idx) > 1 else "")
+    _print_case_header(case_idx, title)
+    try:
+        return _run_and_print(benchmark_cls(**kwargs))
+    except ImportError as exc:
+        print(f"{title} skipped: {exc}")
+        return None
+
+
+def _default_hc_samples_3d(refine_level):
+    refine_level = int(max(refine_level, 0))
+    n_inner = max(96, 64 * (2 ** max(refine_level - 1, 0)))
+    n_outer = max(128, 96 * (2 ** max(refine_level - 1, 0)))
+    return int(n_inner), int(n_outer)
+
+
+def _default_gmsh_sizes_3d(args):
+    h_inner = args.mesh_size_inner if args.mesh_size_inner is not None else 0.20 * float(args.sphere_radius)
+    h_outer = args.mesh_size_outer if args.mesh_size_outer is not None else 0.75 * float(args.sphere_radius)
+    return float(h_inner), float(h_outer)
+
+
+def _probe_mesh_metadata(benchmark_cls, kwargs):
+    probe = benchmark_cls(**kwargs)
+    probe.generate_mesh()
+    probe.load_mesh()
+    return dict(getattr(probe, "mesh_metadata", {}) or {})
+
+
+def _auto_tune_gmsh_to_target_surfaces_3d(
+    args,
+    benchmark_cls,
+    base_kwargs,
+    target_obstacle,
+    target_outer,
+    max_iter=3,
+):
+    target_obstacle = int(target_obstacle) if target_obstacle is not None else 0
+    target_outer = int(target_outer) if target_outer is not None else 0
+    if target_obstacle <= 0 or target_outer <= 0:
+        return None
+
+    kwargs = dict(base_kwargs)
+    kwargs["remesh"] = True
+    inner0, outer0 = _default_gmsh_sizes_3d(args)
+    if kwargs.get("mesh_size_inner") is not None:
+        inner0 = float(kwargs["mesh_size_inner"])
+    if kwargs.get("mesh_size_outer") is not None:
+        outer0 = float(kwargs["mesh_size_outer"])
+    inner = float(inner0)
+    outer = float(max(outer0, inner))
+
+    min_h = 0.02 * float(args.sphere_radius)
+    max_h = 2.0 * float(args.outer_radius)
+    best = None
+    stagnant_iters = 0
+    prev_counts = None
+
+    for _ in range(max(int(max_iter), 1)):
+        kwargs["mesh_size_inner"] = float(inner)
+        kwargs["mesh_size_outer"] = float(outer)
+        try:
+            meta = _probe_mesh_metadata(benchmark_cls, kwargs)
+        except Exception:
+            break
+
+        n_obstacle = int(meta.get("n_obstacle_elements", 0))
+        n_outer = int(meta.get("n_outer_boundary_elements", 0))
+        n_cells = int(meta.get("n_volume_cells", 0))
+        err_obstacle = abs(n_obstacle - target_obstacle)
+        err_outer = abs(n_outer - target_outer)
+        err_sum = err_obstacle + err_outer
+        candidate = (
+            int(err_sum),
+            int(err_obstacle),
+            int(err_outer),
+            float(inner),
+            float(outer),
+            int(n_obstacle),
+            int(n_outer),
+            int(n_cells),
+        )
+        if best is None or candidate < best:
+            best = candidate
+        if err_sum == 0:
+            break
+
+        current_counts = (int(n_obstacle), int(n_outer))
+        if prev_counts is not None and current_counts == prev_counts:
+            stagnant_iters += 1
+        else:
+            stagnant_iters = 0
+        prev_counts = current_counts
+        if stagnant_iters >= 1:
+            break
+
+        ratio_inner = max(float(n_obstacle), 1.0) / max(float(target_obstacle), 1.0)
+        ratio_outer = max(float(n_outer), 1.0) / max(float(target_outer), 1.0)
+        inner = float(np.clip(inner * np.sqrt(ratio_inner), min_h, max_h))
+        outer = float(np.clip(outer * np.sqrt(ratio_outer), min_h, max_h))
+        if outer < inner:
+            outer = inner
+
+    if best is None:
+        return None
+
+    tuned_kwargs = dict(base_kwargs)
+    tuned_kwargs["mesh_size_inner"] = float(best[3])
+    tuned_kwargs["mesh_size_outer"] = float(best[4])
+    tuned_kwargs["remesh"] = True
+    return {
+        "kwargs": tuned_kwargs,
+        "mesh_size_inner": float(best[3]),
+        "mesh_size_outer": float(best[4]),
+        "n_obstacle": int(best[5]),
+        "n_outer": int(best[6]),
+        "n_cells": int(best[7]),
+        "target_obstacle": int(target_obstacle),
+        "target_outer": int(target_outer),
+        "boundary_abs_error": int(best[0]),
+    }
+
+
+def _estimate_hc_volume_cells_3d(
+    args, refine_level, inner_samples, outer_samples, symm_nonobtuse=False, equal_edge=False
+):
+    points, simplices, obstacle, outer_boundary, _ = _generate_stokes_sphere_hc_mesh(
+        dim=3,
+        sphere_radius=args.sphere_radius,
+        outer_radius=args.outer_radius,
+        hc_refine=int(refine_level),
+        hc_inner_samples=int(inner_samples),
+        hc_outer_samples=int(outer_samples),
+        symm_nonobtuse=bool(symm_nonobtuse),
+        equal_edge=bool(equal_edge),
+    )
+    return (
+        int(simplices.shape[0]),
+        int(points.shape[0]),
+        int(len(obstacle)),
+        int(len(outer_boundary)),
+    )
+
+
+def _auto_tune_hc_to_target_cells_3d(
+    args,
+    target_cells,
+    target_obstacle=None,
+    target_outer=None,
+    match_mode="surface",
+    symm_nonobtuse=False,
+    equal_edge=False,
+):
+    base_ref = int(max(args.hc_refine, 1))
+    if args.hc_inner_samples is None or args.hc_outer_samples is None:
+        base_inner, base_outer = _default_hc_samples_3d(base_ref)
+    else:
+        base_inner, base_outer = int(args.hc_inner_samples), int(args.hc_outer_samples)
+
+    # Fast path for default surface mode: directly map Gmsh boundary counts
+    # to HC sampling, then choose a refinement level heuristically from the
+    # target volume-cell scale. This avoids long candidate sweeps.
+    if (
+        (not equal_edge)
+        and match_mode == "surface"
+        and target_obstacle is not None
+        and target_outer is not None
+    ):
+        inner = max(96, int(round(0.5 * (int(target_obstacle) + 4))))
+        outer = max(128, int(round(0.5 * (int(target_outer) - 4))))
+        if outer < inner:
+            outer = inner
+
+        if int(target_cells) >= 20000:
+            refine = max(base_ref, 4)
+        elif int(target_cells) >= 7000:
+            refine = max(base_ref, 3)
+        else:
+            refine = max(base_ref, 2)
+
+        n_cells, n_points, n_obstacle, n_outer = _estimate_hc_volume_cells_3d(
+            args, refine, inner, outer, symm_nonobtuse=symm_nonobtuse, equal_edge=equal_edge
+        )
+        err_cells = abs(n_cells - int(target_cells))
+        err_surface = abs(n_obstacle - int(target_obstacle)) + abs(n_outer - int(target_outer))
+        return {
+            "hc_refine": int(refine),
+            "hc_inner_samples": int(inner),
+            "hc_outer_samples": int(outer),
+            "n_cells": int(n_cells),
+            "n_points": int(n_points),
+            "target_cells": int(target_cells),
+            "abs_error": int(err_cells),
+            "n_obstacle": int(n_obstacle),
+            "n_outer": int(n_outer),
+            "target_obstacle": int(target_obstacle),
+            "target_outer": int(target_outer),
+            "boundary_abs_error": int(err_surface),
+        }
+
+    refine_candidates = sorted(set([max(1, base_ref - 1), base_ref, base_ref + 1, base_ref + 2]))
+
+    # Probe each refine level at its base sampling, then search multipliers
+    # only on the most promising levels to keep runtime reasonable.
+    refine_probes = []
+    for refine in refine_candidates:
+        if args.hc_inner_samples is None or args.hc_outer_samples is None:
+            inner0, outer0 = _default_hc_samples_3d(refine)
+        else:
+            inner0, outer0 = base_inner, base_outer
+        try:
+            n_cells0, _, _, _ = _estimate_hc_volume_cells_3d(
+                args,
+                refine,
+                inner0,
+                outer0,
+                symm_nonobtuse=symm_nonobtuse,
+                equal_edge=equal_edge,
+            )
+        except Exception:
+            continue
+        refine_probes.append((abs(n_cells0 - target_cells), refine, inner0, outer0))
+
+    if not refine_probes:
+        return None
+
+    refine_probes.sort()
+    top_refines = refine_probes[:2]
+    scale_candidates = [0.75, 1.0, 1.25, 1.5, 2.0, 2.5, 3.0]
+
+    best = None
+    for _, refine, inner0, outer0 in top_refines:
+        inner_candidates = {max(96, int(round(inner0 * scale))) for scale in scale_candidates}
+        outer_candidates = {max(128, int(round(outer0 * scale))) for scale in scale_candidates}
+
+        if (not equal_edge) and target_obstacle is not None and target_outer is not None:
+            # In this HC generator, these sample-count heuristics map well to
+            # boundary element counts:
+            # obstacle ≈ 2*inner - 4, outer ≈ 2*outer + 4.
+            inner_from_surface = max(96, int(round(0.5 * (int(target_obstacle) + 4))))
+            outer_from_surface = max(128, int(round(0.5 * (int(target_outer) - 4))))
+            for d in (-2, -1, 0, 1, 2):
+                inner_candidates.add(max(96, inner_from_surface + d))
+            for d in (-8, -4, 0, 4, 8):
+                outer_candidates.add(max(128, outer_from_surface + d))
+
+        for inner in sorted(inner_candidates):
+            for outer in sorted(outer_candidates):
+                if outer < inner:
+                    continue
+                try:
+                    n_cells, n_points, n_obstacle, n_outer = _estimate_hc_volume_cells_3d(
+                        args,
+                        refine,
+                        inner,
+                        outer,
+                        symm_nonobtuse=symm_nonobtuse,
+                        equal_edge=equal_edge,
+                    )
+                except Exception:
+                    continue
+
+                err_cells = abs(n_cells - int(target_cells))
+                if target_obstacle is None or target_outer is None:
+                    err_surface = 0
+                else:
+                    err_surface = abs(n_obstacle - int(target_obstacle)) + abs(n_outer - int(target_outer))
+
+                if match_mode == "cells":
+                    objective = (err_cells, err_surface)
+                elif match_mode == "balanced":
+                    objective = (3 * err_surface + err_cells, err_surface, err_cells)
+                else:
+                    objective = (err_surface, err_cells)
+
+                candidate = (
+                    *objective,
+                    n_points,
+                    n_cells,
+                    n_obstacle,
+                    n_outer,
+                    refine,
+                    inner,
+                    outer,
+                )
+                if best is None or candidate < best:
+                    best = candidate
+
+    if best is None:
+        return None
+
+    n_points = int(best[-7])
+    n_cells = int(best[-6])
+    n_obstacle = int(best[-5])
+    n_outer = int(best[-4])
+    refine = int(best[-3])
+    inner = int(best[-2])
+    outer = int(best[-1])
+    err_cells = abs(n_cells - int(target_cells))
+    err_surface = None
+    if target_obstacle is not None and target_outer is not None:
+        err_surface = abs(n_obstacle - int(target_obstacle)) + abs(n_outer - int(target_outer))
+
+    return {
+        "hc_refine": int(refine),
+        "hc_inner_samples": int(inner),
+        "hc_outer_samples": int(outer),
+        "n_cells": int(n_cells),
+        "n_points": int(n_points),
+        "target_cells": int(target_cells),
+        "abs_error": int(err_cells),
+        "n_obstacle": int(n_obstacle),
+        "n_outer": int(n_outer),
+        "target_obstacle": None if target_obstacle is None else int(target_obstacle),
+        "target_outer": None if target_outer is None else int(target_outer),
+        "boundary_abs_error": None if err_surface is None else int(err_surface),
+    }
+
+
+def _save_mesh_png_3d(bench, out_path, title):
+    points = np.asarray(bench.points, dtype=float)
+    if points.ndim != 2 or points.shape[1] < 3:
+        return None
+
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    width, height = 1400, 1050
+    margin = 40
+    img = Image.new("RGB", (width, height), color=(255, 255, 255))
+    draw = ImageDraw.Draw(img)
+
+    # Simple orthographic camera for a stable 3D snapshot.
+    az = np.deg2rad(35.0)
+    el = np.deg2rad(20.0)
+    Rz = np.array(
+        [
+            [np.cos(az), -np.sin(az), 0.0],
+            [np.sin(az), np.cos(az), 0.0],
+            [0.0, 0.0, 1.0],
+        ],
+        dtype=float,
+    )
+    Rx = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [0.0, np.cos(el), -np.sin(el)],
+            [0.0, np.sin(el), np.cos(el)],
+        ],
+        dtype=float,
+    )
+    R = Rx @ Rz
+
+    centered = np.ascontiguousarray(
+        points[:, :3] - np.mean(points[:, :3], axis=0, keepdims=True),
+        dtype=np.float64,
+    )
+    proj = np.einsum("ij,jk->ik", centered, R.T, optimize=True)
+    x2 = proj[:, 0]
+    y2 = proj[:, 1]
+    z2 = proj[:, 2]
+
+    x_min, y_min = float(np.min(x2)), float(np.min(y2))
+    x_max, y_max = float(np.max(x2)), float(np.max(y2))
+    dx = max(x_max - x_min, 1.0e-12)
+    dy = max(y_max - y_min, 1.0e-12)
+    scale = min((width - 2 * margin) / dx, (height - 2 * margin) / dy)
+    x_pad = (width - scale * dx) * 0.5
+    y_pad = (height - scale * dy) * 0.5
+
+    def to_px(idx):
+        px = x_pad + (x2[idx] - x_min) * scale
+        py = height - (y_pad + (y2[idx] - y_min) * scale)
+        return (float(px), float(py))
+
+    def element_corner_ids(elem):
+        n = len(elem)
+        if n >= 3:
+            return int(elem[0]), int(elem[1]), int(elem[2])
+        return None
+
+    lines = []
+
+    def add_surface(elements, color, width_px):
+        if elements is None:
+            return
+        arr = np.asarray(elements, dtype=np.int64)
+        if arr.size == 0:
+            return
+        for elem in arr:
+            tri = element_corner_ids(elem)
+            if tri is None:
+                continue
+            i, j, k = tri
+            for a, b in ((i, j), (j, k), (k, i)):
+                depth = 0.5 * (z2[a] + z2[b])
+                lines.append((depth, a, b, color, width_px))
+
+    add_surface(bench.outer_boundary_elements, color=(42, 157, 143), width_px=1)
+    add_surface(bench.obstacle_elements, color=(230, 57, 70), width_px=2)
+
+    lines.sort(key=lambda it: it[0])
+    for _, a, b, color, width_px in lines:
+        draw.line([to_px(a), to_px(b)], fill=color, width=width_px)
+
+    img.save(out_path)
+    return str(out_path)
+
+
+def main():
+    args = _build_parser().parse_args()
+    gmsh_kwargs = dict(
+        sphere_radius=args.sphere_radius,
+        outer_radius=args.outer_radius,
+        mu=args.mu,
+        density_difference=args.density_difference,
+        gravity=args.gravity,
+        flow_speed=args.flow_speed,
+        mesh_size_inner=args.mesh_size_inner,
+        mesh_size_outer=args.mesh_size_outer,
+        mesh_order=args.mesh_order,
+        workdir=args.workdir,
+        mesh_name=args.mesh_name,
+        remesh=args.remesh,
+    )
+    hc_kwargs = dict(
+        sphere_radius=args.sphere_radius,
+        outer_radius=args.outer_radius,
+        mu=args.mu,
+        density_difference=args.density_difference,
+        gravity=args.gravity,
+        flow_speed=args.flow_speed,
+        workdir=f"{args.workdir}_hc",
+        hc_refine=args.hc_refine,
+        hc_inner_samples=args.hc_inner_samples,
+        hc_outer_samples=args.hc_outer_samples,
+    )
+    gmsh_symm_kwargs = dict(
+        sphere_radius=args.sphere_radius,
+        outer_radius=args.outer_radius,
+        mu=args.mu,
+        density_difference=args.density_difference,
+        gravity=args.gravity,
+        flow_speed=args.flow_speed,
+        mesh_size_inner=args.mesh_size_inner,
+        mesh_size_outer=args.mesh_size_outer,
+        mesh_order=args.mesh_order,
+        workdir=f"{args.workdir}_symm_nonobtuse",
+        mesh_name="stokes_sphere_3d_symm_nonobtuse.msh",
+        remesh=args.remesh,
+        symm_nonobtuse=True,
+    )
+    hc_symm_kwargs = dict(
+        sphere_radius=args.sphere_radius,
+        outer_radius=args.outer_radius,
+        mu=args.mu,
+        density_difference=args.density_difference,
+        gravity=args.gravity,
+        flow_speed=args.flow_speed,
+        workdir=f"{args.workdir}_hc_symm_nonobtuse",
+        hc_refine=args.hc_refine,
+        hc_inner_samples=args.hc_inner_samples,
+        hc_outer_samples=args.hc_outer_samples,
+        symm_nonobtuse=True,
+    )
+    png_dir = Path(args.mesh_png_dir) if args.mesh_png_dir else (Path(args.workdir) / "mesh_pngs")
+
+    if args.mesh_source == "gmsh":
+        gmsh_bench = _run_case(1, "Gmsh Unsymm+Obtuse Finite-Difference Operator Benchmark", StokesSphereBenchmark3D, gmsh_kwargs)
+        gmsh_ddg_bench = _run_case(2, "Gmsh Unsymm+Obtuse DDG Operator Benchmark", StokesSphereBenchmark3DDDG, gmsh_kwargs)
+        gmsh_symm_bench = _run_case(
+            3,
+            "Gmsh Symm+Nonobtuse Finite-Difference Operator Benchmark",
+            StokesSphereBenchmark3DSymmNonobtuse,
+            gmsh_symm_kwargs,
+        )
+        gmsh_symm_ddg_bench = _run_case(
+            4,
+            "Gmsh Symm+Nonobtuse DDG Operator Benchmark",
+            StokesSphereBenchmark3DDDGSymmNonobtuse,
+            gmsh_symm_kwargs,
+        )
+        if args.save_mesh_pngs:
+            if gmsh_bench is not None:
+                png = _save_mesh_png_3d(gmsh_bench, png_dir / "stokes_3d_gmsh_mesh.png", "StokesSphere3D (Gmsh)")
+                if png is not None:
+                    print(f"Mesh PNG (Case 1): {png}")
+            if gmsh_symm_bench is not None:
+                png = _save_mesh_png_3d(
+                    gmsh_symm_bench,
+                    png_dir / "stokes_3d_gmsh_symm_nonobtuse_mesh.png",
+                    "StokesSphere3D Symm+Nonobtuse (Gmsh)",
+                )
+                if png is not None:
+                    print(f"Mesh PNG (Case 3): {png}")
+        _print_rel_error_by_case([
+            ("Gmsh Unsymm+Obtuse Finite-Difference Operator Benchmark", gmsh_bench),
+            ("Gmsh Unsymm+Obtuse DDG Operator Benchmark", gmsh_ddg_bench),
+            ("Gmsh Symm+Nonobtuse Finite-Difference Operator Benchmark", gmsh_symm_bench),
+            ("Gmsh Symm+Nonobtuse DDG Operator Benchmark", gmsh_symm_ddg_bench),
+        ])
+        _print_vertex_rel_error_by_case([
+            ("Gmsh Unsymm+Obtuse Finite-Difference Operator Benchmark", gmsh_bench),
+            ("Gmsh Unsymm+Obtuse DDG Operator Benchmark", gmsh_ddg_bench),
+            ("Gmsh Symm+Nonobtuse Finite-Difference Operator Benchmark", gmsh_symm_bench),
+            ("Gmsh Symm+Nonobtuse DDG Operator Benchmark", gmsh_symm_ddg_bench),
+        ])
+        return
+
+    if args.mesh_source == "hc":
+        hc_bench = _run_case(1, "HC Unsymm+Obtuse Finite-Difference Operator Benchmark", StokesSphereBenchmark3DHC, hc_kwargs)
+        hc_ddg_bench = _run_case(2, "HC Unsymm+Obtuse DDG Operator Benchmark", StokesSphereBenchmark3DHCDDG, hc_kwargs)
+        hc_symm_bench = _run_case(
+            3,
+            "HC Symm+Nonobtuse Finite-Difference Operator Benchmark",
+            StokesSphereBenchmark3DHCSymmNonobtuse,
+            hc_symm_kwargs,
+        )
+        hc_symm_ddg_bench = _run_case(
+            4,
+            "HC Symm+Nonobtuse DDG Operator Benchmark",
+            StokesSphereBenchmark3DHCDDGSymmNonobtuse,
+            hc_symm_kwargs,
+        )
+        if args.save_mesh_pngs:
+            if hc_bench is not None:
+                png = _save_mesh_png_3d(hc_bench, png_dir / "stokes_3d_hc_mesh.png", "StokesSphere3DHC (HC)")
+                if png is not None:
+                    print(f"Mesh PNG (Case 1): {png}")
+            if hc_symm_bench is not None:
+                png = _save_mesh_png_3d(
+                    hc_symm_bench,
+                    png_dir / "stokes_3d_hc_symm_nonobtuse_mesh.png",
+                    "StokesSphere3D Symm+Nonobtuse (HC)",
+                )
+                if png is not None:
+                    print(f"Mesh PNG (Case 3): {png}")
+        _print_rel_error_by_case([
+            ("HC Unsymm+Obtuse Finite-Difference Operator Benchmark", hc_bench),
+            ("HC Unsymm+Obtuse DDG Operator Benchmark", hc_ddg_bench),
+            ("HC Symm+Nonobtuse Finite-Difference Operator Benchmark", hc_symm_bench),
+            ("HC Symm+Nonobtuse DDG Operator Benchmark", hc_symm_ddg_bench),
+        ])
+        _print_vertex_rel_error_by_case([
+            ("HC Unsymm+Obtuse Finite-Difference Operator Benchmark", hc_bench),
+            ("HC Unsymm+Obtuse DDG Operator Benchmark", hc_ddg_bench),
+            ("HC Symm+Nonobtuse Finite-Difference Operator Benchmark", hc_symm_bench),
+            ("HC Symm+Nonobtuse DDG Operator Benchmark", hc_symm_ddg_bench),
+        ])
+        return
+
+    gmsh_bench = _run_case(1, "Gmsh Unsymm+Obtuse Finite-Difference Operator Benchmark", StokesSphereBenchmark3D, gmsh_kwargs)
+    global_target_cells = None
+    global_target_obstacle = None
+    global_target_outer = None
+    if gmsh_bench is not None:
+        global_target_cells = int(gmsh_bench.mesh_metadata.get("n_volume_cells", 0))
+        global_target_obstacle = int(gmsh_bench.mesh_metadata.get("n_obstacle_elements", 0))
+        global_target_outer = int(gmsh_bench.mesh_metadata.get("n_outer_boundary_elements", 0))
+
+    if gmsh_bench is not None and args.auto_match_hc_cells:
+        print(f"\nHC auto-match: tuning (mode={args.auto_match_mode}) ...")
+        tuned = _auto_tune_hc_to_target_cells_3d(
+            args,
+            global_target_cells,
+            target_obstacle=global_target_obstacle,
+            target_outer=global_target_outer,
+            match_mode=args.auto_match_mode,
+            symm_nonobtuse=False,
+        )
+        if tuned is not None:
+            hc_kwargs["hc_refine"] = tuned["hc_refine"]
+            hc_kwargs["hc_inner_samples"] = tuned["hc_inner_samples"]
+            hc_kwargs["hc_outer_samples"] = tuned["hc_outer_samples"]
+            print(
+                "\nHC auto-match: "
+                f"mode={args.auto_match_mode}, "
+                f"target_cells={tuned['target_cells']}, "
+                f"chosen_cells={tuned['n_cells']}, "
+                f"chosen_points={tuned['n_points']}, "
+                f"hc_refine={tuned['hc_refine']}, "
+                f"hc_inner_samples={tuned['hc_inner_samples']}, "
+                f"hc_outer_samples={tuned['hc_outer_samples']}, "
+                f"target_obstacle={tuned['target_obstacle']}, "
+                f"chosen_obstacle={tuned['n_obstacle']}, "
+                f"target_outer={tuned['target_outer']}, "
+                f"chosen_outer={tuned['n_outer']}"
+            )
+        else:
+            print("\nHC auto-match skipped: no valid HC candidate mesh was produced.")
+
+    hc_bench = _run_case(2, "HC Unsymm+Obtuse Finite-Difference Operator Benchmark", StokesSphereBenchmark3DHC, hc_kwargs)
+    gmsh_ddg_bench = _run_case(3, "Gmsh Unsymm+Obtuse DDG Operator Benchmark", StokesSphereBenchmark3DDDG, gmsh_kwargs)
+    hc_ddg_bench = _run_case(4, "HC Unsymm+Obtuse DDG Operator Benchmark", StokesSphereBenchmark3DHCDDG, hc_kwargs)
+
+    gmsh_symm_bench = None
+
+    if global_target_obstacle is not None and global_target_outer is not None and args.auto_match_hc_cells:
+        print("\nGmsh auto-match (symm_nonobtuse): tuning to global boundary target ...")
+        tuned_gmsh_symm = _auto_tune_gmsh_to_target_surfaces_3d(
+            args,
+            StokesSphereBenchmark3DSymmNonobtuse,
+            gmsh_symm_kwargs,
+            target_obstacle=global_target_obstacle,
+            target_outer=global_target_outer,
+        )
+        if tuned_gmsh_symm is not None:
+            gmsh_symm_kwargs = tuned_gmsh_symm["kwargs"]
+            print(
+                "\nGmsh auto-match (symm_nonobtuse): "
+                f"target_obstacle={tuned_gmsh_symm['target_obstacle']}, "
+                f"chosen_obstacle={tuned_gmsh_symm['n_obstacle']}, "
+                f"target_outer={tuned_gmsh_symm['target_outer']}, "
+                f"chosen_outer={tuned_gmsh_symm['n_outer']}, "
+                f"mesh_size_inner={tuned_gmsh_symm['mesh_size_inner']:.6g}, "
+                f"mesh_size_outer={tuned_gmsh_symm['mesh_size_outer']:.6g}"
+            )
+        else:
+            print("\nGmsh auto-match (symm_nonobtuse) skipped: no valid candidate mesh was produced.")
+
+    gmsh_symm_bench = _run_case(
+        5,
+        "Gmsh Symm+Nonobtuse Finite-Difference Operator Benchmark",
+        StokesSphereBenchmark3DSymmNonobtuse,
+        gmsh_symm_kwargs,
+    )
+
+    if gmsh_symm_bench is not None and args.auto_match_hc_cells and global_target_cells is not None:
+        print(f"\nHC auto-match (symm_nonobtuse): tuning to global target (mode={args.auto_match_mode}) ...")
+        tuned_symm = _auto_tune_hc_to_target_cells_3d(
+            args,
+            global_target_cells,
+            target_obstacle=global_target_obstacle,
+            target_outer=global_target_outer,
+            match_mode=args.auto_match_mode,
+            symm_nonobtuse=True,
+        )
+        if tuned_symm is not None:
+            hc_symm_kwargs["hc_refine"] = tuned_symm["hc_refine"]
+            hc_symm_kwargs["hc_inner_samples"] = tuned_symm["hc_inner_samples"]
+            hc_symm_kwargs["hc_outer_samples"] = tuned_symm["hc_outer_samples"]
+            print(
+                "\nHC auto-match (symm_nonobtuse): "
+                f"mode={args.auto_match_mode}, "
+                f"target_cells={tuned_symm['target_cells']}, "
+                f"chosen_cells={tuned_symm['n_cells']}, "
+                f"chosen_points={tuned_symm['n_points']}, "
+                f"hc_refine={tuned_symm['hc_refine']}, "
+                f"hc_inner_samples={tuned_symm['hc_inner_samples']}, "
+                f"hc_outer_samples={tuned_symm['hc_outer_samples']}, "
+                f"target_obstacle={tuned_symm['target_obstacle']}, "
+                f"chosen_obstacle={tuned_symm['n_obstacle']}, "
+                f"target_outer={tuned_symm['target_outer']}, "
+                f"chosen_outer={tuned_symm['n_outer']}"
+            )
+        else:
+            print("\nHC auto-match (symm_nonobtuse) skipped: no valid HC candidate mesh was produced.")
+
+    hc_symm_bench = _run_case(
+        6,
+        "HC Symm+Nonobtuse Finite-Difference Operator Benchmark",
+        StokesSphereBenchmark3DHCSymmNonobtuse,
+        hc_symm_kwargs,
+    )
+    gmsh_symm_ddg_bench = _run_case(
+        7,
+        "Gmsh Symm+Nonobtuse DDG Operator Benchmark",
+        StokesSphereBenchmark3DDDGSymmNonobtuse,
+        gmsh_symm_kwargs,
+    )
+    hc_symm_ddg_bench = _run_case(
+        8,
+        "HC Symm+Nonobtuse DDG Operator Benchmark",
+        StokesSphereBenchmark3DHCDDGSymmNonobtuse,
+        hc_symm_kwargs,
+    )
+
+    if args.save_mesh_pngs:
+        png_entries = []
+        if gmsh_bench is not None:
+            png_entries.append(("Case 1", _save_mesh_png_3d(gmsh_bench, png_dir / "stokes_3d_gmsh_mesh.png", "StokesSphere3D (Gmsh)")))
+        if hc_bench is not None:
+            png_entries.append(("Case 2", _save_mesh_png_3d(hc_bench, png_dir / "stokes_3d_hc_mesh.png", "StokesSphere3DHC (HC)")))
+        if gmsh_symm_bench is not None:
+            png_entries.append(("Case 5", _save_mesh_png_3d(
+                gmsh_symm_bench,
+                png_dir / "stokes_3d_gmsh_symm_nonobtuse_mesh.png",
+                "StokesSphere3D Symm+Nonobtuse (Gmsh)",
+            )))
+        if hc_symm_bench is not None:
+            png_entries.append(("Case 6", _save_mesh_png_3d(
+                hc_symm_bench,
+                png_dir / "stokes_3d_hc_symm_nonobtuse_mesh.png",
+                "StokesSphere3D Symm+Nonobtuse (HC)",
+            )))
+        for label, png_path in png_entries:
+            if png_path is not None:
+                print(f"Mesh PNG ({label}): {png_path}")
+
+    _print_rel_error_by_case([
+        ("Gmsh Unsymm+Obtuse Finite-Difference Operator Benchmark", gmsh_bench),
+        ("HC Unsymm+Obtuse Finite-Difference Operator Benchmark", hc_bench),
+        ("Gmsh Unsymm+Obtuse DDG Operator Benchmark", gmsh_ddg_bench),
+        ("HC Unsymm+Obtuse DDG Operator Benchmark", hc_ddg_bench),
+        ("Gmsh Symm+Nonobtuse Finite-Difference Operator Benchmark", gmsh_symm_bench),
+        ("HC Symm+Nonobtuse Finite-Difference Operator Benchmark", hc_symm_bench),
+        ("Gmsh Symm+Nonobtuse DDG Operator Benchmark", gmsh_symm_ddg_bench),
+        ("HC Symm+Nonobtuse DDG Operator Benchmark", hc_symm_ddg_bench),
+    ])
+    _print_vertex_rel_error_by_case([
+        ("Gmsh Unsymm+Obtuse Finite-Difference Operator Benchmark", gmsh_bench),
+        ("HC Unsymm+Obtuse Finite-Difference Operator Benchmark", hc_bench),
+        ("Gmsh Unsymm+Obtuse DDG Operator Benchmark", gmsh_ddg_bench),
+        ("HC Unsymm+Obtuse DDG Operator Benchmark", hc_ddg_bench),
+        ("Gmsh Symm+Nonobtuse Finite-Difference Operator Benchmark", gmsh_symm_bench),
+        ("HC Symm+Nonobtuse Finite-Difference Operator Benchmark", hc_symm_bench),
+        ("Gmsh Symm+Nonobtuse DDG Operator Benchmark", gmsh_symm_ddg_bench),
+        ("HC Symm+Nonobtuse DDG Operator Benchmark", hc_symm_ddg_bench),
+    ])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add reusable flow benchmark support for Stokes sphere validation.
- Add 2D axisymmetric and 3D Stokes sphere benchmark cases for Gmsh and HC meshes.
- Add finite-difference/Cauchy stress and DDG operator comparison cases, plus global and nodal-lumped drag error reporting.
- Add runnable scripts for 2D and 3D benchmark sweeps.

## Validation
- python3 -m py_compile benchmarks/_benchmark_classes.py benchmarks/_benchmark_cases.py run_stokes_benchmark_2D.py run_stokes_benchmark_3D.py
- python3 run_stokes_benchmark_2D.py --mesh-source both --no-save-mesh-pngs
- python3 run_stokes_benchmark_3D.py --mesh-source both --no-save-mesh-pngs
