### PR TITLE
Add oscillating droplet pressure-reference benchmark

### DIFF
--- a/cases_dynamic/oscillating_droplet_p_ref/.gitignore
+++ b/cases_dynamic/oscillating_droplet_p_ref/.gitignore
@@ -1,0 +1,8 @@
+out/
+__pycache__/
+*.pyc
+*.npz
+*.csv
+*.json
+*.gif
+*.png

--- a/cases_dynamic/oscillating_droplet_p_ref/README.md
+++ b/cases_dynamic/oscillating_droplet_p_ref/README.md
@@ -155,19 +155,17 @@ m_t = rho V_t
 V_t^tar = scaled V_t
 ```
 
-## ddgclib Operator Additions
+## Benchmark Operator Wrapper
 
-The benchmark adds new functions to `ddgclib/operators/stress.py` and
-`ddgclib/operators/multiphase_stress.py`. The old public pressure-flux path is
-kept available; the pressure-reference method is exposed as a separate operator
-path so existing cases do not have to opt in. A small 3D dual-area fallback is
-also added for HyperCT versions that do not expose the newer `p_ij` helper.
+The benchmark-specific operators now live in `scripts/pr33_operators.py`.
+The core `ddgclib/operators/stress.py` and
+`ddgclib/operators/multiphase_stress.py` files are left on their existing API
+surface.  The benchmark runners use local wrapper imports to bind the PR #33
+helpers into the unchanged base benchmark scripts.
 
-Important one-phase functions:
+Important one-phase helpers:
 
 ```text
-VolumeGradientPressureState
-volume_gradient_pressure_acceleration
 heron_surface_force_from_faces
 heron_forces_for_points
 tet_volume_matrix
@@ -176,9 +174,11 @@ compressible_eos_pressure_correction
 incompressible_volume_projection
 tet_face_ale_fluxes
 active_retopology_tet_remap
+VolumeGradientPressureState
+volume_gradient_pressure_acceleration
 ```
 
-Important multiphase wrappers:
+Important multiphase helpers kept out of the core multiphase operator file:
 
 ```text
 MultiphaseVolumeGradientPressureState

--- a/cases_dynamic/oscillating_droplet_p_ref/README.md
+++ b/cases_dynamic/oscillating_droplet_p_ref/README.md
@@ -1,0 +1,271 @@
+# Oscillating droplet pressure-reference benchmark
+
+This folder contains the benchmark material used to compare EOS pressure,
+local incompressible projection, internal ALE flux, pairwise pressure trials,
+and Delaunay retopology for a Rayleigh-Lamb oscillating droplet.
+
+The presentation is included as:
+
+```text
+20260604_Oscillating Droplet Benchmark_twelve_cases.pptx
+```
+
+## What Was Tested
+
+The benchmark starts from a small `l=2` shape perturbation of a spherical
+droplet and compares the fitted amplitude `a2(t)` against Rayleigh-Lamb theory.
+The same geometry is used to test:
+
+- weak-compressible EOS pressure closure,
+- local incompressible volume projection,
+- Lagrangian material-face ALE flux,
+- deliberately nonzero cell-average/Rusanov flux stress tests,
+- pairwise `A_ij` pressure trials,
+- active Delaunay retopology with a tet-volume pressure closure,
+- GitHub `ddgclib` two-phase triangulation visual comparison.
+
+The stable physical cases use a moving Lagrangian tet mesh. For a material
+face, the mesh velocity equals the material face velocity, so the internal mass
+flux is zero. The vertex positions are still updated dynamically from nodal
+forces.
+
+## Achieved Result
+
+The corrected cases reproduce the Rayleigh-Lamb `a2(t)` response for the
+selected mesh and time horizon. The ddgclib-backed repeats match the previous
+successful benchmark rows to numerical roundoff:
+
+| case | closure | key setting | result |
+|---|---|---|---|
+| #5_ddgclib | compressible EOS | Lagrangian full flux | same `a2(t)` as old #5 |
+| #6_ddgclib | incompressible projection | Lagrangian full flux | same `a2(t)` as old #6 |
+| #11_ddgclib | compressible EOS | active retopology | same `a2(t)` as old #11, nonzero tet flips |
+| #12_ddgclib | incompressible projection | active retopology | same `a2(t)` as old #12, nonzero tet flips |
+
+For #11/#12 the solver tet list is actively rebuilt. The final comparison run
+showed hundreds of changed tets, confirming that retopology happened in the
+solver path, not only in the visualization.
+
+## Problem Addressed
+
+The upstream oscillating-droplet setup can suffer from a retopology artifact:
+after a Delaunay flip, the HC local dual cell around a vertex can change even
+when the physical liquid has not locally compressed by that amount. If density
+and pressure are computed from that changing HC dual volume, this can create an
+artificial density/pressure jump.
+
+The benchmark workaround is:
+
+1. use tet volumes directly for pressure and continuity,
+2. rebuild the tet-volume gradient matrix after retopology,
+3. remap tet mass and target volume from the new tet volumes,
+4. lump tet quantities to vertices barycentrically only for nodal mass/volume
+   diagnostics.
+
+This is a controlled benchmark closure, not a full conservative old-dual to
+new-dual overlap remap.
+
+## Main Equations
+
+Rayleigh-Lamb frequency for shape mode `l`:
+
+```text
+omega_l^2 = l (l - 1) (l + 2) gamma / (rho R^3)
+```
+
+HC/FHeron surface force:
+
+```text
+F_i^Heron = -gamma (HN dA)_i
+```
+
+Tet-volume continuity operator:
+
+```text
+B_{t,i} = partial V_t / partial x_i
+Vdot_t = sum_i B_{t,i} . u_i
+S = B M^{-1} B^T
+```
+
+Weak-compressible EOS correction:
+
+```text
+(I + dt^2 D_K S) delta p
+  = -D_K (V - V^tar + dt B u*)
+
+D_K = diag(K / V_t^0)
+V_t^tar = m_t / rho_0
+```
+
+Local incompressible projection:
+
+```text
+S p = (r - B u) / dt - B M^{-1} F_np
+r = -(V - V^tar) / dt
+```
+
+Lagrangian ALE material-face flux:
+
+```text
+Phi_m,f = rho^up ((u_f - w_f) . A_f)
+
+for a material face:
+u_f = w_f, so Phi_m,f = 0
+```
+
+Tet-volume lumping:
+
+```text
+V_i = sum_{t contains i} V_t / 4
+m_i = sum_{t contains i} m_t / 4
+```
+
+Active retopology remap:
+
+```text
+new Delaunay tets -> recompute V_t and B
+m_t = rho V_t
+V_t^tar = scaled V_t
+```
+
+## ddgclib Operator Additions
+
+The benchmark adds new functions to `ddgclib/operators/stress.py` and
+`ddgclib/operators/multiphase_stress.py`. Existing functions are not changed;
+the new operators are added in a separate benchmark add-on block near the top
+of each file.
+
+Important one-phase functions:
+
+```text
+heron_surface_force_from_faces
+heron_forces_for_points
+tet_volume_matrix
+tet_volume_lumped_nodal_values
+compressible_eos_pressure_correction
+incompressible_volume_projection
+tet_face_ale_fluxes
+active_retopology_tet_remap
+```
+
+Important multiphase wrappers:
+
+```text
+multiphase_tet_volume_matrix
+multiphase_tet_volume_lumped_masses
+multiphase_compressible_eos_pressure_correction
+multiphase_incompressible_volume_projection
+multiphase_active_retopology_remap
+```
+
+## Included Scripts
+
+The `scripts/` folder contains the Python code used for the benchmark and deck
+figures:
+
+```text
+sphere_fheron_eos_projection_benchmark.py
+sphere_fheron_flux_fv_benchmark.py
+sphere_fheron_flux_fv_ddgclib_benchmark.py
+sphere_fheron_twophase_gasmesh_benchmark.py
+run_github_twophase_oscillating_preview.py
+render_github_twophase_triangulation_active_retopology.py
+render_twophase_gasmesh_active_retopology.py
+render_free_surface_air_mesh_preview.py
+plot_github_case_a2_vs_t.py
+plot_force_components_vs_t.py
+crop_fheron_gifs.py
+patch_iwt_office_math_slide3.py
+patch_office_math_slide2.py
+four_tet_retriangulation_dual_volume_demo.py
+four_tet_retriangulation_dual_volume/four_tet_retriangulation_dual_volume_demo.py
+```
+
+## Example Commands
+
+Run #5_ddgclib:
+
+```bash
+python3 scripts/sphere_fheron_flux_fv_ddgclib_benchmark.py \
+  --closure compressible \
+  --subdivision 1 \
+  --steps 81 \
+  --substeps-per-sample 20 \
+  --t-final 0.016 \
+  --shape-mode-ar 1.05 \
+  --damping-ratio 0 \
+  --inertia-scale 1.08 \
+  --mass-model star-volume \
+  --mass-flux-coupling 1 \
+  --momentum-flux-coupling 1 \
+  --face-flux-mode lagrangian \
+  --density-change-limit 0 \
+  --out-dir out/case5_ddgclib
+```
+
+Run #6_ddgclib:
+
+```bash
+python3 scripts/sphere_fheron_flux_fv_ddgclib_benchmark.py \
+  --closure incompressible \
+  --subdivision 1 \
+  --steps 81 \
+  --substeps-per-sample 20 \
+  --t-final 0.016 \
+  --shape-mode-ar 1.05 \
+  --damping-ratio 0 \
+  --inertia-scale 1.08 \
+  --mass-model star-volume \
+  --mass-flux-coupling 1 \
+  --momentum-flux-coupling 1 \
+  --face-flux-mode lagrangian \
+  --density-change-limit 0 \
+  --out-dir out/case6_ddgclib
+```
+
+Run #11/#12 ddgclib active-retopology source rows:
+
+```bash
+python3 scripts/sphere_fheron_flux_fv_ddgclib_benchmark.py \
+  --closure both \
+  --subdivision 1 \
+  --steps 81 \
+  --substeps-per-sample 5 \
+  --t-final 0.016 \
+  --shape-mode-ar 1.05 \
+  --damping-ratio 0 \
+  --inertia-scale 1.08 \
+  --mass-model star-volume \
+  --mass-flux-coupling 1 \
+  --momentum-flux-coupling 1 \
+  --face-flux-mode lagrangian \
+  --density-change-limit 0 \
+  --retriangulation-mode active \
+  --out-dir out/case11_12_ddgclib_active_retopology
+```
+
+Render the GitHub two-phase triangulation view for #11/#12:
+
+```bash
+python3 scripts/render_github_twophase_triangulation_active_retopology.py \
+  --source-dir out/case11_12_ddgclib_active_retopology \
+  --out-dir out/case11_12_ddgclib_github_twophase_triangulation
+```
+
+## Literature References
+
+- Rayleigh, L. (1879). On the capillary phenomena of jets. Proceedings of the
+  Royal Society of London, 29, 71-97.
+- Lamb, H. (1932). Hydrodynamics, 6th ed. Cambridge University Press.
+- Chorin, A. J. (1968). Numerical solution of the Navier-Stokes equations.
+  Mathematics of Computation, 22(104), 745-762.
+- Temam, R. (1969). Sur un schema d'approximation de la solution des equations
+  de Navier-Stokes. Bulletin de la Societe Mathematique de France, 96, 115-152.
+- Hirt, C. W., Amsden, A. A., & Cook, J. L. (1974). An arbitrary
+  Lagrangian-Eulerian computing method for all flow speeds. Journal of
+  Computational Physics, 14, 227-253.
+- Toro, E. F. (2009). Riemann Solvers and Numerical Methods for Fluid
+  Dynamics, 3rd ed. Springer.
+- Chen, Z., & Przekwas, A. (2010). A coupled pressure-based computational
+  method for incompressible/compressible flows. Journal of Computational
+  Physics, 229(24), 9150-9165.

--- a/cases_dynamic/oscillating_droplet_p_ref/README.md
+++ b/cases_dynamic/oscillating_droplet_p_ref/README.md
@@ -2,7 +2,10 @@
 
 This folder contains the benchmark material used to compare EOS pressure,
 local incompressible projection, internal ALE flux, pairwise pressure trials,
-and Delaunay retopology for a Rayleigh-Lamb oscillating droplet.
+and Delaunay retopology for a Rayleigh-Lamb oscillating droplet. The main
+addition is a tet-volume pressure-reference operator that can replace the
+face-average pressure flux in an oscillating-droplet test while still using the
+standard dynamic integrator update `du_i/dt = F_i/m_i`, `dx_i/dt = u_i`.
 
 The presentation is included as:
 
@@ -22,7 +25,8 @@ The same geometry is used to test:
 - deliberately nonzero cell-average/Rusanov flux stress tests,
 - pairwise `A_ij` pressure trials,
 - active Delaunay retopology with a tet-volume pressure closure,
-- GitHub `ddgclib` two-phase triangulation visual comparison.
+- `ddgclib` two-phase liquid/gas triangulation with a multiphase EOS/projection
+  pressure-reference solve.
 
 The stable physical cases use a moving Lagrangian tet mesh. For a material
 face, the mesh velocity equals the material face velocity, so the internal mass
@@ -32,27 +36,43 @@ forces.
 ## Achieved Result
 
 The corrected cases reproduce the Rayleigh-Lamb `a2(t)` response for the
-selected mesh and time horizon. The ddgclib-backed repeats match the previous
-successful benchmark rows to numerical roundoff:
+selected mesh and time horizon. Cases #5/#6 are ddgclib-backed repeats of the
+successful one-phase benchmark. Cases #11/#12 keep a two-phase liquid/gas mesh
+and verify that active Delaunay retopology occurs while the liquid pressure
+operator remains stable:
 
 | case | closure | key setting | result |
 |---|---|---|---|
 | #5_ddgclib | compressible EOS | Lagrangian full flux | same `a2(t)` as old #5 |
 | #6_ddgclib | incompressible projection | Lagrangian full flux | same `a2(t)` as old #6 |
-| #11_ddgclib | compressible EOS | active retopology | same `a2(t)` as old #11, nonzero tet flips |
-| #12_ddgclib | incompressible projection | active retopology | same `a2(t)` as old #12, nonzero tet flips |
+| #11_ddgclib | compressible EOS | liquid + gas mesh, active retopology | Rayleigh match with nonzero tet flips |
+| #12_ddgclib | incompressible projection | liquid + gas mesh, active retopology | Rayleigh match with nonzero tet flips |
 
-For #11/#12 the solver tet list is actively rebuilt. The final comparison run
-showed hundreds of changed tets, confirming that retopology happened in the
-solver path, not only in the visualization.
+For #11/#12 the full liquid-plus-gas vertex cloud is actively rebuilt by
+Delaunay retopology. New tetrahedra are reclassified by their persistent
+Lagrangian vertex phase, and the liquid EOS/projection pressure operator is
+rebuilt from the liquid tet subset. The validation rows report both liquid and
+gas tetrahedra, plus more than one thousand changed combined tets, confirming
+that retopology happened in the solver path, not only in the visualization.
+
+Representative dynamic-integrator validation at `t = 0.016 s`, `AR = 1.05`,
+`R = 1 mm`, `gamma = 0.072 N/m`, and `rho = 1000 kg/m^3`:
+
+| case | final `a2` | Rayleigh `a2` | changed tets | note |
+|---|---:|---:|---:|---|
+| #5_ddgclib | 0.02810 | 0.02989 | 0 | one-phase compressible EOS |
+| #6_ddgclib | 0.02810 | 0.02989 | 0 | one-phase incompressible projection |
+| #11_ddgclib | 0.02830 | 0.02989 | 1084 | two-phase compressible, active retopology |
+| #12_ddgclib | 0.02830 | 0.02989 | 1060 | two-phase incompressible, active retopology |
 
 ## Problem Addressed
 
 The upstream oscillating-droplet setup can suffer from a retopology artifact:
 after a Delaunay flip, the HC local dual cell around a vertex can change even
 when the physical liquid has not locally compressed by that amount. If density
-and pressure are computed from that changing HC dual volume, this can create an
-artificial density/pressure jump.
+and pressure are computed from that changing HC dual volume, the code can read a
+topological connectivity change as a physical compression/expansion event. That
+creates an artificial density/pressure jump and changes the droplet frequency.
 
 The benchmark workaround is:
 
@@ -61,6 +81,13 @@ The benchmark workaround is:
 3. remap tet mass and target volume from the new tet volumes,
 4. lump tet quantities to vertices barycentrically only for nodal mass/volume
    diagnostics.
+
+This works for the benchmark because the pressure equation measures and
+corrects exactly the same quantity after every retopology step: tet volume.
+The operator `B = dV_t/dx_i`, the target tet volumes, and the nodal masses are
+all rebuilt from the same new tet list. The pressure force therefore pushes in
+the direction that reduces the measured tet-volume error instead of reacting to
+an unrelated HC dual-volume jump.
 
 This is a controlled benchmark closure, not a full conservative old-dual to
 new-dual overlap remap.
@@ -131,13 +158,16 @@ V_t^tar = scaled V_t
 ## ddgclib Operator Additions
 
 The benchmark adds new functions to `ddgclib/operators/stress.py` and
-`ddgclib/operators/multiphase_stress.py`. Existing functions are not changed;
-the new operators are added in a separate benchmark add-on block near the top
-of each file.
+`ddgclib/operators/multiphase_stress.py`. The old public pressure-flux path is
+kept available; the pressure-reference method is exposed as a separate operator
+path so existing cases do not have to opt in. A small 3D dual-area fallback is
+also added for HyperCT versions that do not expose the newer `p_ij` helper.
 
 Important one-phase functions:
 
 ```text
+VolumeGradientPressureState
+volume_gradient_pressure_acceleration
 heron_surface_force_from_faces
 heron_forces_for_points
 tet_volume_matrix
@@ -151,6 +181,8 @@ active_retopology_tet_remap
 Important multiphase wrappers:
 
 ```text
+MultiphaseVolumeGradientPressureState
+multiphase_volume_gradient_pressure_acceleration
 multiphase_tet_volume_matrix
 multiphase_tet_volume_lumped_masses
 multiphase_compressible_eos_pressure_correction
@@ -167,9 +199,11 @@ figures:
 sphere_fheron_eos_projection_benchmark.py
 sphere_fheron_flux_fv_benchmark.py
 sphere_fheron_flux_fv_ddgclib_benchmark.py
+sphere_fheron_dynamic_integrator_p_ref.py
 sphere_fheron_twophase_gasmesh_benchmark.py
 run_github_twophase_oscillating_preview.py
 render_github_twophase_triangulation_active_retopology.py
+render_dynamic_integrator_twophase.py
 render_twophase_gasmesh_active_retopology.py
 render_free_surface_air_mesh_preview.py
 plot_github_case_a2_vs_t.py
@@ -223,34 +257,57 @@ python3 scripts/sphere_fheron_flux_fv_ddgclib_benchmark.py \
   --out-dir out/case6_ddgclib
 ```
 
-Run #11/#12 ddgclib active-retopology source rows:
+Run #11/#12 ddgclib dynamic-integrator two-phase active-retopology rows:
 
 ```bash
-python3 scripts/sphere_fheron_flux_fv_ddgclib_benchmark.py \
-  --closure both \
+python3 scripts/sphere_fheron_dynamic_integrator_p_ref.py \
+  --case-id 11 \
   --subdivision 1 \
   --steps 81 \
   --substeps-per-sample 5 \
   --t-final 0.016 \
   --shape-mode-ar 1.05 \
+  --inertia-scale 1.08 \
+  --out-dir out/dynamic_integrator_p_ref_case11_multiphase
+```
+
+Use `--case-id 12 --out-dir out/dynamic_integrator_p_ref_case12_multiphase`
+for the incompressible projection repeat.
+
+Run the built-in dynamic-integrator pressure-reference validation:
+
+```bash
+python3 scripts/sphere_fheron_dynamic_integrator_p_ref.py \
+  --case-id 5 \
+  --subdivision 1 \
+  --steps 81 \
+  --substeps-per-sample 20 \
+  --t-final 0.016 \
+  --shape-mode-ar 1.05 \
   --damping-ratio 0 \
   --inertia-scale 1.08 \
-  --mass-model star-volume \
   --mass-flux-coupling 1 \
   --momentum-flux-coupling 1 \
   --face-flux-mode lagrangian \
   --density-change-limit 0 \
-  --retriangulation-mode active \
-  --out-dir out/case11_12_ddgclib_active_retopology
+  --out-dir out/dynamic_integrator_p_ref_case5
 ```
 
-Render the GitHub two-phase triangulation view for #11/#12:
+Use `--case-id 6`, `--case-id 11`, or `--case-id 12` for the other
+validation runs. Cases #11/#12 use the integrator `retopologize_fn` callback,
+so the pressure state rebuilds the tet list, `B=dV/dx`, masses, and target
+volumes before the next `dudt_fn` call.
+
+Render the dynamic-integrator two-phase GIFs:
 
 ```bash
-python3 scripts/render_github_twophase_triangulation_active_retopology.py \
-  --source-dir out/case11_12_ddgclib_active_retopology \
-  --out-dir out/case11_12_ddgclib_github_twophase_triangulation
+python3 scripts/render_dynamic_integrator_twophase.py \
+  --case-id 11 \
+  --source-dir out/dynamic_integrator_p_ref_case11_multiphase
 ```
+
+Use `--case-id 12 --source-dir out/dynamic_integrator_p_ref_case12_multiphase`
+for the incompressible projection GIF.
 
 ## Literature References
 

--- a/cases_dynamic/oscillating_droplet_p_ref/scripts/crop_fheron_gifs.py
+++ b/cases_dynamic/oscillating_droplet_p_ref/scripts/crop_fheron_gifs.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+from PIL import Image, ImageSequence
+
+
+ROOT = Path(__file__).resolve().parent
+GIFS = [
+    ROOT / "out/sphere_fheron_noflux_0p016/flux_incompressible_sphere.gif",
+    ROOT / "out/sphere_fheron_noflux_0p016/flux_compressible_sphere.gif",
+    ROOT / "out/sphere_fheron_flux_fv/flux_incompressible_sphere_tfinal_0p016.gif",
+    ROOT / "out/sphere_fheron_flux_fv/flux_compressible_sphere_tfinal_0p016.gif",
+    ROOT / "out/sphere_fheron_flux_fv_fullflux_stabilized/flux_compressible_sphere.gif",
+    ROOT / "out/sphere_fheron_flux_fv_fullflux_projected_upwind_nolimit/flux_incompressible_sphere.gif",
+]
+
+
+def tight_name(path: Path) -> Path:
+    return path.with_name(f"{path.stem}_tight{path.suffix}")
+
+
+def frame_bbox(frame: Image.Image, threshold: int = 245) -> tuple[int, int, int, int] | None:
+    array = np.asarray(frame.convert("RGB"))
+    mask = np.any(array < threshold, axis=2)
+    ys, xs = np.where(mask)
+    if xs.size == 0:
+        return None
+    return int(xs.min()), int(ys.min()), int(xs.max()) + 1, int(ys.max()) + 1
+
+
+def union_bbox(path: Path, padding: int = 12) -> tuple[int, int, int, int]:
+    image = Image.open(path)
+    union: list[int] | None = None
+    for frame in ImageSequence.Iterator(image):
+        box = frame_bbox(frame)
+        if box is None:
+            continue
+        if union is None:
+            union = list(box)
+        else:
+            union = [
+                min(union[0], box[0]),
+                min(union[1], box[1]),
+                max(union[2], box[2]),
+                max(union[3], box[3]),
+            ]
+    if union is None:
+        return 0, 0, image.width, image.height
+    return (
+        max(0, union[0] - padding),
+        max(0, union[1] - padding),
+        min(image.width, union[2] + padding),
+        min(image.height, union[3] + padding),
+    )
+
+
+def crop_gif(path: Path) -> Path:
+    image = Image.open(path)
+    crop = union_bbox(path)
+    durations: list[int] = []
+    frames: list[Image.Image] = []
+    for frame in ImageSequence.Iterator(image):
+        durations.append(int(frame.info.get("duration", image.info.get("duration", 80))))
+        frames.append(frame.convert("RGB").crop(crop))
+    output = tight_name(path)
+    frames[0].save(
+        output,
+        save_all=True,
+        append_images=frames[1:],
+        duration=durations,
+        loop=int(image.info.get("loop", 0)),
+        optimize=True,
+        disposal=2,
+    )
+    return output
+
+
+def main() -> int:
+    for path in GIFS:
+        output = crop_gif(path)
+        with Image.open(path) as original, Image.open(output) as cropped:
+            print(f"{path.relative_to(ROOT)} {original.size} -> {output.relative_to(ROOT)} {cropped.size}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cases_dynamic/oscillating_droplet_p_ref/scripts/four_tet_retriangulation_dual_volume/four_tet_retriangulation_dual_volume_demo.py
+++ b/cases_dynamic/oscillating_droplet_p_ref/scripts/four_tet_retriangulation_dual_volume/four_tet_retriangulation_dual_volume_demo.py
@@ -1,0 +1,1393 @@
+#!/usr/bin/env python3
+"""Delaunay-valid HC retriangulation demo for interface dual volume.
+
+This script builds a minimal two-snapshot case:
+
+* step 0: vertices are triangulated through ddgclib's dynamic-integrator
+  retopology path, which rebuilds the HC connectivity with SciPy Delaunay.
+* step 1: vertices have moved slightly, then the same retopology path is run
+  again. Both snapshots therefore follow the same ddgclib triangulation rule.
+
+The interface vertices lie on a unit sphere.  The selected-vertex liquid dual
+volume is computed from the barycentric HC tetrahedra: each incident tetrahedron
+contributes one quarter of its tetrahedral volume to the selected vertex's
+barycentric dual cell, then those contributions are split by phase.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import itertools
+import json
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DEFAULT_OUT_DIR = SCRIPT_DIR / "out" / "four_tet_retriangulation_dual_volume"
+os.environ.setdefault("MPLCONFIGDIR", str(DEFAULT_OUT_DIR / ".mplconfig"))
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from mpl_toolkits.mplot3d.art3d import Line3DCollection, Poly3DCollection
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
+
+REPO_ROOT = SCRIPT_DIR.parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from hyperct import Complex
+from hyperct.ddg import compute_vd
+
+from ddgclib.dynamic_integrators._integrators_dynamic import _retopologize
+
+
+SPHERE_CENTER = np.zeros(3)
+SPHERE_RADIUS = 1.0
+SELECTED_LABEL = "a"
+
+AIR_COLOR = "#9aa0a6"
+LIQUID_COLOR = "#1f77b4"
+INTERFACE_COLOR = "#2ca25f"
+SELECTED_COLOR = "#c62828"
+EDGE_COLOR = "#222222"
+REMOVED_EDGE_COLOR = "#d62728"
+ADDED_EDGE_COLOR = "#2ca02c"
+CHANGE_ARROW_COLOR = "#8e24aa"
+MOVED_VERTEX_COLOR = "#ff7f0e"
+INTERFACE_LABELS = ("a", "b", "c", "d", "e", "f", "g", "h")
+
+
+@dataclass(frozen=True)
+class TetRecord:
+    name: str
+    phase: str
+    labels: tuple[str, str, str, str]
+
+
+@dataclass
+class Snapshot:
+    step: int
+    name: str
+    tets: list[TetRecord]
+    hc_dual_vertices: int
+    liquid_dual_volume: float
+    air_dual_volume: float
+    total_dual_volume: float
+    per_tet: list[dict[str, object]]
+
+
+@dataclass(frozen=True)
+class Comparison:
+    delta_liquid_volume: float
+    delta_liquid_percent: float
+    max_vertex_position_delta: float
+    removed_edges: tuple[tuple[str, str], ...]
+    added_edges: tuple[tuple[str, str], ...]
+    moved_vertices: tuple[str, ...]
+
+
+def sphere_point(y: float, z: float) -> np.ndarray:
+    """Point on the positive-x cap of the unit sphere."""
+    x2 = SPHERE_RADIUS * SPHERE_RADIUS - y * y - z * z
+    if x2 <= 0.0:
+        raise ValueError("interface point is outside the requested sphere cap")
+    return np.array([np.sqrt(x2), y, z], dtype=float)
+
+
+def build_before_points() -> dict[str, np.ndarray]:
+    """Local vertices before motion: interface cap, one air, one liquid."""
+    return {
+        "a": np.array([1.0, 0.0, 0.0], dtype=float),
+        "b": sphere_point(0.24000000, 0.20000000),
+        "c": sphere_point(-0.10000000, 0.29000000),
+        "d": sphere_point(0.34000000, -0.08000000),
+        "e": sphere_point(-0.26000000, -0.15000000),
+        "f": sphere_point(0.06000000, -0.33000000),
+        "g": sphere_point(-0.36000000, 0.08000000),
+        "h": sphere_point(0.26000000, 0.34000000),
+        "air": np.array([1.32, 0.04, 0.02], dtype=float),
+        "liq": np.array([0.64, -0.02, -0.02], dtype=float),
+    }
+
+
+def build_after_points() -> dict[str, np.ndarray]:
+    """Local vertices after one point moves, still on the sphere cap."""
+    points = build_before_points()
+    points["e"] = sphere_point(-0.23500000, -0.07500000)
+    return points
+
+
+def connect_tetrahedron(vertices: dict[str, object], labels: Iterable[str]) -> None:
+    tet_vertices = [vertices[label] for label in labels]
+    for i, vi in enumerate(tet_vertices):
+        for vj in tet_vertices[i + 1 :]:
+            vi.connect(vj)
+
+
+def build_hc(
+    points: dict[str, np.ndarray],
+    tets: list[TetRecord],
+) -> tuple[Complex, dict[str, object]]:
+    hc = Complex(
+        3,
+        domain=[
+            (0.55, 1.35),
+            (-0.50, 0.50),
+            (-0.40, 0.40),
+        ],
+    )
+    vertices = {label: hc.V[tuple(coord)] for label, coord in points.items()}
+    for label, vertex in vertices.items():
+        vertex.label = label
+        vertex.u = np.zeros(3)
+        vertex.p = 0.0
+        vertex.m = 1.0
+        vertex.is_interface = label in INTERFACE_LABELS
+        if vertex.is_interface:
+            vertex.phase = "interface"
+        else:
+            vertex.phase = "liquid" if label == "liq" else "air"
+
+    for tet in tets:
+        connect_tetrahedron(vertices, tet.labels)
+    return hc, vertices
+
+
+def compute_hc_duals(hc: Complex) -> int:
+    """Populate HC barycentric dual data for the current connectivity."""
+    boundary_vertices = hc.boundary()
+    for vertex in hc.V:
+        vertex.boundary = vertex in boundary_vertices
+    with np.errstate(invalid="ignore", divide="ignore"):
+        compute_vd(hc, method="barycentric")
+    return len(hc.Vd)
+
+
+def tet_volume(points: dict[str, np.ndarray], labels: tuple[str, str, str, str]) -> float:
+    p0, p1, p2, p3 = (points[label] for label in labels)
+    mat = np.vstack((p1 - p0, p2 - p0, p3 - p0))
+    return abs(float(np.linalg.det(mat))) / 6.0
+
+
+def percent_change(before: float, after: float) -> float:
+    if abs(before) < 1e-30:
+        return float("nan")
+    return 100.0 * (after - before) / before
+
+
+def phase_from_tet(points: dict[str, np.ndarray], labels: tuple[str, str, str, str]) -> str:
+    if "liq" in labels and "air" not in labels:
+        return "liquid"
+    if "air" in labels and "liq" not in labels:
+        return "air"
+    centroid = np.mean([points[label] for label in labels], axis=0)
+    r = np.linalg.norm(centroid - SPHERE_CENTER)
+    return "liquid" if r <= SPHERE_RADIUS else "air"
+
+
+def tetrahedra_from_hc_cliques(
+    hc: Complex,
+    points: dict[str, np.ndarray],
+) -> list[TetRecord]:
+    """Recover tetrahedra as 4-cliques in the current HC connectivity graph."""
+    clique_labels: list[tuple[str, str, str, str]] = []
+    for vertices in itertools.combinations(list(hc.V), 4):
+        is_tetrahedron = all(
+            vj in vi.nn for vi, vj in itertools.combinations(vertices, 2)
+        )
+        if is_tetrahedron:
+            clique_labels.append(tuple(sorted(vertex.label for vertex in vertices)))
+
+    clique_labels = sorted(set(clique_labels))
+    records: list[TetRecord] = []
+    for index, tet_labels in enumerate(clique_labels):
+        phase = phase_from_tet(points, tet_labels)
+        records.append(TetRecord(f"T{index:02d}", phase, tet_labels))
+    return records
+
+
+def selected_dual_simplex_vertices(
+    points: dict[str, np.ndarray],
+    tet_labels: tuple[str, str, str, str],
+    selected_label: str,
+) -> list[np.ndarray]:
+    """Barycentric subdivision tets belonging to one selected primal vertex."""
+    if selected_label not in tet_labels:
+        return []
+
+    selected = points[selected_label]
+    others = [label for label in tet_labels if label != selected_label]
+    tet_centroid = np.mean([points[label] for label in tet_labels], axis=0)
+
+    small_tets = []
+    for order in itertools.permutations(others):
+        p1 = 0.5 * (selected + points[order[0]])
+        p2 = (selected + points[order[0]] + points[order[1]]) / 3.0
+        small_tets.append(np.array([selected, p1, p2, tet_centroid], dtype=float))
+    return small_tets
+
+
+def summarize_snapshot(
+    step: int,
+    name: str,
+    hc: Complex,
+    points: dict[str, np.ndarray],
+    tets: list[TetRecord],
+    selected_label: str,
+) -> Snapshot:
+    hc_dual_vertices = compute_hc_duals(hc)
+
+    per_tet = []
+    liquid_dual_volume = 0.0
+    air_dual_volume = 0.0
+    for tet in tets:
+        full_volume = tet_volume(points, tet.labels)
+        selected_volume = full_volume / 4.0 if selected_label in tet.labels else 0.0
+        if tet.phase == "liquid":
+            liquid_dual_volume += selected_volume
+        elif tet.phase == "air":
+            air_dual_volume += selected_volume
+        per_tet.append(
+            {
+                "name": tet.name,
+                "phase": tet.phase,
+                "labels": list(tet.labels),
+                "tet_volume": full_volume,
+                "selected_dual_volume": selected_volume,
+            }
+        )
+
+    return Snapshot(
+        step=step,
+        name=name,
+        tets=tets,
+        hc_dual_vertices=hc_dual_vertices,
+        liquid_dual_volume=liquid_dual_volume,
+        air_dual_volume=air_dual_volume,
+        total_dual_volume=liquid_dual_volume + air_dual_volume,
+        per_tet=per_tet,
+    )
+
+
+def tetra_faces(vertices: np.ndarray) -> list[np.ndarray]:
+    return [
+        vertices[[0, 1, 2]],
+        vertices[[0, 1, 3]],
+        vertices[[0, 2, 3]],
+        vertices[[1, 2, 3]],
+    ]
+
+
+def unique_edges(tets: list[TetRecord]) -> list[tuple[str, str]]:
+    edges: set[tuple[str, str]] = set()
+    for tet in tets:
+        for a_label, b_label in itertools.combinations(tet.labels, 2):
+            edges.add(tuple(sorted((a_label, b_label))))
+    return sorted(edges)
+
+
+def edge_midpoint(points: dict[str, np.ndarray], edge: tuple[str, str]) -> np.ndarray:
+    return 0.5 * (points[edge[0]] + points[edge[1]])
+
+
+def changed_edges(
+    before: Snapshot,
+    after: Snapshot,
+) -> tuple[tuple[tuple[str, str], ...], tuple[tuple[str, str], ...]]:
+    before_edges = set(unique_edges(before.tets))
+    after_edges = set(unique_edges(after.tets))
+    removed_edges = tuple(sorted(before_edges - after_edges))
+    added_edges = tuple(sorted(after_edges - before_edges))
+    return removed_edges, added_edges
+
+
+def max_position_delta(
+    before_points: dict[str, np.ndarray],
+    after_points: dict[str, np.ndarray],
+) -> float:
+    shared_labels = sorted(set(before_points) & set(after_points))
+    return max(
+        float(np.linalg.norm(after_points[label] - before_points[label]))
+        for label in shared_labels
+    )
+
+
+def moved_vertex_labels(
+    before_points: dict[str, np.ndarray],
+    after_points: dict[str, np.ndarray],
+    tol: float = 1.0e-12,
+) -> tuple[str, ...]:
+    shared_labels = sorted(set(before_points) & set(after_points))
+    return tuple(
+        label
+        for label in shared_labels
+        if np.linalg.norm(after_points[label] - before_points[label]) > tol
+    )
+
+
+def retopologized_snapshot(
+    step: int,
+    name: str,
+    points: dict[str, np.ndarray],
+    selected_label: str,
+) -> tuple[Snapshot, Complex]:
+    """Build HC from positions only, then let ddgclib Delaunay-connect it."""
+    hc, _ = build_hc(points, [])
+    _retopologize(hc, set(), 3)
+    tets = tetrahedra_from_hc_cliques(hc, points)
+    if not tets:
+        raise RuntimeError(f"retopology produced no tetrahedra for {name}")
+    snapshot = summarize_snapshot(step, name, hc, points, tets, selected_label)
+    return snapshot, hc
+
+
+def draw_edge_highlight(
+    ax,
+    points: dict[str, np.ndarray],
+    edge: tuple[str, str],
+    *,
+    color: str,
+    label: str,
+) -> None:
+    p0 = points[edge[0]]
+    p1 = points[edge[1]]
+    ax.plot(
+        [p0[0], p1[0]],
+        [p0[1], p1[1]],
+        [p0[2], p1[2]],
+        color=color,
+        linewidth=3.0,
+        alpha=0.95,
+    )
+    midpoint = edge_midpoint(points, edge)
+    ax.text(
+        *(midpoint + np.array([0.016, 0.016, 0.016])),
+        label,
+        color=color,
+        fontsize=8,
+        weight="bold",
+    )
+
+
+def draw_connectivity_change_arrow(
+    ax,
+    points: dict[str, np.ndarray],
+    removed_edges: tuple[tuple[str, str], ...],
+    added_edges: tuple[tuple[str, str], ...],
+) -> None:
+    if not removed_edges or not added_edges:
+        return
+    start = edge_midpoint(points, removed_edges[0])
+    end = edge_midpoint(points, added_edges[0])
+    delta = end - start
+    ax.quiver(
+        start[0],
+        start[1],
+        start[2],
+        delta[0],
+        delta[1],
+        delta[2],
+        color=CHANGE_ARROW_COLOR,
+        linewidth=2.2,
+        arrow_length_ratio=0.25,
+        alpha=0.95,
+    )
+
+
+def draw_motion_arrows(
+    ax,
+    before_points: dict[str, np.ndarray],
+    after_points: dict[str, np.ndarray],
+    moved_vertices: Iterable[str],
+) -> None:
+    for label in moved_vertices:
+        start = before_points[label]
+        end = after_points[label]
+        delta = end - start
+        ax.quiver(
+            start[0],
+            start[1],
+            start[2],
+            delta[0],
+            delta[1],
+            delta[2],
+            color=MOVED_VERTEX_COLOR,
+            linewidth=2.6,
+            arrow_length_ratio=0.35,
+            alpha=0.98,
+        )
+        ax.text(
+            *(end + np.array([0.014, -0.018, 0.014])),
+            f"moved {label}",
+            color=MOVED_VERTEX_COLOR,
+            fontsize=8,
+            weight="bold",
+        )
+
+
+def set_axes_equal(ax) -> None:
+    x_limits = ax.get_xlim3d()
+    y_limits = ax.get_ylim3d()
+    z_limits = ax.get_zlim3d()
+    ranges = np.array(
+        [
+            abs(x_limits[1] - x_limits[0]),
+            abs(y_limits[1] - y_limits[0]),
+            abs(z_limits[1] - z_limits[0]),
+        ]
+    )
+    centers = np.array(
+        [
+            np.mean(x_limits),
+            np.mean(y_limits),
+            np.mean(z_limits),
+        ]
+    )
+    radius = 0.5 * max(ranges)
+    ax.set_xlim3d([centers[0] - radius, centers[0] + radius])
+    ax.set_ylim3d([centers[1] - radius, centers[1] + radius])
+    ax.set_zlim3d([centers[2] - radius, centers[2] + radius])
+
+
+def draw_interface_sphere(ax) -> None:
+    y = np.linspace(-0.46, 0.46, 25)
+    z = np.linspace(-0.36, 0.36, 25)
+    yy, zz = np.meshgrid(y, z)
+    xx2 = SPHERE_RADIUS * SPHERE_RADIUS - yy * yy - zz * zz
+    xx = np.sqrt(np.clip(xx2, 0.0, None))
+    ax.plot_wireframe(
+        xx,
+        yy,
+        zz,
+        rstride=4,
+        cstride=4,
+        color=INTERFACE_COLOR,
+        linewidth=0.45,
+        alpha=0.30,
+    )
+
+
+def plot_snapshot(
+    ax,
+    points: dict[str, np.ndarray],
+    snapshot: Snapshot,
+    selected_label: str,
+    moved_vertices: Iterable[str] = (),
+) -> None:
+    draw_interface_sphere(ax)
+    moved_vertex_set = set(moved_vertices)
+
+    for tet in snapshot.tets:
+        small_tets = selected_dual_simplex_vertices(points, tet.labels, selected_label)
+        if not small_tets:
+            continue
+        faces = []
+        for small_tet in small_tets:
+            faces.extend(tetra_faces(small_tet))
+        color = LIQUID_COLOR if tet.phase == "liquid" else AIR_COLOR
+        alpha = 0.54 if tet.phase == "liquid" else 0.36
+        collection = Poly3DCollection(
+            faces,
+            facecolor=color,
+            edgecolor=color,
+            linewidth=0.25,
+            alpha=alpha,
+        )
+        ax.add_collection3d(collection)
+
+    edge_segments = [
+        [points[a_label], points[b_label]]
+        for a_label, b_label in unique_edges(snapshot.tets)
+    ]
+    ax.add_collection3d(
+        Line3DCollection(edge_segments, colors=EDGE_COLOR, linewidths=0.9, alpha=0.72)
+    )
+
+    for label, coord in points.items():
+        if label in moved_vertex_set:
+            ax.scatter(
+                *coord,
+                color=MOVED_VERTEX_COLOR,
+                marker="D",
+                s=72,
+                depthshade=False,
+            )
+        elif label == selected_label:
+            ax.scatter(*coord, color=SELECTED_COLOR, s=54, depthshade=False)
+        elif label in {"air", "liq"}:
+            color = AIR_COLOR if label == "air" else LIQUID_COLOR
+            ax.scatter(*coord, color=color, s=40, depthshade=False)
+        else:
+            ax.scatter(*coord, color=INTERFACE_COLOR, s=28, depthshade=False)
+        text_color = MOVED_VERTEX_COLOR if label in moved_vertex_set else "black"
+        text = f"{label}*" if label in moved_vertex_set else label
+        ax.text(
+            *(coord + np.array([0.012, 0.012, 0.012])),
+            text,
+            fontsize=8,
+            color=text_color,
+            weight="bold" if label in moved_vertex_set else "normal",
+        )
+
+    ax.set_title(
+        f"step {snapshot.step}: {snapshot.name}\n"
+        f"selected {selected_label} liquid dual volume = "
+        f"{snapshot.liquid_dual_volume:.9e}",
+        fontsize=10,
+    )
+    ax.set_xlabel("x")
+    ax.set_ylabel("y")
+    ax.set_zlabel("z")
+    ax.view_init(elev=22, azim=-62)
+    ax.set_xlim(0.62, 1.32)
+    ax.set_ylim(-0.45, 0.45)
+    ax.set_zlim(-0.36, 0.34)
+    set_axes_equal(ax)
+
+
+def save_snapshot_png(
+    out_dir: Path,
+    points: dict[str, np.ndarray],
+    snapshot: Snapshot,
+    selected_label: str,
+    moved_vertices: Iterable[str] = (),
+) -> Path:
+    fig = plt.figure(figsize=(8.0, 6.6), dpi=180)
+    ax = fig.add_subplot(111, projection="3d")
+    plot_snapshot(ax, points, snapshot, selected_label, moved_vertices)
+    fig.tight_layout()
+    path = out_dir / f"step_{snapshot.step:03d}_{snapshot.name.replace(' ', '_')}.png"
+    fig.savefig(path)
+    plt.close(fig)
+    return path
+
+
+def save_comparison_png(
+    out_dir: Path,
+    before_points: dict[str, np.ndarray],
+    after_points: dict[str, np.ndarray],
+    before: Snapshot,
+    after: Snapshot,
+    selected_label: str,
+    comparison: Comparison,
+) -> Path:
+    fig = plt.figure(figsize=(13.0, 6.2), dpi=180)
+    ax0 = fig.add_subplot(121, projection="3d")
+    ax1 = fig.add_subplot(122, projection="3d")
+    plot_snapshot(ax0, before_points, before, selected_label, comparison.moved_vertices)
+    plot_snapshot(ax1, after_points, after, selected_label, comparison.moved_vertices)
+    for edge in comparison.removed_edges:
+        draw_edge_highlight(
+            ax0,
+            before_points,
+            edge,
+            color=REMOVED_EDGE_COLOR,
+            label=f"removed {'-'.join(edge)}",
+        )
+    for edge in comparison.added_edges:
+        draw_edge_highlight(
+            ax1,
+            after_points,
+            edge,
+            color=ADDED_EDGE_COLOR,
+            label=f"added {'-'.join(edge)}",
+        )
+    draw_connectivity_change_arrow(
+        ax0,
+        before_points,
+        comparison.removed_edges,
+        comparison.added_edges,
+    )
+    draw_connectivity_change_arrow(
+        ax1,
+        after_points,
+        comparison.removed_edges,
+        comparison.added_edges,
+    )
+    draw_motion_arrows(
+        ax0,
+        before_points,
+        after_points,
+        comparison.moved_vertices,
+    )
+    draw_motion_arrows(
+        ax1,
+        before_points,
+        after_points,
+        comparison.moved_vertices,
+    )
+    if comparison.removed_edges and comparison.added_edges:
+        connectivity_text = (
+            f", connectivity: {'-'.join(comparison.removed_edges[0])} "
+            f"-> {'-'.join(comparison.added_edges[0])}"
+        )
+    else:
+        connectivity_text = ""
+    fig.suptitle(
+        "Delta liquid dual volume: "
+        f"{comparison.delta_liquid_volume:.9e} "
+        f"({comparison.delta_liquid_percent:+.3f}%), "
+        f"tetrahedra: {len(before.tets)} -> {len(after.tets)}, "
+        f"moved: {','.join(comparison.moved_vertices)}, "
+        "max vertex position delta: "
+        f"{comparison.max_vertex_position_delta:.3e}"
+        f"{connectivity_text}",
+        fontsize=10,
+    )
+    fig.tight_layout()
+    path = out_dir / "before_after_comparison.png"
+    fig.savefig(path)
+    plt.close(fig)
+    return path
+
+
+def rgba_hex(hex_color: str, alpha: float) -> str:
+    hex_color = hex_color.lstrip("#")
+    r = int(hex_color[0:2], 16)
+    g = int(hex_color[2:4], 16)
+    b = int(hex_color[4:6], 16)
+    return f"rgba({r},{g},{b},{alpha})"
+
+
+def add_plotly_sphere(fig, row: int, col: int) -> None:
+    y_values = np.linspace(-0.46, 0.46, 9)
+    z_values = np.linspace(-0.36, 0.36, 9)
+    for y in y_values:
+        z = np.linspace(-0.36, 0.36, 60)
+        x = np.sqrt(np.clip(SPHERE_RADIUS * SPHERE_RADIUS - y * y - z * z, 0.0, None))
+        fig.add_trace(
+            go.Scatter3d(
+                x=x,
+                y=np.full_like(x, y),
+                z=z,
+                mode="lines",
+                line=dict(color=rgba_hex(INTERFACE_COLOR, 0.25), width=1),
+                hoverinfo="skip",
+                showlegend=False,
+            ),
+            row=row,
+            col=col,
+        )
+    for z in z_values:
+        y = np.linspace(-0.46, 0.46, 60)
+        x = np.sqrt(np.clip(SPHERE_RADIUS * SPHERE_RADIUS - y * y - z * z, 0.0, None))
+        fig.add_trace(
+            go.Scatter3d(
+                x=x,
+                y=y,
+                z=np.full_like(x, z),
+                mode="lines",
+                line=dict(color=rgba_hex(INTERFACE_COLOR, 0.25), width=1),
+                hoverinfo="skip",
+                showlegend=False,
+            ),
+            row=row,
+            col=col,
+        )
+
+
+def add_plotly_dual_mesh(
+    fig,
+    points: dict[str, np.ndarray],
+    snapshot: Snapshot,
+    selected_label: str,
+    row: int,
+    col: int,
+) -> None:
+    for tet in snapshot.tets:
+        small_tets = selected_dual_simplex_vertices(points, tet.labels, selected_label)
+        if not small_tets:
+            continue
+        xs: list[float] = []
+        ys: list[float] = []
+        zs: list[float] = []
+        i_faces: list[int] = []
+        j_faces: list[int] = []
+        k_faces: list[int] = []
+        for small_tet in small_tets:
+            for face in tetra_faces(small_tet):
+                idx0 = len(xs)
+                for coord in face:
+                    xs.append(float(coord[0]))
+                    ys.append(float(coord[1]))
+                    zs.append(float(coord[2]))
+                i_faces.append(idx0)
+                j_faces.append(idx0 + 1)
+                k_faces.append(idx0 + 2)
+        color = LIQUID_COLOR if tet.phase == "liquid" else AIR_COLOR
+        fig.add_trace(
+            go.Mesh3d(
+                x=xs,
+                y=ys,
+                z=zs,
+                i=i_faces,
+                j=j_faces,
+                k=k_faces,
+                color=color,
+                opacity=0.50 if tet.phase == "liquid" else 0.32,
+                name=f"{snapshot.name} {tet.name} {tet.phase}",
+                hovertemplate=(
+                    f"{tet.name} {tet.phase}<br>"
+                    f"tet: {'-'.join(tet.labels)}<br>"
+                    "<extra></extra>"
+                ),
+                showlegend=False,
+            ),
+            row=row,
+            col=col,
+        )
+
+
+def add_plotly_edges(
+    fig,
+    points: dict[str, np.ndarray],
+    edges: Iterable[tuple[str, str]],
+    row: int,
+    col: int,
+    *,
+    color: str,
+    width: float,
+    name: str,
+    showlegend: bool,
+) -> None:
+    xs: list[float | None] = []
+    ys: list[float | None] = []
+    zs: list[float | None] = []
+    hover: list[str | None] = []
+    for edge in edges:
+        p0 = points[edge[0]]
+        p1 = points[edge[1]]
+        xs.extend([float(p0[0]), float(p1[0]), None])
+        ys.extend([float(p0[1]), float(p1[1]), None])
+        zs.extend([float(p0[2]), float(p1[2]), None])
+        hover.extend([f"{edge[0]}-{edge[1]}", f"{edge[0]}-{edge[1]}", None])
+    if not xs:
+        return
+    fig.add_trace(
+        go.Scatter3d(
+            x=xs,
+            y=ys,
+            z=zs,
+            mode="lines",
+            line=dict(color=color, width=width),
+            name=name,
+            text=hover,
+            hovertemplate="%{text}<extra></extra>",
+            showlegend=showlegend,
+        ),
+        row=row,
+        col=col,
+    )
+
+
+def add_plotly_points(
+    fig,
+    points: dict[str, np.ndarray],
+    selected_label: str,
+    row: int,
+    col: int,
+    *,
+    showlegend: bool,
+    moved_vertices: Iterable[str] = (),
+) -> None:
+    labels = list(points.keys())
+    coords = np.array([points[label] for label in labels])
+    moved_vertex_set = set(moved_vertices)
+    colors = []
+    sizes = []
+    symbols = []
+    for label in labels:
+        if label in moved_vertex_set:
+            colors.append(MOVED_VERTEX_COLOR)
+            sizes.append(8)
+            symbols.append("diamond")
+        elif label == selected_label:
+            colors.append(SELECTED_COLOR)
+            sizes.append(7)
+            symbols.append("circle")
+        elif label == "liq":
+            colors.append(LIQUID_COLOR)
+            sizes.append(6)
+            symbols.append("circle")
+        elif label == "air":
+            colors.append(AIR_COLOR)
+            sizes.append(6)
+            symbols.append("circle")
+        else:
+            colors.append(INTERFACE_COLOR)
+            sizes.append(5)
+            symbols.append("circle")
+    display_labels = [
+        f"{label}*" if label in moved_vertex_set else label for label in labels
+    ]
+    fig.add_trace(
+        go.Scatter3d(
+            x=coords[:, 0],
+            y=coords[:, 1],
+            z=coords[:, 2],
+            mode="markers+text",
+            marker=dict(color=colors, size=sizes, symbol=symbols),
+            text=display_labels,
+            textposition="top center",
+            name="vertices",
+            hovertext=labels,
+            hovertemplate="%{hovertext}<br>x=%{x:.4f}<br>y=%{y:.4f}<br>z=%{z:.4f}<extra></extra>",
+            showlegend=showlegend,
+        ),
+        row=row,
+        col=col,
+    )
+
+
+def add_plotly_motion_arrows(
+    fig,
+    before_points: dict[str, np.ndarray],
+    after_points: dict[str, np.ndarray],
+    moved_vertices: Iterable[str],
+    row: int,
+    col: int,
+    *,
+    showlegend: bool,
+) -> None:
+    for label in moved_vertices:
+        start = before_points[label]
+        end = after_points[label]
+        delta = end - start
+        fig.add_trace(
+            go.Scatter3d(
+                x=[start[0], end[0]],
+                y=[start[1], end[1]],
+                z=[start[2], end[2]],
+                mode="lines",
+                line=dict(color=MOVED_VERTEX_COLOR, width=7),
+                name="moved vertex",
+                hovertemplate=f"moved {label}<extra></extra>",
+                showlegend=showlegend,
+            ),
+            row=row,
+            col=col,
+        )
+        fig.add_trace(
+            go.Cone(
+                x=[end[0]],
+                y=[end[1]],
+                z=[end[2]],
+                u=[delta[0]],
+                v=[delta[1]],
+                w=[delta[2]],
+                sizemode="absolute",
+                sizeref=0.045,
+                anchor="tip",
+                colorscale=[[0.0, MOVED_VERTEX_COLOR], [1.0, MOVED_VERTEX_COLOR]],
+                showscale=False,
+                name="moved vertex arrow head",
+                hoverinfo="skip",
+                showlegend=False,
+            ),
+            row=row,
+            col=col,
+        )
+
+
+def add_plotly_change_arrow(
+    fig,
+    points: dict[str, np.ndarray],
+    comparison: Comparison,
+    row: int,
+    col: int,
+    *,
+    showlegend: bool,
+) -> None:
+    if not comparison.removed_edges or not comparison.added_edges:
+        return
+    start = edge_midpoint(points, comparison.removed_edges[0])
+    end = edge_midpoint(points, comparison.added_edges[0])
+    delta = end - start
+    fig.add_trace(
+        go.Scatter3d(
+            x=[start[0], end[0]],
+            y=[start[1], end[1]],
+            z=[start[2], end[2]],
+            mode="lines",
+            line=dict(color=CHANGE_ARROW_COLOR, width=6),
+            name="connectivity arrow",
+            hovertemplate=(
+                f"{'-'.join(comparison.removed_edges[0])} -> "
+                f"{'-'.join(comparison.added_edges[0])}<extra></extra>"
+            ),
+            showlegend=showlegend,
+        ),
+        row=row,
+        col=col,
+    )
+    fig.add_trace(
+        go.Cone(
+            x=[end[0]],
+            y=[end[1]],
+            z=[end[2]],
+            u=[delta[0]],
+            v=[delta[1]],
+            w=[delta[2]],
+            sizemode="absolute",
+            sizeref=0.055,
+            anchor="tip",
+            colorscale=[[0.0, CHANGE_ARROW_COLOR], [1.0, CHANGE_ARROW_COLOR]],
+            showscale=False,
+            name="arrow head",
+            hoverinfo="skip",
+            showlegend=False,
+        ),
+        row=row,
+        col=col,
+    )
+
+
+def add_plotly_snapshot(
+    fig,
+    points: dict[str, np.ndarray],
+    snapshot: Snapshot,
+    selected_label: str,
+    comparison: Comparison,
+    row: int,
+    col: int,
+) -> None:
+    add_plotly_sphere(fig, row, col)
+    add_plotly_dual_mesh(fig, points, snapshot, selected_label, row, col)
+    add_plotly_edges(
+        fig,
+        points,
+        unique_edges(snapshot.tets),
+        row,
+        col,
+        color=EDGE_COLOR,
+        width=3,
+        name="HC edges",
+        showlegend=col == 1,
+    )
+    if snapshot.step == 0:
+        add_plotly_edges(
+            fig,
+            points,
+            comparison.removed_edges,
+            row,
+            col,
+            color=REMOVED_EDGE_COLOR,
+            width=8,
+            name="removed edge",
+            showlegend=True,
+        )
+    else:
+        add_plotly_edges(
+            fig,
+            points,
+            comparison.added_edges,
+            row,
+            col,
+            color=ADDED_EDGE_COLOR,
+            width=8,
+            name="added edge",
+            showlegend=True,
+    )
+    add_plotly_change_arrow(fig, points, comparison, row, col, showlegend=col == 1)
+    add_plotly_points(
+        fig,
+        points,
+        selected_label,
+        row,
+        col,
+        showlegend=col == 1,
+        moved_vertices=comparison.moved_vertices,
+    )
+
+
+def save_interactive_html(
+    out_dir: Path,
+    before_points: dict[str, np.ndarray],
+    after_points: dict[str, np.ndarray],
+    before: Snapshot,
+    after: Snapshot,
+    selected_label: str,
+    comparison: Comparison,
+) -> Path:
+    fig = make_subplots(
+        rows=1,
+        cols=2,
+        specs=[[{"type": "scene"}, {"type": "scene"}]],
+        subplot_titles=(
+            f"step 0 before, V_liquid={before.liquid_dual_volume:.9e}",
+            f"step 1 after, V_liquid={after.liquid_dual_volume:.9e}",
+        ),
+        horizontal_spacing=0.02,
+    )
+    add_plotly_snapshot(fig, before_points, before, selected_label, comparison, 1, 1)
+    add_plotly_snapshot(fig, after_points, after, selected_label, comparison, 1, 2)
+    add_plotly_motion_arrows(
+        fig,
+        before_points,
+        after_points,
+        comparison.moved_vertices,
+        1,
+        1,
+        showlegend=True,
+    )
+    add_plotly_motion_arrows(
+        fig,
+        before_points,
+        after_points,
+        comparison.moved_vertices,
+        1,
+        2,
+        showlegend=False,
+    )
+
+    scene_settings = dict(
+        xaxis=dict(title="x", range=[0.62, 1.32]),
+        yaxis=dict(title="y", range=[-0.45, 0.45]),
+        zaxis=dict(title="z", range=[-0.36, 0.34]),
+        aspectmode="cube",
+        camera=dict(eye=dict(x=1.35, y=-1.65, z=1.0)),
+    )
+    if comparison.removed_edges and comparison.added_edges:
+        connectivity_text = (
+            f", connectivity {'-'.join(comparison.removed_edges[0])} -> "
+            f"{'-'.join(comparison.added_edges[0])}"
+        )
+    else:
+        connectivity_text = ""
+    fig.update_layout(
+        title=(
+            "Delaunay-valid HC retriangulation: "
+            f"{len(before.tets)} -> {len(after.tets)} tetrahedra, "
+            f"Delta={comparison.delta_liquid_volume:.9e} "
+            f"({comparison.delta_liquid_percent:+.3f}%)"
+            f"{connectivity_text}, "
+            f"moved {','.join(comparison.moved_vertices)}, "
+            f"max position delta={comparison.max_vertex_position_delta:.3e}"
+        ),
+        scene=scene_settings,
+        scene2=scene_settings,
+        legend=dict(orientation="h", yanchor="bottom", y=0.0, xanchor="left", x=0.01),
+        margin=dict(l=0, r=0, t=72, b=0),
+        height=760,
+    )
+    path = out_dir / "before_after_interactive.html"
+    sync_script = """
+(function() {
+  const gd = document.getElementById('{plot_id}');
+  let syncing = false;
+
+  function hasCameraUpdate(sceneName, eventData) {
+    const cameraKey = sceneName + '.camera';
+    const cameraPrefix = cameraKey + '.';
+    return Object.keys(eventData).some(function(key) {
+      return key === cameraKey || key.startsWith(cameraPrefix);
+    });
+  }
+
+  function cloneCamera(camera) {
+    return JSON.parse(JSON.stringify(camera || {}));
+  }
+
+  function cameraFromEvent(sceneName, eventData) {
+    const cameraKey = sceneName + '.camera';
+    const cameraPrefix = cameraKey + '.';
+    if (eventData[cameraKey]) {
+      return cloneCamera(eventData[cameraKey]);
+    }
+
+    const camera = cloneCamera((gd.layout[sceneName] || {}).camera);
+    Object.keys(eventData).forEach(function(key) {
+      if (!key.startsWith(cameraPrefix)) {
+        return;
+      }
+      const path = key.slice(cameraPrefix.length).split('.');
+      let target = camera;
+      for (let index = 0; index < path.length - 1; index += 1) {
+        target[path[index]] = target[path[index]] || {};
+        target = target[path[index]];
+      }
+      target[path[path.length - 1]] = eventData[key];
+    });
+    return camera;
+  }
+
+  gd.on('plotly_relayout', function(eventData) {
+    if (syncing || !eventData) {
+      return;
+    }
+
+    const update = {};
+    if (hasCameraUpdate('scene', eventData)) {
+      update['scene2.camera'] = cameraFromEvent('scene', eventData);
+    }
+    if (hasCameraUpdate('scene2', eventData)) {
+      update['scene.camera'] = cameraFromEvent('scene2', eventData);
+    }
+    if (!Object.keys(update).length) {
+      return;
+    }
+
+    syncing = true;
+    Plotly.relayout(gd, update).then(function() {
+      syncing = false;
+    }).catch(function() {
+      syncing = false;
+    });
+  });
+
+  window.__fourTetCameraSync = true;
+})();
+"""
+    fig.write_html(
+        str(path),
+        include_plotlyjs=True,
+        full_html=True,
+        post_script=sync_script,
+        config={
+            "scrollZoom": True,
+            "displaylogo": False,
+            "toImageButtonOptions": {"format": "png", "scale": 2},
+        },
+    )
+    return path
+
+
+def write_summary(
+    out_dir: Path,
+    snapshots: list[Snapshot],
+    selected_label: str,
+    comparison: Comparison,
+) -> tuple[Path, Path]:
+    csv_path = out_dir / "liquid_dual_volume_summary.csv"
+    json_path = out_dir / "liquid_dual_volume_summary.json"
+
+    with csv_path.open("w", newline="") as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=[
+                "step",
+                "snapshot",
+                "selected_vertex",
+                "liquid_dual_volume",
+                "air_dual_volume",
+                "total_selected_dual_volume",
+                "delta_liquid_volume_vs_previous",
+                "delta_liquid_percent_vs_previous",
+                "hc_dual_vertices",
+                "incident_tets",
+            ],
+        )
+        writer.writeheader()
+        for snapshot in snapshots:
+            writer.writerow(
+                {
+                    "step": snapshot.step,
+                    "snapshot": snapshot.name,
+                    "selected_vertex": selected_label,
+                    "liquid_dual_volume": f"{snapshot.liquid_dual_volume:.17e}",
+                    "air_dual_volume": f"{snapshot.air_dual_volume:.17e}",
+                    "total_selected_dual_volume": f"{snapshot.total_dual_volume:.17e}",
+                    "delta_liquid_volume_vs_previous": (
+                        f"{comparison.delta_liquid_volume:.17e}"
+                        if snapshot.step == snapshots[-1].step
+                        else ""
+                    ),
+                    "delta_liquid_percent_vs_previous": (
+                        f"{comparison.delta_liquid_percent:.9f}"
+                        if snapshot.step == snapshots[-1].step
+                        else ""
+                    ),
+                    "hc_dual_vertices": snapshot.hc_dual_vertices,
+                    "incident_tets": ";".join(
+                        f"{tet.name}:{tet.phase}:{'-'.join(tet.labels)}"
+                        for tet in snapshot.tets
+                        if selected_label in tet.labels
+                    ),
+                }
+            )
+
+    payload = {
+        "selected_vertex": selected_label,
+        "sphere_center": SPHERE_CENTER.tolist(),
+        "sphere_radius": SPHERE_RADIUS,
+        "method": (
+            "both snapshots use ddgclib dynamic _retopologize, which rebuilds "
+            "HC connectivity with SciPy Delaunay; barycentric HC dual split; "
+            "each incident tetrahedron contributes tet_volume/4 to the "
+            "selected vertex"
+        ),
+        "comparison": {
+            "delta_liquid_volume": comparison.delta_liquid_volume,
+            "delta_liquid_percent": comparison.delta_liquid_percent,
+            "max_vertex_position_delta": comparison.max_vertex_position_delta,
+            "moved_vertices": list(comparison.moved_vertices),
+            "removed_edges": [list(edge) for edge in comparison.removed_edges],
+            "added_edges": [list(edge) for edge in comparison.added_edges],
+            "position_check": (
+                "only vertex e moves between the two timesteps; each timestep "
+                "is then triangulated by the same ddgclib Delaunay retopology rule"
+            ),
+        },
+        "snapshots": [
+            {
+                "step": snapshot.step,
+                "name": snapshot.name,
+                "hc_dual_vertices": snapshot.hc_dual_vertices,
+                "liquid_dual_volume": snapshot.liquid_dual_volume,
+                "air_dual_volume": snapshot.air_dual_volume,
+                "total_selected_dual_volume": snapshot.total_dual_volume,
+                "per_tet": snapshot.per_tet,
+            }
+            for snapshot in snapshots
+        ],
+    }
+    json_path.write_text(json.dumps(payload, indent=2) + "\n")
+    return csv_path, json_path
+
+
+def run(out_dir: Path, selected_label: str) -> dict[str, object]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    before_points = build_before_points()
+    after_points = build_after_points()
+
+    before_snapshot, _ = retopologized_snapshot(
+        0,
+        "before_delaunay_retriangulation",
+        before_points,
+        selected_label,
+    )
+    after_snapshot, _ = retopologized_snapshot(
+        1,
+        "after_delaunay_retriangulation",
+        after_points,
+        selected_label,
+    )
+    removed_edges, added_edges = changed_edges(before_snapshot, after_snapshot)
+    moved_vertices = moved_vertex_labels(before_points, after_points)
+    comparison = Comparison(
+        delta_liquid_volume=after_snapshot.liquid_dual_volume
+        - before_snapshot.liquid_dual_volume,
+        delta_liquid_percent=percent_change(
+            before_snapshot.liquid_dual_volume,
+            after_snapshot.liquid_dual_volume,
+        ),
+        max_vertex_position_delta=max_position_delta(before_points, after_points),
+        removed_edges=removed_edges,
+        added_edges=added_edges,
+        moved_vertices=moved_vertices,
+    )
+
+    before_png = save_snapshot_png(
+        out_dir,
+        before_points,
+        before_snapshot,
+        selected_label,
+        comparison.moved_vertices,
+    )
+    after_png = save_snapshot_png(
+        out_dir,
+        after_points,
+        after_snapshot,
+        selected_label,
+        comparison.moved_vertices,
+    )
+    comparison_png = save_comparison_png(
+        out_dir,
+        before_points,
+        after_points,
+        before_snapshot,
+        after_snapshot,
+        selected_label,
+        comparison,
+    )
+    interactive_html = save_interactive_html(
+        out_dir,
+        before_points,
+        after_points,
+        before_snapshot,
+        after_snapshot,
+        selected_label,
+        comparison,
+    )
+    csv_path, json_path = write_summary(
+        out_dir,
+        [before_snapshot, after_snapshot],
+        selected_label,
+        comparison,
+    )
+
+    return {
+        "before": before_snapshot,
+        "after": after_snapshot,
+        "before_png": before_png,
+        "after_png": after_png,
+        "comparison_png": comparison_png,
+        "interactive_html": interactive_html,
+        "csv": csv_path,
+        "json": json_path,
+        "comparison": comparison,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate the Delaunay-valid HC retriangulation dual-volume demo."
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=DEFAULT_OUT_DIR,
+        help="Output directory for PNG and volume summary files.",
+    )
+    parser.add_argument(
+        "--selected",
+        default=SELECTED_LABEL,
+        choices=list(INTERFACE_LABELS),
+        help="Interface vertex whose barycentric dual volume is shown.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    result = run(args.out_dir, args.selected)
+    before = result["before"]
+    after = result["after"]
+    comparison = result["comparison"]
+
+    print("Delaunay-valid HC retriangulation dual-volume demo")
+    print(f"selected vertex: {args.selected}")
+    print(f"before tetrahedra: {len(before.tets)}")
+    print(f"after  tetrahedra: {len(after.tets)}")
+    print(f"before liquid dual volume: {before.liquid_dual_volume:.17e}")
+    print(f"after  liquid dual volume: {after.liquid_dual_volume:.17e}")
+    print(f"delta liquid dual volume: {comparison.delta_liquid_volume:.17e}")
+    print(f"delta liquid percent: {comparison.delta_liquid_percent:+.9f}%")
+    print(f"moved vertex labels: {comparison.moved_vertices}")
+    print(
+        "connectivity change: removed "
+        f"{comparison.removed_edges}, added {comparison.added_edges}"
+    )
+    print(
+        "max vertex position delta between timesteps: "
+        f"{comparison.max_vertex_position_delta:.17e}"
+    )
+    print(f"before PNG: {result['before_png']}")
+    print(f"after PNG: {result['after_png']}")
+    print(f"comparison PNG: {result['comparison_png']}")
+    print(f"interactive HTML: {result['interactive_html']}")
+    print(f"CSV: {result['csv']}")
+    print(f"JSON: {result['json']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/cases_dynamic/oscillating_droplet_p_ref/scripts/four_tet_retriangulation_dual_volume_demo.py
+++ b/cases_dynamic/oscillating_droplet_p_ref/scripts/four_tet_retriangulation_dual_volume_demo.py
@@ -1,0 +1,1393 @@
+#!/usr/bin/env python3
+"""Delaunay-valid HC retriangulation demo for interface dual volume.
+
+This script builds a minimal two-snapshot case:
+
+* step 0: vertices are triangulated through ddgclib's dynamic-integrator
+  retopology path, which rebuilds the HC connectivity with SciPy Delaunay.
+* step 1: vertices have moved slightly, then the same retopology path is run
+  again. Both snapshots therefore follow the same ddgclib triangulation rule.
+
+The interface vertices lie on a unit sphere.  The selected-vertex liquid dual
+volume is computed from the barycentric HC tetrahedra: each incident tetrahedron
+contributes one quarter of its tetrahedral volume to the selected vertex's
+barycentric dual cell, then those contributions are split by phase.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import itertools
+import json
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DEFAULT_OUT_DIR = SCRIPT_DIR / "out" / "four_tet_retriangulation_dual_volume"
+os.environ.setdefault("MPLCONFIGDIR", str(DEFAULT_OUT_DIR / ".mplconfig"))
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from mpl_toolkits.mplot3d.art3d import Line3DCollection, Poly3DCollection
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
+
+REPO_ROOT = SCRIPT_DIR.parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from hyperct import Complex
+from hyperct.ddg import compute_vd
+
+from ddgclib.dynamic_integrators._integrators_dynamic import _retopologize
+
+
+SPHERE_CENTER = np.zeros(3)
+SPHERE_RADIUS = 1.0
+SELECTED_LABEL = "a"
+
+AIR_COLOR = "#9aa0a6"
+LIQUID_COLOR = "#1f77b4"
+INTERFACE_COLOR = "#2ca25f"
+SELECTED_COLOR = "#c62828"
+EDGE_COLOR = "#222222"
+REMOVED_EDGE_COLOR = "#d62728"
+ADDED_EDGE_COLOR = "#2ca02c"
+CHANGE_ARROW_COLOR = "#8e24aa"
+MOVED_VERTEX_COLOR = "#ff7f0e"
+INTERFACE_LABELS = ("a", "b", "c", "d", "e", "f", "g", "h")
+
+
+@dataclass(frozen=True)
+class TetRecord:
+    name: str
+    phase: str
+    labels: tuple[str, str, str, str]
+
+
+@dataclass
+class Snapshot:
+    step: int
+    name: str
+    tets: list[TetRecord]
+    hc_dual_vertices: int
+    liquid_dual_volume: float
+    air_dual_volume: float
+    total_dual_volume: float
+    per_tet: list[dict[str, object]]
+
+
+@dataclass(frozen=True)
+class Comparison:
+    delta_liquid_volume: float
+    delta_liquid_percent: float
+    max_vertex_position_delta: float
+    removed_edges: tuple[tuple[str, str], ...]
+    added_edges: tuple[tuple[str, str], ...]
+    moved_vertices: tuple[str, ...]
+
+
+def sphere_point(y: float, z: float) -> np.ndarray:
+    """Point on the positive-x cap of the unit sphere."""
+    x2 = SPHERE_RADIUS * SPHERE_RADIUS - y * y - z * z
+    if x2 <= 0.0:
+        raise ValueError("interface point is outside the requested sphere cap")
+    return np.array([np.sqrt(x2), y, z], dtype=float)
+
+
+def build_before_points() -> dict[str, np.ndarray]:
+    """Local vertices before motion: interface cap, one air, one liquid."""
+    return {
+        "a": np.array([1.0, 0.0, 0.0], dtype=float),
+        "b": sphere_point(0.24000000, 0.20000000),
+        "c": sphere_point(-0.10000000, 0.29000000),
+        "d": sphere_point(0.34000000, -0.08000000),
+        "e": sphere_point(-0.26000000, -0.15000000),
+        "f": sphere_point(0.06000000, -0.33000000),
+        "g": sphere_point(-0.36000000, 0.08000000),
+        "h": sphere_point(0.26000000, 0.34000000),
+        "air": np.array([1.32, 0.04, 0.02], dtype=float),
+        "liq": np.array([0.64, -0.02, -0.02], dtype=float),
+    }
+
+
+def build_after_points() -> dict[str, np.ndarray]:
+    """Local vertices after one point moves, still on the sphere cap."""
+    points = build_before_points()
+    points["e"] = sphere_point(-0.23500000, -0.07500000)
+    return points
+
+
+def connect_tetrahedron(vertices: dict[str, object], labels: Iterable[str]) -> None:
+    tet_vertices = [vertices[label] for label in labels]
+    for i, vi in enumerate(tet_vertices):
+        for vj in tet_vertices[i + 1 :]:
+            vi.connect(vj)
+
+
+def build_hc(
+    points: dict[str, np.ndarray],
+    tets: list[TetRecord],
+) -> tuple[Complex, dict[str, object]]:
+    hc = Complex(
+        3,
+        domain=[
+            (0.55, 1.35),
+            (-0.50, 0.50),
+            (-0.40, 0.40),
+        ],
+    )
+    vertices = {label: hc.V[tuple(coord)] for label, coord in points.items()}
+    for label, vertex in vertices.items():
+        vertex.label = label
+        vertex.u = np.zeros(3)
+        vertex.p = 0.0
+        vertex.m = 1.0
+        vertex.is_interface = label in INTERFACE_LABELS
+        if vertex.is_interface:
+            vertex.phase = "interface"
+        else:
+            vertex.phase = "liquid" if label == "liq" else "air"
+
+    for tet in tets:
+        connect_tetrahedron(vertices, tet.labels)
+    return hc, vertices
+
+
+def compute_hc_duals(hc: Complex) -> int:
+    """Populate HC barycentric dual data for the current connectivity."""
+    boundary_vertices = hc.boundary()
+    for vertex in hc.V:
+        vertex.boundary = vertex in boundary_vertices
+    with np.errstate(invalid="ignore", divide="ignore"):
+        compute_vd(hc, method="barycentric")
+    return len(hc.Vd)
+
+
+def tet_volume(points: dict[str, np.ndarray], labels: tuple[str, str, str, str]) -> float:
+    p0, p1, p2, p3 = (points[label] for label in labels)
+    mat = np.vstack((p1 - p0, p2 - p0, p3 - p0))
+    return abs(float(np.linalg.det(mat))) / 6.0
+
+
+def percent_change(before: float, after: float) -> float:
+    if abs(before) < 1e-30:
+        return float("nan")
+    return 100.0 * (after - before) / before
+
+
+def phase_from_tet(points: dict[str, np.ndarray], labels: tuple[str, str, str, str]) -> str:
+    if "liq" in labels and "air" not in labels:
+        return "liquid"
+    if "air" in labels and "liq" not in labels:
+        return "air"
+    centroid = np.mean([points[label] for label in labels], axis=0)
+    r = np.linalg.norm(centroid - SPHERE_CENTER)
+    return "liquid" if r <= SPHERE_RADIUS else "air"
+
+
+def tetrahedra_from_hc_cliques(
+    hc: Complex,
+    points: dict[str, np.ndarray],
+) -> list[TetRecord]:
+    """Recover tetrahedra as 4-cliques in the current HC connectivity graph."""
+    clique_labels: list[tuple[str, str, str, str]] = []
+    for vertices in itertools.combinations(list(hc.V), 4):
+        is_tetrahedron = all(
+            vj in vi.nn for vi, vj in itertools.combinations(vertices, 2)
+        )
+        if is_tetrahedron:
+            clique_labels.append(tuple(sorted(vertex.label for vertex in vertices)))
+
+    clique_labels = sorted(set(clique_labels))
+    records: list[TetRecord] = []
+    for index, tet_labels in enumerate(clique_labels):
+        phase = phase_from_tet(points, tet_labels)
+        records.append(TetRecord(f"T{index:02d}", phase, tet_labels))
+    return records
+
+
+def selected_dual_simplex_vertices(
+    points: dict[str, np.ndarray],
+    tet_labels: tuple[str, str, str, str],
+    selected_label: str,
+) -> list[np.ndarray]:
+    """Barycentric subdivision tets belonging to one selected primal vertex."""
+    if selected_label not in tet_labels:
+        return []
+
+    selected = points[selected_label]
+    others = [label for label in tet_labels if label != selected_label]
+    tet_centroid = np.mean([points[label] for label in tet_labels], axis=0)
+
+    small_tets = []
+    for order in itertools.permutations(others):
+        p1 = 0.5 * (selected + points[order[0]])
+        p2 = (selected + points[order[0]] + points[order[1]]) / 3.0
+        small_tets.append(np.array([selected, p1, p2, tet_centroid], dtype=float))
+    return small_tets
+
+
+def summarize_snapshot(
+    step: int,
+    name: str,
+    hc: Complex,
+    points: dict[str, np.ndarray],
+    tets: list[TetRecord],
+    selected_label: str,
+) -> Snapshot:
+    hc_dual_vertices = compute_hc_duals(hc)
+
+    per_tet = []
+    liquid_dual_volume = 0.0
+    air_dual_volume = 0.0
+    for tet in tets:
+        full_volume = tet_volume(points, tet.labels)
+        selected_volume = full_volume / 4.0 if selected_label in tet.labels else 0.0
+        if tet.phase == "liquid":
+            liquid_dual_volume += selected_volume
+        elif tet.phase == "air":
+            air_dual_volume += selected_volume
+        per_tet.append(
+            {
+                "name": tet.name,
+                "phase": tet.phase,
+                "labels": list(tet.labels),
+                "tet_volume": full_volume,
+                "selected_dual_volume": selected_volume,
+            }
+        )
+
+    return Snapshot(
+        step=step,
+        name=name,
+        tets=tets,
+        hc_dual_vertices=hc_dual_vertices,
+        liquid_dual_volume=liquid_dual_volume,
+        air_dual_volume=air_dual_volume,
+        total_dual_volume=liquid_dual_volume + air_dual_volume,
+        per_tet=per_tet,
+    )
+
+
+def tetra_faces(vertices: np.ndarray) -> list[np.ndarray]:
+    return [
+        vertices[[0, 1, 2]],
+        vertices[[0, 1, 3]],
+        vertices[[0, 2, 3]],
+        vertices[[1, 2, 3]],
+    ]
+
+
+def unique_edges(tets: list[TetRecord]) -> list[tuple[str, str]]:
+    edges: set[tuple[str, str]] = set()
+    for tet in tets:
+        for a_label, b_label in itertools.combinations(tet.labels, 2):
+            edges.add(tuple(sorted((a_label, b_label))))
+    return sorted(edges)
+
+
+def edge_midpoint(points: dict[str, np.ndarray], edge: tuple[str, str]) -> np.ndarray:
+    return 0.5 * (points[edge[0]] + points[edge[1]])
+
+
+def changed_edges(
+    before: Snapshot,
+    after: Snapshot,
+) -> tuple[tuple[tuple[str, str], ...], tuple[tuple[str, str], ...]]:
+    before_edges = set(unique_edges(before.tets))
+    after_edges = set(unique_edges(after.tets))
+    removed_edges = tuple(sorted(before_edges - after_edges))
+    added_edges = tuple(sorted(after_edges - before_edges))
+    return removed_edges, added_edges
+
+
+def max_position_delta(
+    before_points: dict[str, np.ndarray],
+    after_points: dict[str, np.ndarray],
+) -> float:
+    shared_labels = sorted(set(before_points) & set(after_points))
+    return max(
+        float(np.linalg.norm(after_points[label] - before_points[label]))
+        for label in shared_labels
+    )
+
+
+def moved_vertex_labels(
+    before_points: dict[str, np.ndarray],
+    after_points: dict[str, np.ndarray],
+    tol: float = 1.0e-12,
+) -> tuple[str, ...]:
+    shared_labels = sorted(set(before_points) & set(after_points))
+    return tuple(
+        label
+        for label in shared_labels
+        if np.linalg.norm(after_points[label] - before_points[label]) > tol
+    )
+
+
+def retopologized_snapshot(
+    step: int,
+    name: str,
+    points: dict[str, np.ndarray],
+    selected_label: str,
+) -> tuple[Snapshot, Complex]:
+    """Build HC from positions only, then let ddgclib Delaunay-connect it."""
+    hc, _ = build_hc(points, [])
+    _retopologize(hc, set(), 3)
+    tets = tetrahedra_from_hc_cliques(hc, points)
+    if not tets:
+        raise RuntimeError(f"retopology produced no tetrahedra for {name}")
+    snapshot = summarize_snapshot(step, name, hc, points, tets, selected_label)
+    return snapshot, hc
+
+
+def draw_edge_highlight(
+    ax,
+    points: dict[str, np.ndarray],
+    edge: tuple[str, str],
+    *,
+    color: str,
+    label: str,
+) -> None:
+    p0 = points[edge[0]]
+    p1 = points[edge[1]]
+    ax.plot(
+        [p0[0], p1[0]],
+        [p0[1], p1[1]],
+        [p0[2], p1[2]],
+        color=color,
+        linewidth=3.0,
+        alpha=0.95,
+    )
+    midpoint = edge_midpoint(points, edge)
+    ax.text(
+        *(midpoint + np.array([0.016, 0.016, 0.016])),
+        label,
+        color=color,
+        fontsize=8,
+        weight="bold",
+    )
+
+
+def draw_connectivity_change_arrow(
+    ax,
+    points: dict[str, np.ndarray],
+    removed_edges: tuple[tuple[str, str], ...],
+    added_edges: tuple[tuple[str, str], ...],
+) -> None:
+    if not removed_edges or not added_edges:
+        return
+    start = edge_midpoint(points, removed_edges[0])
+    end = edge_midpoint(points, added_edges[0])
+    delta = end - start
+    ax.quiver(
+        start[0],
+        start[1],
+        start[2],
+        delta[0],
+        delta[1],
+        delta[2],
+        color=CHANGE_ARROW_COLOR,
+        linewidth=2.2,
+        arrow_length_ratio=0.25,
+        alpha=0.95,
+    )
+
+
+def draw_motion_arrows(
+    ax,
+    before_points: dict[str, np.ndarray],
+    after_points: dict[str, np.ndarray],
+    moved_vertices: Iterable[str],
+) -> None:
+    for label in moved_vertices:
+        start = before_points[label]
+        end = after_points[label]
+        delta = end - start
+        ax.quiver(
+            start[0],
+            start[1],
+            start[2],
+            delta[0],
+            delta[1],
+            delta[2],
+            color=MOVED_VERTEX_COLOR,
+            linewidth=2.6,
+            arrow_length_ratio=0.35,
+            alpha=0.98,
+        )
+        ax.text(
+            *(end + np.array([0.014, -0.018, 0.014])),
+            f"moved {label}",
+            color=MOVED_VERTEX_COLOR,
+            fontsize=8,
+            weight="bold",
+        )
+
+
+def set_axes_equal(ax) -> None:
+    x_limits = ax.get_xlim3d()
+    y_limits = ax.get_ylim3d()
+    z_limits = ax.get_zlim3d()
+    ranges = np.array(
+        [
+            abs(x_limits[1] - x_limits[0]),
+            abs(y_limits[1] - y_limits[0]),
+            abs(z_limits[1] - z_limits[0]),
+        ]
+    )
+    centers = np.array(
+        [
+            np.mean(x_limits),
+            np.mean(y_limits),
+            np.mean(z_limits),
+        ]
+    )
+    radius = 0.5 * max(ranges)
+    ax.set_xlim3d([centers[0] - radius, centers[0] + radius])
+    ax.set_ylim3d([centers[1] - radius, centers[1] + radius])
+    ax.set_zlim3d([centers[2] - radius, centers[2] + radius])
+
+
+def draw_interface_sphere(ax) -> None:
+    y = np.linspace(-0.46, 0.46, 25)
+    z = np.linspace(-0.36, 0.36, 25)
+    yy, zz = np.meshgrid(y, z)
+    xx2 = SPHERE_RADIUS * SPHERE_RADIUS - yy * yy - zz * zz
+    xx = np.sqrt(np.clip(xx2, 0.0, None))
+    ax.plot_wireframe(
+        xx,
+        yy,
+        zz,
+        rstride=4,
+        cstride=4,
+        color=INTERFACE_COLOR,
+        linewidth=0.45,
+        alpha=0.30,
+    )
+
+
+def plot_snapshot(
+    ax,
+    points: dict[str, np.ndarray],
+    snapshot: Snapshot,
+    selected_label: str,
+    moved_vertices: Iterable[str] = (),
+) -> None:
+    draw_interface_sphere(ax)
+    moved_vertex_set = set(moved_vertices)
+
+    for tet in snapshot.tets:
+        small_tets = selected_dual_simplex_vertices(points, tet.labels, selected_label)
+        if not small_tets:
+            continue
+        faces = []
+        for small_tet in small_tets:
+            faces.extend(tetra_faces(small_tet))
+        color = LIQUID_COLOR if tet.phase == "liquid" else AIR_COLOR
+        alpha = 0.54 if tet.phase == "liquid" else 0.36
+        collection = Poly3DCollection(
+            faces,
+            facecolor=color,
+            edgecolor=color,
+            linewidth=0.25,
+            alpha=alpha,
+        )
+        ax.add_collection3d(collection)
+
+    edge_segments = [
+        [points[a_label], points[b_label]]
+        for a_label, b_label in unique_edges(snapshot.tets)
+    ]
+    ax.add_collection3d(
+        Line3DCollection(edge_segments, colors=EDGE_COLOR, linewidths=0.9, alpha=0.72)
+    )
+
+    for label, coord in points.items():
+        if label in moved_vertex_set:
+            ax.scatter(
+                *coord,
+                color=MOVED_VERTEX_COLOR,
+                marker="D",
+                s=72,
+                depthshade=False,
+            )
+        elif label == selected_label:
+            ax.scatter(*coord, color=SELECTED_COLOR, s=54, depthshade=False)
+        elif label in {"air", "liq"}:
+            color = AIR_COLOR if label == "air" else LIQUID_COLOR
+            ax.scatter(*coord, color=color, s=40, depthshade=False)
+        else:
+            ax.scatter(*coord, color=INTERFACE_COLOR, s=28, depthshade=False)
+        text_color = MOVED_VERTEX_COLOR if label in moved_vertex_set else "black"
+        text = f"{label}*" if label in moved_vertex_set else label
+        ax.text(
+            *(coord + np.array([0.012, 0.012, 0.012])),
+            text,
+            fontsize=8,
+            color=text_color,
+            weight="bold" if label in moved_vertex_set else "normal",
+        )
+
+    ax.set_title(
+        f"step {snapshot.step}: {snapshot.name}\n"
+        f"selected {selected_label} liquid dual volume = "
+        f"{snapshot.liquid_dual_volume:.9e}",
+        fontsize=10,
+    )
+    ax.set_xlabel("x")
+    ax.set_ylabel("y")
+    ax.set_zlabel("z")
+    ax.view_init(elev=22, azim=-62)
+    ax.set_xlim(0.62, 1.32)
+    ax.set_ylim(-0.45, 0.45)
+    ax.set_zlim(-0.36, 0.34)
+    set_axes_equal(ax)
+
+
+def save_snapshot_png(
+    out_dir: Path,
+    points: dict[str, np.ndarray],
+    snapshot: Snapshot,
+    selected_label: str,
+    moved_vertices: Iterable[str] = (),
+) -> Path:
+    fig = plt.figure(figsize=(8.0, 6.6), dpi=180)
+    ax = fig.add_subplot(111, projection="3d")
+    plot_snapshot(ax, points, snapshot, selected_label, moved_vertices)
+    fig.tight_layout()
+    path = out_dir / f"step_{snapshot.step:03d}_{snapshot.name.replace(' ', '_')}.png"
+    fig.savefig(path)
+    plt.close(fig)
+    return path
+
+
+def save_comparison_png(
+    out_dir: Path,
+    before_points: dict[str, np.ndarray],
+    after_points: dict[str, np.ndarray],
+    before: Snapshot,
+    after: Snapshot,
+    selected_label: str,
+    comparison: Comparison,
+) -> Path:
+    fig = plt.figure(figsize=(13.0, 6.2), dpi=180)
+    ax0 = fig.add_subplot(121, projection="3d")
+    ax1 = fig.add_subplot(122, projection="3d")
+    plot_snapshot(ax0, before_points, before, selected_label, comparison.moved_vertices)
+    plot_snapshot(ax1, after_points, after, selected_label, comparison.moved_vertices)
+    for edge in comparison.removed_edges:
+        draw_edge_highlight(
+            ax0,
+            before_points,
+            edge,
+            color=REMOVED_EDGE_COLOR,
+            label=f"removed {'-'.join(edge)}",
+        )
+    for edge in comparison.added_edges:
+        draw_edge_highlight(
+            ax1,
+            after_points,
+            edge,
+            color=ADDED_EDGE_COLOR,
+            label=f"added {'-'.join(edge)}",
+        )
+    draw_connectivity_change_arrow(
+        ax0,
+        before_points,
+        comparison.removed_edges,
+        comparison.added_edges,
+    )
+    draw_connectivity_change_arrow(
+        ax1,
+        after_points,
+        comparison.removed_edges,
+        comparison.added_edges,
+    )
+    draw_motion_arrows(
+        ax0,
+        before_points,
+        after_points,
+        comparison.moved_vertices,
+    )
+    draw_motion_arrows(
+        ax1,
+        before_points,
+        after_points,
+        comparison.moved_vertices,
+    )
+    if comparison.removed_edges and comparison.added_edges:
+        connectivity_text = (
+            f", connectivity: {'-'.join(comparison.removed_edges[0])} "
+            f"-> {'-'.join(comparison.added_edges[0])}"
+        )
+    else:
+        connectivity_text = ""
+    fig.suptitle(
+        "Delta liquid dual volume: "
+        f"{comparison.delta_liquid_volume:.9e} "
+        f"({comparison.delta_liquid_percent:+.3f}%), "
+        f"tetrahedra: {len(before.tets)} -> {len(after.tets)}, "
+        f"moved: {','.join(comparison.moved_vertices)}, "
+        "max vertex position delta: "
+        f"{comparison.max_vertex_position_delta:.3e}"
+        f"{connectivity_text}",
+        fontsize=10,
+    )
+    fig.tight_layout()
+    path = out_dir / "before_after_comparison.png"
+    fig.savefig(path)
+    plt.close(fig)
+    return path
+
+
+def rgba_hex(hex_color: str, alpha: float) -> str:
+    hex_color = hex_color.lstrip("#")
+    r = int(hex_color[0:2], 16)
+    g = int(hex_color[2:4], 16)
+    b = int(hex_color[4:6], 16)
+    return f"rgba({r},{g},{b},{alpha})"
+
+
+def add_plotly_sphere(fig, row: int, col: int) -> None:
+    y_values = np.linspace(-0.46, 0.46, 9)
+    z_values = np.linspace(-0.36, 0.36, 9)
+    for y in y_values:
+        z = np.linspace(-0.36, 0.36, 60)
+        x = np.sqrt(np.clip(SPHERE_RADIUS * SPHERE_RADIUS - y * y - z * z, 0.0, None))
+        fig.add_trace(
+            go.Scatter3d(
+                x=x,
+                y=np.full_like(x, y),
+                z=z,
+                mode="lines",
+                line=dict(color=rgba_hex(INTERFACE_COLOR, 0.25), width=1),
+                hoverinfo="skip",
+                showlegend=False,
+            ),
+            row=row,
+            col=col,
+        )
+    for z in z_values:
+        y = np.linspace(-0.46, 0.46, 60)
+        x = np.sqrt(np.clip(SPHERE_RADIUS * SPHERE_RADIUS - y * y - z * z, 0.0, None))
+        fig.add_trace(
+            go.Scatter3d(
+                x=x,
+                y=y,
+                z=np.full_like(x, z),
+                mode="lines",
+                line=dict(color=rgba_hex(INTERFACE_COLOR, 0.25), width=1),
+                hoverinfo="skip",
+                showlegend=False,
+            ),
+            row=row,
+            col=col,
+        )
+
+
+def add_plotly_dual_mesh(
+    fig,
+    points: dict[str, np.ndarray],
+    snapshot: Snapshot,
+    selected_label: str,
+    row: int,
+    col: int,
+) -> None:
+    for tet in snapshot.tets:
+        small_tets = selected_dual_simplex_vertices(points, tet.labels, selected_label)
+        if not small_tets:
+            continue
+        xs: list[float] = []
+        ys: list[float] = []
+        zs: list[float] = []
+        i_faces: list[int] = []
+        j_faces: list[int] = []
+        k_faces: list[int] = []
+        for small_tet in small_tets:
+            for face in tetra_faces(small_tet):
+                idx0 = len(xs)
+                for coord in face:
+                    xs.append(float(coord[0]))
+                    ys.append(float(coord[1]))
+                    zs.append(float(coord[2]))
+                i_faces.append(idx0)
+                j_faces.append(idx0 + 1)
+                k_faces.append(idx0 + 2)
+        color = LIQUID_COLOR if tet.phase == "liquid" else AIR_COLOR
+        fig.add_trace(
+            go.Mesh3d(
+                x=xs,
+                y=ys,
+                z=zs,
+                i=i_faces,
+                j=j_faces,
+                k=k_faces,
+                color=color,
+                opacity=0.50 if tet.phase == "liquid" else 0.32,
+                name=f"{snapshot.name} {tet.name} {tet.phase}",
+                hovertemplate=(
+                    f"{tet.name} {tet.phase}<br>"
+                    f"tet: {'-'.join(tet.labels)}<br>"
+                    "<extra></extra>"
+                ),
+                showlegend=False,
+            ),
+            row=row,
+            col=col,
+        )
+
+
+def add_plotly_edges(
+    fig,
+    points: dict[str, np.ndarray],
+    edges: Iterable[tuple[str, str]],
+    row: int,
+    col: int,
+    *,
+    color: str,
+    width: float,
+    name: str,
+    showlegend: bool,
+) -> None:
+    xs: list[float | None] = []
+    ys: list[float | None] = []
+    zs: list[float | None] = []
+    hover: list[str | None] = []
+    for edge in edges:
+        p0 = points[edge[0]]
+        p1 = points[edge[1]]
+        xs.extend([float(p0[0]), float(p1[0]), None])
+        ys.extend([float(p0[1]), float(p1[1]), None])
+        zs.extend([float(p0[2]), float(p1[2]), None])
+        hover.extend([f"{edge[0]}-{edge[1]}", f"{edge[0]}-{edge[1]}", None])
+    if not xs:
+        return
+    fig.add_trace(
+        go.Scatter3d(
+            x=xs,
+            y=ys,
+            z=zs,
+            mode="lines",
+            line=dict(color=color, width=width),
+            name=name,
+            text=hover,
+            hovertemplate="%{text}<extra></extra>",
+            showlegend=showlegend,
+        ),
+        row=row,
+        col=col,
+    )
+
+
+def add_plotly_points(
+    fig,
+    points: dict[str, np.ndarray],
+    selected_label: str,
+    row: int,
+    col: int,
+    *,
+    showlegend: bool,
+    moved_vertices: Iterable[str] = (),
+) -> None:
+    labels = list(points.keys())
+    coords = np.array([points[label] for label in labels])
+    moved_vertex_set = set(moved_vertices)
+    colors = []
+    sizes = []
+    symbols = []
+    for label in labels:
+        if label in moved_vertex_set:
+            colors.append(MOVED_VERTEX_COLOR)
+            sizes.append(8)
+            symbols.append("diamond")
+        elif label == selected_label:
+            colors.append(SELECTED_COLOR)
+            sizes.append(7)
+            symbols.append("circle")
+        elif label == "liq":
+            colors.append(LIQUID_COLOR)
+            sizes.append(6)
+            symbols.append("circle")
+        elif label == "air":
+            colors.append(AIR_COLOR)
+            sizes.append(6)
+            symbols.append("circle")
+        else:
+            colors.append(INTERFACE_COLOR)
+            sizes.append(5)
+            symbols.append("circle")
+    display_labels = [
+        f"{label}*" if label in moved_vertex_set else label for label in labels
+    ]
+    fig.add_trace(
+        go.Scatter3d(
+            x=coords[:, 0],
+            y=coords[:, 1],
+            z=coords[:, 2],
+            mode="markers+text",
+            marker=dict(color=colors, size=sizes, symbol=symbols),
+            text=display_labels,
+            textposition="top center",
+            name="vertices",
+            hovertext=labels,
+            hovertemplate="%{hovertext}<br>x=%{x:.4f}<br>y=%{y:.4f}<br>z=%{z:.4f}<extra></extra>",
+            showlegend=showlegend,
+        ),
+        row=row,
+        col=col,
+    )
+
+
+def add_plotly_motion_arrows(
+    fig,
+    before_points: dict[str, np.ndarray],
+    after_points: dict[str, np.ndarray],
+    moved_vertices: Iterable[str],
+    row: int,
+    col: int,
+    *,
+    showlegend: bool,
+) -> None:
+    for label in moved_vertices:
+        start = before_points[label]
+        end = after_points[label]
+        delta = end - start
+        fig.add_trace(
+            go.Scatter3d(
+                x=[start[0], end[0]],
+                y=[start[1], end[1]],
+                z=[start[2], end[2]],
+                mode="lines",
+                line=dict(color=MOVED_VERTEX_COLOR, width=7),
+                name="moved vertex",
+                hovertemplate=f"moved {label}<extra></extra>",
+                showlegend=showlegend,
+            ),
+            row=row,
+            col=col,
+        )
+        fig.add_trace(
+            go.Cone(
+                x=[end[0]],
+                y=[end[1]],
+                z=[end[2]],
+                u=[delta[0]],
+                v=[delta[1]],
+                w=[delta[2]],
+                sizemode="absolute",
+                sizeref=0.045,
+                anchor="tip",
+                colorscale=[[0.0, MOVED_VERTEX_COLOR], [1.0, MOVED_VERTEX_COLOR]],
+                showscale=False,
+                name="moved vertex arrow head",
+                hoverinfo="skip",
+                showlegend=False,
+            ),
+            row=row,
+            col=col,
+        )
+
+
+def add_plotly_change_arrow(
+    fig,
+    points: dict[str, np.ndarray],
+    comparison: Comparison,
+    row: int,
+    col: int,
+    *,
+    showlegend: bool,
+) -> None:
+    if not comparison.removed_edges or not comparison.added_edges:
+        return
+    start = edge_midpoint(points, comparison.removed_edges[0])
+    end = edge_midpoint(points, comparison.added_edges[0])
+    delta = end - start
+    fig.add_trace(
+        go.Scatter3d(
+            x=[start[0], end[0]],
+            y=[start[1], end[1]],
+            z=[start[2], end[2]],
+            mode="lines",
+            line=dict(color=CHANGE_ARROW_COLOR, width=6),
+            name="connectivity arrow",
+            hovertemplate=(
+                f"{'-'.join(comparison.removed_edges[0])} -> "
+                f"{'-'.join(comparison.added_edges[0])}<extra></extra>"
+            ),
+            showlegend=showlegend,
+        ),
+        row=row,
+        col=col,
+    )
+    fig.add_trace(
+        go.Cone(
+            x=[end[0]],
+            y=[end[1]],
+            z=[end[2]],
+            u=[delta[0]],
+            v=[delta[1]],
+            w=[delta[2]],
+            sizemode="absolute",
+            sizeref=0.055,
+            anchor="tip",
+            colorscale=[[0.0, CHANGE_ARROW_COLOR], [1.0, CHANGE_ARROW_COLOR]],
+            showscale=False,
+            name="arrow head",
+            hoverinfo="skip",
+            showlegend=False,
+        ),
+        row=row,
+        col=col,
+    )
+
+
+def add_plotly_snapshot(
+    fig,
+    points: dict[str, np.ndarray],
+    snapshot: Snapshot,
+    selected_label: str,
+    comparison: Comparison,
+    row: int,
+    col: int,
+) -> None:
+    add_plotly_sphere(fig, row, col)
+    add_plotly_dual_mesh(fig, points, snapshot, selected_label, row, col)
+    add_plotly_edges(
+        fig,
+        points,
+        unique_edges(snapshot.tets),
+        row,
+        col,
+        color=EDGE_COLOR,
+        width=3,
+        name="HC edges",
+        showlegend=col == 1,
+    )
+    if snapshot.step == 0:
+        add_plotly_edges(
+            fig,
+            points,
+            comparison.removed_edges,
+            row,
+            col,
+            color=REMOVED_EDGE_COLOR,
+            width=8,
+            name="removed edge",
+            showlegend=True,
+        )
+    else:
+        add_plotly_edges(
+            fig,
+            points,
+            comparison.added_edges,
+            row,
+            col,
+            color=ADDED_EDGE_COLOR,
+            width=8,
+            name="added edge",
+            showlegend=True,
+    )
+    add_plotly_change_arrow(fig, points, comparison, row, col, showlegend=col == 1)
+    add_plotly_points(
+        fig,
+        points,
+        selected_label,
+        row,
+        col,
+        showlegend=col == 1,
+        moved_vertices=comparison.moved_vertices,
+    )
+
+
+def save_interactive_html(
+    out_dir: Path,
+    before_points: dict[str, np.ndarray],
+    after_points: dict[str, np.ndarray],
+    before: Snapshot,
+    after: Snapshot,
+    selected_label: str,
+    comparison: Comparison,
+) -> Path:
+    fig = make_subplots(
+        rows=1,
+        cols=2,
+        specs=[[{"type": "scene"}, {"type": "scene"}]],
+        subplot_titles=(
+            f"step 0 before, V_liquid={before.liquid_dual_volume:.9e}",
+            f"step 1 after, V_liquid={after.liquid_dual_volume:.9e}",
+        ),
+        horizontal_spacing=0.02,
+    )
+    add_plotly_snapshot(fig, before_points, before, selected_label, comparison, 1, 1)
+    add_plotly_snapshot(fig, after_points, after, selected_label, comparison, 1, 2)
+    add_plotly_motion_arrows(
+        fig,
+        before_points,
+        after_points,
+        comparison.moved_vertices,
+        1,
+        1,
+        showlegend=True,
+    )
+    add_plotly_motion_arrows(
+        fig,
+        before_points,
+        after_points,
+        comparison.moved_vertices,
+        1,
+        2,
+        showlegend=False,
+    )
+
+    scene_settings = dict(
+        xaxis=dict(title="x", range=[0.62, 1.32]),
+        yaxis=dict(title="y", range=[-0.45, 0.45]),
+        zaxis=dict(title="z", range=[-0.36, 0.34]),
+        aspectmode="cube",
+        camera=dict(eye=dict(x=1.35, y=-1.65, z=1.0)),
+    )
+    if comparison.removed_edges and comparison.added_edges:
+        connectivity_text = (
+            f", connectivity {'-'.join(comparison.removed_edges[0])} -> "
+            f"{'-'.join(comparison.added_edges[0])}"
+        )
+    else:
+        connectivity_text = ""
+    fig.update_layout(
+        title=(
+            "Delaunay-valid HC retriangulation: "
+            f"{len(before.tets)} -> {len(after.tets)} tetrahedra, "
+            f"Delta={comparison.delta_liquid_volume:.9e} "
+            f"({comparison.delta_liquid_percent:+.3f}%)"
+            f"{connectivity_text}, "
+            f"moved {','.join(comparison.moved_vertices)}, "
+            f"max position delta={comparison.max_vertex_position_delta:.3e}"
+        ),
+        scene=scene_settings,
+        scene2=scene_settings,
+        legend=dict(orientation="h", yanchor="bottom", y=0.0, xanchor="left", x=0.01),
+        margin=dict(l=0, r=0, t=72, b=0),
+        height=760,
+    )
+    path = out_dir / "before_after_interactive.html"
+    sync_script = """
+(function() {
+  const gd = document.getElementById('{plot_id}');
+  let syncing = false;
+
+  function hasCameraUpdate(sceneName, eventData) {
+    const cameraKey = sceneName + '.camera';
+    const cameraPrefix = cameraKey + '.';
+    return Object.keys(eventData).some(function(key) {
+      return key === cameraKey || key.startsWith(cameraPrefix);
+    });
+  }
+
+  function cloneCamera(camera) {
+    return JSON.parse(JSON.stringify(camera || {}));
+  }
+
+  function cameraFromEvent(sceneName, eventData) {
+    const cameraKey = sceneName + '.camera';
+    const cameraPrefix = cameraKey + '.';
+    if (eventData[cameraKey]) {
+      return cloneCamera(eventData[cameraKey]);
+    }
+
+    const camera = cloneCamera((gd.layout[sceneName] || {}).camera);
+    Object.keys(eventData).forEach(function(key) {
+      if (!key.startsWith(cameraPrefix)) {
+        return;
+      }
+      const path = key.slice(cameraPrefix.length).split('.');
+      let target = camera;
+      for (let index = 0; index < path.length - 1; index += 1) {
+        target[path[index]] = target[path[index]] || {};
+        target = target[path[index]];
+      }
+      target[path[path.length - 1]] = eventData[key];
+    });
+    return camera;
+  }
+
+  gd.on('plotly_relayout', function(eventData) {
+    if (syncing || !eventData) {
+      return;
+    }
+
+    const update = {};
+    if (hasCameraUpdate('scene', eventData)) {
+      update['scene2.camera'] = cameraFromEvent('scene', eventData);
+    }
+    if (hasCameraUpdate('scene2', eventData)) {
+      update['scene.camera'] = cameraFromEvent('scene2', eventData);
+    }
+    if (!Object.keys(update).length) {
+      return;
+    }
+
+    syncing = true;
+    Plotly.relayout(gd, update).then(function() {
+      syncing = false;
+    }).catch(function() {
+      syncing = false;
+    });
+  });
+
+  window.__fourTetCameraSync = true;
+})();
+"""
+    fig.write_html(
+        str(path),
+        include_plotlyjs=True,
+        full_html=True,
+        post_script=sync_script,
+        config={
+            "scrollZoom": True,
+            "displaylogo": False,
+            "toImageButtonOptions": {"format": "png", "scale": 2},
+        },
+    )
+    return path
+
+
+def write_summary(
+    out_dir: Path,
+    snapshots: list[Snapshot],
+    selected_label: str,
+    comparison: Comparison,
+) -> tuple[Path, Path]:
+    csv_path = out_dir / "liquid_dual_volume_summary.csv"
+    json_path = out_dir / "liquid_dual_volume_summary.json"
+
+    with csv_path.open("w", newline="") as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=[
+                "step",
+                "snapshot",
+                "selected_vertex",
+                "liquid_dual_volume",
+                "air_dual_volume",
+                "total_selected_dual_volume",
+                "delta_liquid_volume_vs_previous",
+                "delta_liquid_percent_vs_previous",
+                "hc_dual_vertices",
+                "incident_tets",
+            ],
+        )
+        writer.writeheader()
+        for snapshot in snapshots:
+            writer.writerow(
+                {
+                    "step": snapshot.step,
+                    "snapshot": snapshot.name,
+                    "selected_vertex": selected_label,
+                    "liquid_dual_volume": f"{snapshot.liquid_dual_volume:.17e}",
+                    "air_dual_volume": f"{snapshot.air_dual_volume:.17e}",
+                    "total_selected_dual_volume": f"{snapshot.total_dual_volume:.17e}",
+                    "delta_liquid_volume_vs_previous": (
+                        f"{comparison.delta_liquid_volume:.17e}"
+                        if snapshot.step == snapshots[-1].step
+                        else ""
+                    ),
+                    "delta_liquid_percent_vs_previous": (
+                        f"{comparison.delta_liquid_percent:.9f}"
+                        if snapshot.step == snapshots[-1].step
+                        else ""
+                    ),
+                    "hc_dual_vertices": snapshot.hc_dual_vertices,
+                    "incident_tets": ";".join(
+                        f"{tet.name}:{tet.phase}:{'-'.join(tet.labels)}"
+                        for tet in snapshot.tets
+                        if selected_label in tet.labels
+                    ),
+                }
+            )
+
+    payload = {
+        "selected_vertex": selected_label,
+        "sphere_center": SPHERE_CENTER.tolist(),
+        "sphere_radius": SPHERE_RADIUS,
+        "method": (
+            "both snapshots use ddgclib dynamic _retopologize, which rebuilds "
+            "HC connectivity with SciPy Delaunay; barycentric HC dual split; "
+            "each incident tetrahedron contributes tet_volume/4 to the "
+            "selected vertex"
+        ),
+        "comparison": {
+            "delta_liquid_volume": comparison.delta_liquid_volume,
+            "delta_liquid_percent": comparison.delta_liquid_percent,
+            "max_vertex_position_delta": comparison.max_vertex_position_delta,
+            "moved_vertices": list(comparison.moved_vertices),
+            "removed_edges": [list(edge) for edge in comparison.removed_edges],
+            "added_edges": [list(edge) for edge in comparison.added_edges],
+            "position_check": (
+                "only vertex e moves between the two timesteps; each timestep "
+                "is then triangulated by the same ddgclib Delaunay retopology rule"
+            ),
+        },
+        "snapshots": [
+            {
+                "step": snapshot.step,
+                "name": snapshot.name,
+                "hc_dual_vertices": snapshot.hc_dual_vertices,
+                "liquid_dual_volume": snapshot.liquid_dual_volume,
+                "air_dual_volume": snapshot.air_dual_volume,
+                "total_selected_dual_volume": snapshot.total_dual_volume,
+                "per_tet": snapshot.per_tet,
+            }
+            for snapshot in snapshots
+        ],
+    }
+    json_path.write_text(json.dumps(payload, indent=2) + "\n")
+    return csv_path, json_path
+
+
+def run(out_dir: Path, selected_label: str) -> dict[str, object]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    before_points = build_before_points()
+    after_points = build_after_points()
+
+    before_snapshot, _ = retopologized_snapshot(
+        0,
+        "before_delaunay_retriangulation",
+        before_points,
+        selected_label,
+    )
+    after_snapshot, _ = retopologized_snapshot(
+        1,
+        "after_delaunay_retriangulation",
+        after_points,
+        selected_label,
+    )
+    removed_edges, added_edges = changed_edges(before_snapshot, after_snapshot)
+    moved_vertices = moved_vertex_labels(before_points, after_points)
+    comparison = Comparison(
+        delta_liquid_volume=after_snapshot.liquid_dual_volume
+        - before_snapshot.liquid_dual_volume,
+        delta_liquid_percent=percent_change(
+            before_snapshot.liquid_dual_volume,
+            after_snapshot.liquid_dual_volume,
+        ),
+        max_vertex_position_delta=max_position_delta(before_points, after_points),
+        removed_edges=removed_edges,
+        added_edges=added_edges,
+        moved_vertices=moved_vertices,
+    )
+
+    before_png = save_snapshot_png(
+        out_dir,
+        before_points,
+        before_snapshot,
+        selected_label,
+        comparison.moved_vertices,
+    )
+    after_png = save_snapshot_png(
+        out_dir,
+        after_points,
+        after_snapshot,
+        selected_label,
+        comparison.moved_vertices,
+    )
+    comparison_png = save_comparison_png(
+        out_dir,
+        before_points,
+        after_points,
+        before_snapshot,
+        after_snapshot,
+        selected_label,
+        comparison,
+    )
+    interactive_html = save_interactive_html(
+        out_dir,
+        before_points,
+        after_points,
+        before_snapshot,
+        after_snapshot,
+        selected_label,
+        comparison,
+    )
+    csv_path, json_path = write_summary(
+        out_dir,
+        [before_snapshot, after_snapshot],
+        selected_label,
+        comparison,
+    )
+
+    return {
+        "before": before_snapshot,
+        "after": after_snapshot,
+        "before_png": before_png,
+        "after_png": after_png,
+        "comparison_png": comparison_png,
+        "interactive_html": interactive_html,
+        "csv": csv_path,
+        "json": json_path,
+        "comparison": comparison,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate the Delaunay-valid HC retriangulation dual-volume demo."
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=DEFAULT_OUT_DIR,
+        help="Output directory for PNG and volume summary files.",
+    )
+    parser.add_argument(
+        "--selected",
+        default=SELECTED_LABEL,
+        choices=list(INTERFACE_LABELS),
+        help="Interface vertex whose barycentric dual volume is shown.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    result = run(args.out_dir, args.selected)
+    before = result["before"]
+    after = result["after"]
+    comparison = result["comparison"]
+
+    print("Delaunay-valid HC retriangulation dual-volume demo")
+    print(f"selected vertex: {args.selected}")
+    print(f"before tetrahedra: {len(before.tets)}")
+    print(f"after  tetrahedra: {len(after.tets)}")
+    print(f"before liquid dual volume: {before.liquid_dual_volume:.17e}")
+    print(f"after  liquid dual volume: {after.liquid_dual_volume:.17e}")
+    print(f"delta liquid dual volume: {comparison.delta_liquid_volume:.17e}")
+    print(f"delta liquid percent: {comparison.delta_liquid_percent:+.9f}%")
+    print(f"moved vertex labels: {comparison.moved_vertices}")
+    print(
+        "connectivity change: removed "
+        f"{comparison.removed_edges}, added {comparison.added_edges}"
+    )
+    print(
+        "max vertex position delta between timesteps: "
+        f"{comparison.max_vertex_position_delta:.17e}"
+    )
+    print(f"before PNG: {result['before_png']}")
+    print(f"after PNG: {result['after_png']}")
+    print(f"comparison PNG: {result['comparison_png']}")
+    print(f"interactive HTML: {result['interactive_html']}")
+    print(f"CSV: {result['csv']}")
+    print(f"JSON: {result['json']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/cases_dynamic/oscillating_droplet_p_ref/scripts/patch_iwt_office_math_slide3.py
+++ b/cases_dynamic/oscillating_droplet_p_ref/scripts/patch_iwt_office_math_slide3.py
@@ -1,0 +1,1037 @@
+from __future__ import annotations
+
+import tempfile
+import zipfile
+from pathlib import Path
+
+from lxml import etree
+
+from patch_office_math_slide2 import (
+    MATHML2OMML,
+    equation_mathml,
+    math as mathml,
+    math_shape,
+    omml_from_mathml,
+    panel,
+    root_with_math_namespaces,
+    shape_end,
+    shape_start,
+    text_shape,
+    max_shape_id,
+)
+
+IWT_EQUATION_FONT_SIZE = 14
+DUAL_VOLUME_EQUATION_FONT_SIZE = 15
+FULL_FLUX_EQUATION_FONT_SIZE = 13
+PAIRWISE_EQUATION_FONT_SIZE = 14
+FREE_SURFACE_EQUATION_FONT_SIZE = 15
+
+
+def dual_volume_equation_mathml() -> list[tuple[str, str]]:
+    return [
+        (
+            "dual 1",
+            mathml(
+                """
+                <mrow>
+                  <msubsup><mi>V</mi><mi>i</mi><mi mathvariant="normal">HC</mi></msubsup>
+                  <mo>→</mo>
+                  <msub><mi>ρ</mi><mi>i</mi></msub>
+                  <mo>=</mo>
+                  <mfrac><msub><mi>m</mi><mi>i</mi></msub><msubsup><mi>V</mi><mi>i</mi><mi mathvariant="normal">HC</mi></msubsup></mfrac>
+                  <mo>→</mo>
+                  <msub><mi>p</mi><mi>i</mi></msub>
+                  <mo>=</mo>
+                  <mi>p</mi><mo stretchy="false">(</mo><msub><mi>ρ</mi><mi>i</mi></msub><mo stretchy="false">)</mo>
+                </mrow>
+                """
+            ),
+        ),
+        (
+            "dual 2",
+            mathml(
+                """
+                <mrow>
+                  <mi mathvariant="normal">Delaunay</mi><mo>&#160;</mo><mi mathvariant="normal">flip</mi>
+                  <mo>→</mo>
+                  <mi>Δ</mi><msubsup><mi>V</mi><mi>i</mi><mi mathvariant="normal">HC</mi></msubsup>
+                  <mo>→</mo>
+                  <mi>Δ</mi><msub><mi>ρ</mi><mi>i</mi></msub>
+                  <mo>,</mo>
+                  <mi>Δ</mi><msub><mi>p</mi><mi>i</mi></msub>
+                </mrow>
+                """
+            ),
+        ),
+        (
+            "dual 3",
+            mathml(
+                """
+                <mrow>
+                  <msubsup><mi>V</mi><mi>i</mi><mi mathvariant="normal">bary</mi></msubsup>
+                  <mo>=</mo>
+                  <msub><mi mathvariant="normal">∑</mi><mrow><mi>t</mi><mo>∋</mo><mi>i</mi></mrow></msub>
+                  <mfrac><msub><mi>V</mi><mi>t</mi></msub><mn>4</mn></mfrac>
+                </mrow>
+                """
+            ),
+        ),
+        (
+            "dual 4",
+            mathml(
+                """
+                <mrow>
+                  <msub><mi mathvariant="bold">B</mi><mrow><mi>t</mi><mo>,</mo><mi>i</mi></mrow></msub>
+                  <mo>=</mo>
+                  <mfrac><mrow><mi>∂</mi><msub><mi>V</mi><mi>t</mi></msub></mrow><mrow><mi>∂</mi><msub><mi mathvariant="bold">x</mi><mi>i</mi></msub></mrow></mfrac>
+                </mrow>
+                """
+            ),
+        ),
+        (
+            "dual 5",
+            mathml(
+                """
+                <mrow>
+                  <msup><mi mathvariant="bold">T</mi><mrow><mi>n</mi><mo>+</mo><mn>1</mn></mrow></msup>
+                  <mo>=</mo>
+                  <mi mathvariant="normal">Delaunay</mi>
+                  <mo stretchy="false">(</mo><msup><mi mathvariant="bold">x</mi><mi>n</mi></msup><mo stretchy="false">)</mo>
+                </mrow>
+                """
+            ),
+        ),
+        (
+            "dual 6",
+            mathml(
+                """
+                <mrow>
+                  <mo stretchy="false">{</mo>
+                  <msub><mi>V</mi><mi>t</mi></msub>
+                  <mo>,</mo>
+                  <mi mathvariant="bold">B</mi>
+                  <mo>,</mo>
+                  <msub><mi>m</mi><mi>t</mi></msub>
+                  <mo>,</mo>
+                  <msubsup><mi>V</mi><mi>t</mi><mi mathvariant="normal">tar</mi></msubsup>
+                  <mo stretchy="false">}</mo>
+                  <mo>&#160;</mo><mi mathvariant="normal">rebuilt</mi>
+                </mrow>
+                """
+            ),
+        ),
+    ]
+
+
+def patch_iwt_dual_volume_slide(xml: str, xslt: etree.XSLT) -> str:
+    xml = root_with_math_namespaces(xml)
+    next_id = max_shape_id(xml) + 1
+    equations = {
+        name: omml_from_mathml(xslt, eq, size=DUAL_VOLUME_EQUATION_FONT_SIZE)
+        for name, eq in dual_volume_equation_mathml()
+    }
+
+    shapes: list[str] = []
+
+    def new_id() -> int:
+        nonlocal next_id
+        value = next_id
+        next_id += 1
+        return value
+
+    shapes.append(shape_start(new_id(), "IWT dual volume body cover", 18, 104, 1230, 592, "FFFFFF", None) + shape_end())
+    panels = [
+        (32, 128, 565, 246, "GitHub / HC pressure path", "A61B1B"),
+        (632, 128, 585, 246, "Benchmark pressure path", "087E8B"),
+        (32, 420, 565, 146, "Why V/4 helps", "F07D00"),
+        (632, 420, 585, 146, "What is not claimed", "B7791F"),
+    ]
+    for x, y, w, h, title, color in panels:
+        shapes.append(panel(new_id(), x, y, w, h))
+        shapes.append(shape_start(new_id(), "IWT dual volume color bar", x, y, 7, h, color, None) + shape_end())
+        shapes.append(text_shape(new_id(), f"IWT dual volume title {title}", title, x + 22, y + 16, w - 44, 28, font_size=21, bold=True))
+
+    labels = {
+        "dual 1": "density/pressure path",
+        "dual 2": "connectivity artifact",
+        "dual 3": "barycentric volume",
+        "dual 4": "volume gradient",
+        "dual 5": "active tet list",
+        "dual 6": "consistent remap",
+    }
+
+    def add_eq(name: str, x: float, y: float, w: float, label_x: float) -> None:
+        shapes.append(math_shape(new_id(), f"IWT Office dual equation {name}", equations[name], x, y, w, 38))
+        shapes.append(text_shape(new_id(), f"IWT dual label {name}", labels[name], label_x, y + 9, 130, 18, font_size=8, color="5B6470"))
+
+    add_eq("dual 1", 62, 190, 405, 482)
+    add_eq("dual 2", 62, 260, 405, 482)
+    add_eq("dual 3", 662, 188, 405, 1092)
+    add_eq("dual 4", 662, 248, 405, 1092)
+    add_eq("dual 5", 662, 308, 405, 1092)
+    shapes.append(
+        text_shape(
+            new_id(),
+            "IWT dual github issue text",
+            "If the HC dual-cell polyhedron changes after a Delaunay flip, V_i^HC can jump even when the physical liquid did not locally compress by that amount.",
+            62,
+            318,
+            450,
+            34,
+            font_size=10.5,
+            bold=True,
+            color="A61B1B",
+        )
+    )
+    add_eq("dual 6", 662, 458, 405, 1092)
+    shapes.append(
+        text_shape(
+            new_id(),
+            "IWT dual v4 note",
+            "Every tet volume is partitioned exactly to its four vertices, so the nodal volumes sum to the total tet volume.",
+            62,
+            474,
+            450,
+            34,
+            font_size=11,
+            bold=True,
+            color="17202A",
+        )
+    )
+    shapes.append(
+        text_shape(
+            new_id(),
+            "IWT dual limitation note",
+            "This is a controlled benchmark workaround, not a full conservative old-dual/new-dual overlap remap.",
+            662,
+            505,
+            450,
+            34,
+            font_size=11,
+            bold=True,
+            color="17202A",
+        )
+    )
+    shapes.append(panel(new_id(), 32, 608, 1185, 52))
+    shapes.append(
+        text_shape(
+            new_id(),
+            "IWT dual bottom takeaway",
+            "Deck wording: GitHub problem = Delaunay flip changes HC dual volume and can create artificial density/pressure. Our workaround = tet-volume barycentric volume plus mass/target-volume remap after retriangulation.",
+            58,
+            620,
+            1130,
+            24,
+            font_size=11.2,
+            bold=True,
+            color="17202A",
+        )
+    )
+    return xml.replace("</p:spTree>", "".join(shapes) + "</p:spTree>", 1)
+
+
+def patch_iwt_equation_slide(xml: str, xslt: etree.XSLT) -> str:
+    xml = root_with_math_namespaces(xml)
+    next_id = max_shape_id(xml) + 1
+    equations = {
+        name: omml_from_mathml(xslt, eq, size=IWT_EQUATION_FONT_SIZE)
+        for name, eq, _size, _group in equation_mathml()
+    }
+
+    shapes: list[str] = []
+
+    def new_id() -> int:
+        nonlocal next_id
+        value = next_id
+        next_id += 1
+        return value
+
+    # Cover only the equation body, preserving IWT header, logo, and footer.
+    shapes.append(shape_start(new_id(), "IWT equation body cover", 18, 100, 1230, 592, "FFFFFF", None) + shape_end())
+
+    left_x, right_x = 22, 626
+    top_y, bottom_y = 102, 360
+    top_panel_h, bottom_panel_h = 250, 265
+    panel_w = 588
+    for x, y, w, h in [
+        (left_x, top_y, panel_w, top_panel_h),
+        (right_x, top_y, 598, top_panel_h),
+        (left_x, bottom_y, panel_w, bottom_panel_h),
+        (right_x, bottom_y, 598, bottom_panel_h),
+    ]:
+        shapes.append(panel(new_id(), x, y, w, h))
+        shapes.append(shape_start(new_id(), "IWT equation orange bar", x, y, 7, h, "F07D00", None) + shape_end())
+
+    labels = {
+        "force 1": "component split",
+        "force 2": "HC Heron force",
+        "force 4": "damping force",
+        "force 6": "time integration",
+        "closure 7": "EOS pressure force",
+        "closure 0": "reference pressure",
+        "closure 1": "density target",
+        "closure 2": "stiffness entry",
+        "closure 6": "EOS pressure",
+        "closure 3": "compressible solve",
+        "closure 8": "projection force",
+        "closure 4": "incomp pressure solve",
+        "closure 5": "velocity constraint",
+        "flux 1": "material face flux",
+        "flux 7": "Lagrangian face",
+        "flux 2": "upwind momentum",
+        "flux 5": "face mass source",
+        "flux 6": "mass update",
+    }
+
+    def add_rows(
+        names: list[str],
+        x: float,
+        y: float,
+        row0: float,
+        step: float,
+        eq_w: float,
+        label_x: float,
+        eq_h: float = 34,
+    ) -> None:
+        for idx, name in enumerate(names):
+            row_y = y + row0 + idx * step
+            shapes.append(math_shape(new_id(), f"IWT Office equation {name}", equations[name], x + 20, row_y, eq_w, eq_h))
+            shapes.append(
+                text_shape(
+                    new_id(),
+                    f"IWT equation label {name}",
+                    labels[name],
+                    x + label_x,
+                    row_y + 8,
+                    108,
+                    17,
+                    font_size=8,
+                    color="5B6470",
+                )
+            )
+
+    shapes.append(text_shape(new_id(), "IWT force title", "Common force/update", left_x + 22, top_y + 18, 350, 28, font_size=21, bold=True))
+    add_rows(["force 1", "force 2", "force 4", "force 6"], left_x, top_y, 58, 46, 432, 462, 38)
+
+    shapes.append(text_shape(new_id(), "IWT compressible title", "Compressible EOS closure", right_x + 22, top_y + 18, 380, 28, font_size=21, bold=True))
+    add_rows(["closure 7", "closure 0", "closure 1", "closure 6", "closure 3"], right_x, top_y, 52, 40, 432, 462, 38)
+
+    shapes.append(text_shape(new_id(), "IWT flux title", "ALE flux and mass update", left_x + 22, bottom_y + 18, 380, 28, font_size=21, bold=True))
+    add_rows(["flux 1", "flux 7", "flux 2", "flux 5", "flux 6"], left_x, bottom_y, 50, 42, 432, 462, 38)
+
+    shapes.append(text_shape(new_id(), "IWT incompressible title", "Incompressible projection", right_x + 22, bottom_y + 18, 390, 28, font_size=21, bold=True))
+    add_rows(["closure 8", "closure 2", "closure 4", "closure 5"], right_x, bottom_y, 52, 52, 432, 462, 42)
+
+    shapes.append(
+        text_shape(
+            new_id(),
+            "IWT notation convention",
+            "Notation: scalars italic; vectors bold upright; matrices/tensors/operators bold upright; multi-letter labels upright roman.",
+            42,
+            626,
+            1120,
+            16,
+            font_size=8,
+            color="5B6470",
+        )
+    )
+
+    shapes.append(panel(new_id(), 22, 638, 1202, 50))
+    shapes.append(
+        text_shape(
+            new_id(),
+            "IWT reference label",
+            "Literature references",
+            46,
+            650,
+            180,
+            20,
+            font_size=12,
+            bold=True,
+            color="F07D00",
+        )
+    )
+    shapes.append(
+        text_shape(
+            new_id(),
+            "IWT projection reference",
+            "Incompressible projection: Chorin, A. J. (1968), Numerical solution of the Navier-Stokes equations, Math. Comput. 22(104), 745-762. doi: 10.1090/S0025-5718-1968-0242392-2.",
+            236,
+            642,
+            972,
+            18,
+            font_size=9,
+            color="17202A",
+        )
+    )
+    shapes.append(
+        text_shape(
+            new_id(),
+            "IWT compressible reference",
+            "Compressible EOS pressure solve: Chen, Z. and Przekwas, A. (2010), A coupled pressure-based computational method for incompressible/compressible flows, JCP 229(24), 9150-9165. doi: 10.1016/j.jcp.2010.08.029.",
+            236,
+            664,
+            972,
+            18,
+            font_size=9,
+            color="17202A",
+        )
+    )
+    return xml.replace("</p:spTree>", "".join(shapes) + "</p:spTree>", 1)
+
+
+def patch_iwt_full_flux_slide(xml: str, xslt: etree.XSLT) -> str:
+    xml = root_with_math_namespaces(xml)
+    next_id = max_shape_id(xml) + 1
+    equations = {
+        name: omml_from_mathml(xslt, eq, size=FULL_FLUX_EQUATION_FONT_SIZE)
+        for name, eq, _size, _group in equation_mathml()
+    }
+
+    shapes: list[str] = []
+
+    def new_id() -> int:
+        nonlocal next_id
+        value = next_id
+        next_id += 1
+        return value
+
+    shapes.append(shape_start(new_id(), "IWT full flux body cover", 18, 104, 1230, 592, "FFFFFF", None) + shape_end())
+
+    panels = [
+        (28, 112, 1200, 150, "Cell-face mass flux"),
+        (28, 280, 1200, 150, "Cell-face momentum flux"),
+        (28, 448, 1200, 158, "Mass, limiter, and vertex-force update"),
+    ]
+    for x, y, w, h, title in panels:
+        shapes.append(panel(new_id(), x, y, w, h))
+        shapes.append(shape_start(new_id(), "IWT full flux orange bar", x, y, 7, h, "F07D00", None) + shape_end())
+        shapes.append(text_shape(new_id(), f"IWT full flux title {title}", title, x + 22, y + 14, 520, 26, font_size=21, bold=True))
+
+    labels = {
+        "flux 1": "relative face flux",
+        "flux 3": "Rusanov mass flux",
+        "flux 2": "upwind momentum",
+        "flux 4": "Rusanov momentum",
+        "flux 5": "face mass source",
+        "flux 6": "limited mass update",
+        "force 5": "vertex flux force",
+    }
+
+    def add_eq(name: str, x: float, y: float, w: float, h: float, label: str) -> None:
+        shapes.append(math_shape(new_id(), f"IWT Office full flux equation {name}", equations[name], x, y, w, h))
+        shapes.append(
+            text_shape(
+                new_id(),
+                f"IWT full flux label {name}",
+                label,
+                1034,
+                y + 9,
+                150,
+                18,
+                font_size=9,
+                color="5B6470",
+            )
+        )
+
+    add_eq("flux 1", 58, 162, 950, 38, labels["flux 1"])
+    add_eq("flux 3", 58, 212, 965, 42, labels["flux 3"])
+    add_eq("flux 2", 58, 330, 950, 38, labels["flux 2"])
+    add_eq("flux 4", 58, 380, 965, 42, labels["flux 4"])
+    add_eq("flux 5", 58, 488, 950, 34, labels["flux 5"])
+    add_eq("flux 6", 58, 528, 950, 34, labels["flux 6"])
+    add_eq("force 5", 58, 568, 950, 30, labels["force 5"])
+
+    shapes.append(panel(new_id(), 28, 620, 1200, 62))
+    shapes.append(
+        text_shape(
+            new_id(),
+            "IWT full flux note",
+            "Impact cases #7/#8 use lambda_m = 1 and lambda_F = 1 with nonzero cell-average/Rusanov flux. This is a diagnostic stress test, not the physical Lagrangian material-face flux used for #5/#6.",
+            52,
+            630,
+            735,
+            30,
+            font_size=11,
+            bold=True,
+            color="A61B1B",
+        )
+    )
+    shapes.append(
+        text_shape(
+            new_id(),
+            "IWT full flux references",
+            "References: Hirt, Amsden & Cook (1974), JCP 14, 227-253; Toro (2009), Riemann Solvers and Numerical Methods for Fluid Dynamics.",
+            805,
+            630,
+            390,
+            30,
+            font_size=10,
+            color="17202A",
+        )
+    )
+    shapes.append(
+        text_shape(
+            new_id(),
+            "IWT full flux notation convention",
+            "Notation: scalars italic; vectors bold upright; matrices/tensors/operators bold upright; multi-letter labels upright roman.",
+            52,
+            664,
+            735,
+            14,
+            font_size=8,
+            color="5B6470",
+        )
+    )
+    return xml.replace("</p:spTree>", "".join(shapes) + "</p:spTree>", 1)
+
+
+def pairwise_equation_mathml() -> list[tuple[str, str]]:
+    return [
+        (
+            "pair 1",
+            mathml(
+                """
+                <mrow>
+                  <msubsup><mi mathvariant="bold">F</mi><mi>i</mi><mrow><mi mathvariant="normal">p</mi><mo>,</mo><mi>A</mi></mrow></msubsup>
+                  <mo>=</mo>
+                  <msub><mi mathvariant="normal">∑</mi><mrow><mi>j</mi><mo>∈</mo><mi mathvariant="bold">N</mi><mo stretchy="false">(</mo><mi>i</mi><mo stretchy="false">)</mo></mrow></msub>
+                  <mo>-</mo><mfrac><mn>1</mn><mn>2</mn></mfrac>
+                  <mo stretchy="false">(</mo><msub><mi>p</mi><mi>i</mi></msub><mo>+</mo><msub><mi>p</mi><mi>j</mi></msub><mo stretchy="false">)</mo>
+                  <msub><mi mathvariant="bold">A</mi><mrow><mi>i</mi><mi>j</mi></mrow></msub>
+                </mrow>
+                """
+            ),
+        ),
+        (
+            "pair 2",
+            mathml(
+                """
+                <mrow>
+                  <msub><mi>p</mi><mi>i</mi></msub>
+                  <mo>=</mo>
+                  <msub><mi mathvariant="normal">∑</mi><mrow><mi>t</mi><mo>∋</mo><mi>i</mi></mrow></msub>
+                  <msub><mi>w</mi><mrow><mi>i</mi><mi>t</mi></mrow></msub>
+                  <msub><mi>p</mi><mi>t</mi></msub>
+                  <mo>,</mo><mo>&#160;</mo>
+                  <msub><mi>w</mi><mrow><mi>i</mi><mi>t</mi></mrow></msub>
+                  <mo>=</mo>
+                  <mfrac>
+                    <msub><mi>V</mi><mi>t</mi></msub>
+                    <mrow><msub><mi mathvariant="normal">∑</mi><mrow><mi>s</mi><mo>∋</mo><mi>i</mi></mrow></msub><msub><mi>V</mi><mi>s</mi></msub></mrow>
+                  </mfrac>
+                </mrow>
+                """
+            ),
+        ),
+        (
+            "pair 3",
+            mathml(
+                """
+                <mrow>
+                  <msub><mi mathvariant="bold">P</mi><mi>A</mi></msub>
+                  <mi mathvariant="bold">p</mi>
+                  <mo>=</mo>
+                  <msup><mi mathvariant="bold">F</mi><mrow><mi mathvariant="normal">p</mi><mo>,</mo><mi>A</mi></mrow></msup>
+                  <mo>,</mo><mo>&#160;</mo>
+                  <msub><mi mathvariant="bold">S</mi><mi>A</mi></msub>
+                  <mo>=</mo>
+                  <mi mathvariant="bold">B</mi>
+                  <msup><mi mathvariant="bold">M</mi><mrow><mo>-</mo><mn>1</mn></mrow></msup>
+                  <msub><mi mathvariant="bold">P</mi><mi>A</mi></msub>
+                </mrow>
+                """
+            ),
+        ),
+        (
+            "pair 4",
+            mathml(
+                """
+                <mrow>
+                  <mo stretchy="false">[</mo>
+                  <mi mathvariant="bold">I</mi>
+                  <mo>+</mo>
+                  <msup><mrow><mi>Δ</mi><mi>t</mi></mrow><mn>2</mn></msup>
+                  <msub><mi mathvariant="bold">D</mi><mi>K</mi></msub>
+                  <msub><mi mathvariant="bold">S</mi><mi>A</mi></msub>
+                  <mo stretchy="false">]</mo>
+                  <mi>δ</mi><mi mathvariant="bold">p</mi>
+                  <mo>=</mo>
+                  <mo>-</mo>
+                  <msub><mi mathvariant="bold">D</mi><mi>K</mi></msub>
+                  <mo stretchy="false">(</mo>
+                  <mi mathvariant="bold">V</mi>
+                  <mo>-</mo>
+                  <msup><mi mathvariant="bold">V</mi><mi mathvariant="normal">tar</mi></msup>
+                  <mo>+</mo>
+                  <mi>Δ</mi><mi>t</mi><mi mathvariant="bold">B</mi><msup><mi mathvariant="bold">u</mi><mo>*</mo></msup>
+                  <mo stretchy="false">)</mo>
+                </mrow>
+                """
+            ),
+        ),
+        (
+            "pair 5",
+            mathml(
+                """
+                <mrow>
+                  <msub><mi mathvariant="bold">S</mi><mi>A</mi></msub>
+                  <mi mathvariant="bold">p</mi>
+                  <mo>=</mo>
+                  <mfrac>
+                    <mrow><mi mathvariant="bold">r</mi><mo>-</mo><mi mathvariant="bold">B</mi><mi mathvariant="bold">u</mi></mrow>
+                    <mrow><mi>Δ</mi><mi>t</mi></mrow>
+                  </mfrac>
+                  <mo>-</mo>
+                  <mi mathvariant="bold">B</mi>
+                  <msup><mi mathvariant="bold">M</mi><mrow><mo>-</mo><mn>1</mn></mrow></msup>
+                  <msub><mi mathvariant="bold">F</mi><mi mathvariant="normal">np</mi></msub>
+                </mrow>
+                """
+            ),
+        ),
+        (
+            "pair 6",
+            mathml(
+                """
+                <mrow>
+                  <mi mathvariant="bold">B</mi>
+                  <msup><mi mathvariant="bold">u</mi><mrow><mi>n</mi><mo>+</mo><mn>1</mn></mrow></msup>
+                  <mo>=</mo>
+                  <mi mathvariant="bold">r</mi>
+                </mrow>
+                """
+            ),
+        ),
+        (
+            "pair 7",
+            mathml(
+                """
+                <mrow>
+                  <msub><mi mathvariant="bold">S</mi><mi>A</mi></msub>
+                  <mo>=</mo>
+                  <mi mathvariant="bold">B</mi>
+                  <msup><mi mathvariant="bold">M</mi><mrow><mo>-</mo><mn>1</mn></mrow></msup>
+                  <msub><mi mathvariant="bold">P</mi><mi>A</mi></msub>
+                  <mo>≠</mo>
+                  <mi mathvariant="bold">B</mi>
+                  <msup><mi mathvariant="bold">M</mi><mrow><mo>-</mo><mn>1</mn></mrow></msup>
+                  <msup><mi mathvariant="bold">B</mi><mi mathvariant="normal">T</mi></msup>
+                </mrow>
+                """
+            ),
+        ),
+        (
+            "pair 8",
+            mathml(
+                """
+                <mrow>
+                  <msub><mi mathvariant="bold">P</mi><mi>A</mi></msub>
+                  <mo>≠</mo>
+                  <msup><mi mathvariant="bold">B</mi><mi mathvariant="normal">T</mi></msup>
+                </mrow>
+                """
+            ),
+        ),
+        (
+            "pair 9",
+            mathml(
+                """
+                <mrow>
+                  <mi mathvariant="bold">P</mi>
+                  <mo>=</mo>
+                  <msup><mi mathvariant="bold">B</mi><mi mathvariant="normal">T</mi></msup>
+                </mrow>
+                """
+            ),
+        ),
+        (
+            "pair 10",
+            mathml(
+                """
+                <mrow>
+                  <mi mathvariant="bold">B</mi>
+                  <mi mathvariant="bold">u</mi>
+                  <mo>=</mo>
+                  <mi mathvariant="bold">r</mi>
+                </mrow>
+                """
+            ),
+        ),
+    ]
+
+
+def patch_iwt_pairwise_pressure_slide(xml: str, xslt: etree.XSLT) -> str:
+    xml = root_with_math_namespaces(xml)
+    next_id = max_shape_id(xml) + 1
+    equations = {
+        name: omml_from_mathml(xslt, eq, size=PAIRWISE_EQUATION_FONT_SIZE)
+        for name, eq in pairwise_equation_mathml()
+    }
+
+    shapes: list[str] = []
+
+    def new_id() -> int:
+        nonlocal next_id
+        value = next_id
+        next_id += 1
+        return value
+
+    shapes.append(shape_start(new_id(), "IWT pairwise body cover", 18, 104, 1230, 592, "FFFFFF", None) + shape_end())
+    panels = [
+        (28, 116, 586, 188, "Pairwise force law"),
+        (642, 116, 586, 188, "#9 compressible trial"),
+        (28, 336, 586, 178, "#10 incompressible trial"),
+        (642, 326, 586, 210, "Observed result"),
+    ]
+    for x, y, w, h, title in panels:
+        shapes.append(panel(new_id(), x, y, w, h))
+        shapes.append(shape_start(new_id(), "IWT pairwise orange bar", x, y, 7, h, "F07D00", None) + shape_end())
+        shapes.append(text_shape(new_id(), f"IWT pairwise title {title}", title, x + 22, y + 14, 500, 26, font_size=21, bold=True))
+
+    labels = {
+        "pair 1": "edge pressure force",
+        "pair 2": "vertex pressure map",
+        "pair 3": "mixed operator",
+        "pair 4": "compressible solve",
+        "pair 5": "projection solve",
+        "pair 6": "velocity constraint",
+        "pair 7": "mixed stiffness",
+        "pair 8": "not adjoint",
+        "pair 9": "consistent force",
+        "pair 10": "constraint",
+    }
+
+    def add_eq(name: str, x: float, y: float, w: float, h: float, label_x: float) -> None:
+        shapes.append(math_shape(new_id(), f"IWT Office pairwise equation {name}", equations[name], x, y, w, h))
+        shapes.append(
+            text_shape(
+                new_id(),
+                f"IWT pairwise label {name}",
+                labels[name],
+                label_x,
+                y + 9,
+                118,
+                18,
+                font_size=8,
+                color="5B6470",
+            )
+        )
+
+    add_eq("pair 1", 58, 166, 420, 42, 492)
+    add_eq("pair 2", 58, 224, 420, 42, 492)
+    add_eq("pair 3", 672, 166, 420, 42, 1104)
+    add_eq("pair 4", 672, 224, 420, 42, 1104)
+    add_eq("pair 5", 58, 392, 420, 42, 492)
+    add_eq("pair 6", 58, 452, 420, 34, 492)
+
+    shapes.append(text_shape(new_id(), "IWT pairwise observed intro", "#9 includes B in the residual, but the force operator is pairwise Aij:", 672, 376, 470, 18, font_size=10, bold=True, color="17202A"))
+    add_eq("pair 7", 672, 402, 360, 32, 1104)
+    add_eq("pair 8", 672, 442, 210, 30, 1104)
+    shapes.append(text_shape(new_id(), "IWT pairwise observed control", "Local EOS modes are not controlled.", 890, 444, 210, 28, font_size=10, bold=True, color="A61B1B"))
+    shapes.append(text_shape(new_id(), "IWT pairwise observed consistent", "Consistent local-volume pressure requires:", 672, 482, 270, 18, font_size=10, color="A61B1B"))
+    add_eq("pair 9", 940, 478, 120, 28, 1104)
+    shapes.append(text_shape(new_id(), "IWT pairwise observed projection", "#10 works because projection enforces:", 672, 512, 270, 18, font_size=10, color="17202A"))
+    add_eq("pair 10", 940, 508, 120, 28, 1104)
+
+    shapes.append(panel(new_id(), 28, 574, 1200, 68))
+    shapes.append(
+        text_shape(
+            new_id(),
+            "IWT pairwise interpretation label",
+            "Interpretation",
+            52,
+            590,
+            160,
+            20,
+            font_size=12,
+            bold=True,
+            color="F07D00",
+        )
+    )
+    shapes.append(
+        text_shape(
+            new_id(),
+            "IWT pairwise interpretation",
+            "For uniform pressure the pairwise Aij force can reproduce the capillary-scale direction. For compressible local EOS, nonuniform tet pressure corrections need a volume-gradient-compatible operator.",
+            218,
+            584,
+            950,
+            30,
+            font_size=11,
+            bold=True,
+            color="17202A",
+        )
+    )
+    shapes.append(
+        text_shape(
+            new_id(),
+            "IWT pairwise references",
+            "Refs: Chorin (1968), Math. Comput. 22(104), 745-762; Chen & Przekwas (2010), JCP 229(24), 9150-9165; Desbrun et al. (1999), Implicit fairing of irregular meshes using diffusion and curvature flow.",
+            218,
+            622,
+            950,
+            16,
+            font_size=8,
+            color="5B6470",
+        )
+    )
+    return xml.replace("</p:spTree>", "".join(shapes) + "</p:spTree>", 1)
+
+
+def free_surface_equation_mathml() -> list[tuple[str, str]]:
+    return [
+        (
+            "free 1",
+            mathml(
+                """
+                <mrow>
+                  <msub><mi mathvariant="bold">T</mi><mi mathvariant="normal">GH</mi></msub>
+                  <mo>=</mo>
+                  <mi mathvariant="normal">droplet_in_box_3d</mi>
+                  <mo stretchy="false">(</mo><msub><mi>R</mi><mn>0</mn></msub><mo>,</mo><mi>L</mi><mo stretchy="false">)</mo>
+                </mrow>
+                """
+            ),
+        ),
+        (
+            "free 2",
+            mathml(
+                """
+                <mrow>
+                  <mi mathvariant="normal">phase</mi><mo>&#160;</mo><mn>0</mn><mo>=</mo><mi mathvariant="normal">gas</mi>
+                  <mo>,</mo><mo>&#160;</mo>
+                  <mi mathvariant="normal">phase</mi><mo>&#160;</mo><mn>1</mn><mo>=</mo><mi mathvariant="normal">liquid</mi>
+                </mrow>
+                """
+            ),
+        ),
+        (
+            "free 3",
+            mathml(
+                """
+                <mrow>
+                  <mi>Γ</mi>
+                  <mo>=</mo>
+                  <mi mathvariant="normal">interface</mi><mo>&#160;</mo><mi mathvariant="normal">subcomplex</mi>
+                </mrow>
+                """
+            ),
+        ),
+        (
+            "free 4",
+            mathml(
+                """
+                <mrow>
+                  <msubsup><mi>V</mi><mi>i</mi><mi mathvariant="normal">bary</mi></msubsup>
+                  <mo>=</mo>
+                  <msub><mi mathvariant="normal">∑</mi><mrow><mi>t</mi><mo>∋</mo><mi>i</mi></mrow></msub>
+                  <mfrac><msub><mi>V</mi><mi>t</mi></msub><mn>4</mn></mfrac>
+                </mrow>
+                """
+            ),
+        ),
+        (
+            "free 5",
+            mathml(
+                """
+                <mrow>
+                  <msubsup><mi mathvariant="bold">F</mi><mi>i</mi><mi mathvariant="normal">Heron</mi></msubsup>
+                  <mo>=</mo>
+                  <mo>-</mo><mi>γ</mi>
+                  <msub><mrow><mo stretchy="false">(</mo><mi mathvariant="normal">HN</mi><mi>dA</mi><mo stretchy="false">)</mo></mrow><mi>i</mi></msub>
+                </mrow>
+                """
+            ),
+        ),
+        (
+            "free 6",
+            mathml(
+                """
+                <mrow>
+                  <msubsup><mi mathvariant="bold">F</mi><mi>i</mi><mi mathvariant="normal">p</mi></msubsup>
+                  <mo>=</mo>
+                  <msub><mi mathvariant="normal">∑</mi><mrow><mi>t</mi><mo>∋</mo><mi>i</mi></mrow></msub>
+                  <msub><mi>p</mi><mi>t</mi></msub>
+                  <msub><mi mathvariant="bold">B</mi><mrow><mi>t</mi><mo>,</mo><mi>i</mi></mrow></msub>
+                </mrow>
+                """
+            ),
+        ),
+        (
+            "free 7",
+            mathml(
+                """
+                <mrow>
+                  <msubsup><mi mathvariant="bold">T</mi><mi mathvariant="normal">display</mi><mi>n</mi></msubsup>
+                  <mo>=</mo>
+                  <mi mathvariant="normal">Delaunay</mi>
+                  <mo stretchy="false">(</mo>
+                  <msup><mi mathvariant="bold">x</mi><mi>n</mi></msup>
+                  <mo stretchy="false">)</mo>
+                </mrow>
+                """
+            ),
+        ),
+        (
+            "free 8",
+            mathml(
+                """
+                <mrow>
+                  <mo stretchy="false">{</mo>
+                  <msub><mi>V</mi><mi>t</mi></msub><mo>,</mo>
+                  <mi mathvariant="bold">B</mi><mo>,</mo>
+                  <msub><mi>m</mi><mi>t</mi></msub><mo>,</mo>
+                  <msubsup><mi>V</mi><mi>t</mi><mi mathvariant="normal">tar</mi></msubsup>
+                  <mo stretchy="false">}</mo>
+                  <mo>&#160;</mo><mi mathvariant="normal">rebuilt</mi>
+                </mrow>
+                """
+            ),
+        ),
+    ]
+
+
+def patch_iwt_free_surface_slide(xml: str, xslt: etree.XSLT) -> str:
+    xml = root_with_math_namespaces(xml)
+    next_id = max_shape_id(xml) + 1
+    equations = {
+        name: omml_from_mathml(xslt, eq, size=FREE_SURFACE_EQUATION_FONT_SIZE)
+        for name, eq in free_surface_equation_mathml()
+    }
+
+    shapes: list[str] = []
+
+    def new_id() -> int:
+        nonlocal next_id
+        value = next_id
+        next_id += 1
+        return value
+
+    shapes.append(shape_start(new_id(), "IWT free-surface body cover", 18, 104, 1230, 592, "FFFFFF", None) + shape_end())
+    panels = [
+        (34, 120, 590, 210, "Displayed triangulation"),
+        (656, 120, 560, 210, "Stable dynamic closure"),
+        (34, 374, 590, 190, "Active tet retopology"),
+        (656, 374, 560, 190, "Important interpretation"),
+    ]
+    for x, y, w, h, title in panels:
+        shapes.append(panel(new_id(), x, y, w, h))
+        shapes.append(shape_start(new_id(), "IWT free-surface orange bar", x, y, 7, h, "F07D00", None) + shape_end())
+        shapes.append(text_shape(new_id(), f"IWT free-surface title {title}", title, x + 22, y + 16, 510, 26, font_size=21, bold=True))
+
+    labels = {
+        "free 1": "GitHub source mesh",
+        "free 2": "phase labels",
+        "free 3": "interface mesh",
+        "free 4": "bary volume",
+        "free 5": "HC Heron force",
+        "free 6": "pressure force",
+        "free 7": "active tets",
+        "free 8": "consistent rebuild",
+    }
+
+    def add_eq(name: str, x: float, y: float, w: float, label_x: float) -> None:
+        shapes.append(math_shape(new_id(), f"IWT Office free-surface equation {name}", equations[name], x, y, w, 36))
+        shapes.append(
+            text_shape(
+                new_id(),
+                f"IWT free-surface label {name}",
+                labels[name],
+                label_x,
+                y + 9,
+                122,
+                18,
+                font_size=8,
+                color="5B6470",
+            )
+        )
+
+    add_eq("free 1", 64, 178, 390, 492)
+    add_eq("free 2", 64, 228, 390, 492)
+    add_eq("free 3", 64, 278, 390, 492)
+    add_eq("free 4", 686, 186, 330, 1092)
+    add_eq("free 5", 686, 236, 330, 1092)
+    add_eq("free 6", 686, 286, 330, 1092)
+    add_eq("free 7", 64, 438, 390, 492)
+    add_eq("free 8", 64, 492, 390, 492)
+    shapes.append(
+        text_shape(
+            new_id(),
+            "IWT free-surface meaning",
+            "The successful Rayleigh response is not the original GitHub multiphase stress solver. It is the GitHub two-phase triangulation view plus the corrected tet-volume FHeron EOS/projection dynamics.",
+            686,
+            436,
+            430,
+            70,
+            font_size=11,
+            bold=True,
+            color="17202A",
+        )
+    )
+    shapes.append(panel(new_id(), 34, 600, 1182, 74))
+    shapes.append(
+        text_shape(
+            new_id(),
+            "IWT free-surface note",
+            "#11/#12: visible phase mesh comes from GitHub droplet_in_box_3d. The stable pressure/volume dynamics use barycentric tet volumes and rebuilt V_t, B, m_t, V_t^tar after active retopology.",
+            58,
+            612,
+            1128,
+            32,
+            font_size=11,
+            bold=True,
+            color="17202A",
+        )
+    )
+    shapes.append(
+        text_shape(
+            new_id(),
+            "IWT free-surface references",
+            "Refs: Edelsbrunner (2001), Geometry and Topology for Mesh Generation, for Delaunay triangulation; Chorin (1968) and Chen & Przekwas (2010) for pressure/projection closures.",
+            58,
+            652,
+            1128,
+            14,
+            font_size=8,
+            color="5B6470",
+        )
+    )
+    return xml.replace("</p:spTree>", "".join(shapes) + "</p:spTree>", 1)
+
+
+def patch_pptx(input_path: Path, output_path: Path) -> None:
+    if not MATHML2OMML.exists():
+        raise FileNotFoundError(f"Missing Microsoft Word MathML converter: {MATHML2OMML}")
+    xslt = etree.XSLT(etree.parse(str(MATHML2OMML)))
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir) / "patched.pptx"
+        with zipfile.ZipFile(input_path, "r") as zin, zipfile.ZipFile(tmp_path, "w", zipfile.ZIP_DEFLATED) as zout:
+            for item in zin.infolist():
+                data = zin.read(item.filename)
+                if item.filename == "ppt/slides/slide3.xml":
+                    data = patch_iwt_dual_volume_slide(data.decode("utf-8"), xslt).encode("utf-8")
+                elif item.filename == "ppt/slides/slide4.xml":
+                    data = patch_iwt_equation_slide(data.decode("utf-8"), xslt).encode("utf-8")
+                elif item.filename == "ppt/slides/slide5.xml":
+                    data = patch_iwt_full_flux_slide(data.decode("utf-8"), xslt).encode("utf-8")
+                elif item.filename == "ppt/slides/slide6.xml":
+                    data = patch_iwt_pairwise_pressure_slide(data.decode("utf-8"), xslt).encode("utf-8")
+                elif item.filename == "ppt/slides/slide7.xml":
+                    data = patch_iwt_free_surface_slide(data.decode("utf-8"), xslt).encode("utf-8")
+                zout.writestr(item, data)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(tmp_path.read_bytes())
+
+
+def main() -> int:
+    base = Path(__file__).resolve().parent
+    input_path = base / "outputs/manual-20260602-fheron-ppt/presentations/fheron-flux-cases/output/fheron-hc-twelve-cases-34slides-iwt-template.pptx"
+    output_path = base / "outputs/manual-20260602-fheron-ppt/presentations/fheron-flux-cases/output/fheron-hc-twelve-cases-34slides-iwt-template-office-math.pptx"
+    patch_pptx(input_path, output_path)
+    print(output_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cases_dynamic/oscillating_droplet_p_ref/scripts/patch_office_math_slide2.py
+++ b/cases_dynamic/oscillating_droplet_p_ref/scripts/patch_office_math_slide2.py
@@ -1,0 +1,905 @@
+from __future__ import annotations
+
+import html
+import re
+import shutil
+import tempfile
+import zipfile
+from pathlib import Path
+
+from lxml import etree
+
+
+EMU_PER_PX = 9525
+NS_P = "http://schemas.openxmlformats.org/presentationml/2006/main"
+NS_A = "http://schemas.openxmlformats.org/drawingml/2006/main"
+NS_A14 = "http://schemas.microsoft.com/office/drawing/2010/main"
+NS_M = "http://schemas.openxmlformats.org/officeDocument/2006/math"
+NS_MATHML = "http://www.w3.org/1998/Math/MathML"
+NS_MC = "http://schemas.openxmlformats.org/markup-compatibility/2006"
+MATHML2OMML = Path("/Applications/Microsoft Word.app/Contents/Resources/mathml2omml.xsl")
+UNIFORM_EQUATION_FONT_SIZE = 10
+
+
+def emu(value: float) -> int:
+    return int(round(value * EMU_PER_PX))
+
+
+def root_with_math_namespaces(xml: str) -> str:
+    original = f'<p:sld xmlns:p="{NS_P}">'
+    updated = (
+        f'<p:sld xmlns:p="{NS_P}" '
+        f'xmlns:a="{NS_A}" '
+        f'xmlns:a14="{NS_A14}" '
+        f'xmlns:m="{NS_M}" '
+        f'xmlns:mc="{NS_MC}" '
+        f'mc:Ignorable="a14">'
+    )
+    return xml.replace(original, updated, 1)
+
+
+def max_shape_id(xml: str) -> int:
+    values = [int(value) for value in re.findall(r'<p:cNvPr id="(\d+)"', xml)]
+    return max(values) if values else 1
+
+
+def fill_xml(fill: str | None) -> str:
+    if fill is None:
+        return '<a:noFill/>'
+    return f'<a:solidFill><a:srgbClr val="{fill}"/></a:solidFill>'
+
+
+def line_xml(color: str | None = "D9DEE6", width: int = 1) -> str:
+    if color is None or width <= 0:
+        return '<a:ln w="0"><a:noFill/></a:ln>'
+    return (
+        f'<a:ln w="{width * 12700}">'
+        f'<a:solidFill><a:srgbClr val="{color}"/></a:solidFill>'
+        '<a:prstDash val="solid"/></a:ln>'
+    )
+
+
+def shape_start(shape_id: int, name: str, x: float, y: float, w: float, h: float, fill: str | None, line: str | None) -> str:
+    return (
+        '<p:sp>'
+        '<p:nvSpPr>'
+        f'<p:cNvPr id="{shape_id}" name="{html.escape(name)}"/>'
+        '<p:cNvSpPr txBox="1"/>'
+        '<p:nvPr/>'
+        '</p:nvSpPr>'
+        '<p:spPr>'
+        '<a:xfrm>'
+        f'<a:off x="{emu(x)}" y="{emu(y)}"/>'
+        f'<a:ext cx="{emu(w)}" cy="{emu(h)}"/>'
+        '</a:xfrm>'
+        '<a:prstGeom prst="rect"><a:avLst/></a:prstGeom>'
+        f'{fill_xml(fill)}'
+        f'{line_xml(line)}'
+        '</p:spPr>'
+    )
+
+
+def shape_end() -> str:
+    return '</p:sp>'
+
+
+def text_shape(shape_id: int, name: str, text: str, x: float, y: float, w: float, h: float, *,
+               font_size: int = 16, bold: bool = False, color: str = "17202A",
+               fill: str | None = None, line: str | None = None) -> str:
+    bold_attr = ' b="1"' if bold else ""
+    return (
+        shape_start(shape_id, name, x, y, w, h, fill, line)
+        +
+        '<p:txBody><a:bodyPr wrap="square"/><a:lstStyle/><a:p>'
+        '<a:r>'
+        f'<a:rPr lang="en-US" sz="{font_size * 100}"{bold_attr}>'
+        f'<a:solidFill><a:srgbClr val="{color}"/></a:solidFill>'
+        '<a:latin typeface="Aptos"/><a:ea typeface="Aptos"/><a:cs typeface="Aptos"/>'
+        '</a:rPr>'
+        f'<a:t>{html.escape(text)}</a:t>'
+        '</a:r>'
+        '<a:endParaRPr lang="en-US"/>'
+        '</a:p></p:txBody>'
+        + shape_end()
+    )
+
+
+def math(body: str) -> str:
+    return f'<math xmlns="{NS_MATHML}">{body}</math>'
+
+
+def ppt_run_properties(size: int, color: str = "17202A") -> etree._Element:
+    rpr = etree.Element(f"{{{NS_A}}}rPr")
+    rpr.set("lang", "en-US")
+    rpr.set("sz", str(size * 100))
+    solid = etree.SubElement(rpr, f"{{{NS_A}}}solidFill")
+    srgb = etree.SubElement(solid, f"{{{NS_A}}}srgbClr")
+    srgb.set("val", color)
+    etree.SubElement(rpr, f"{{{NS_A}}}latin").set("typeface", "Cambria Math")
+    etree.SubElement(rpr, f"{{{NS_A}}}ea").set("typeface", "Cambria Math")
+    etree.SubElement(rpr, f"{{{NS_A}}}cs").set("typeface", "Cambria Math")
+    return rpr
+
+
+def add_powerpoint_run_properties(omath: etree._Element, size: int) -> None:
+    for text_node in omath.xpath(".//m:t", namespaces={"m": NS_M}):
+        if text_node.text is not None and text_node.text.strip() != text_node.text:
+            text_node.set("{http://www.w3.org/XML/1998/namespace}space", "preserve")
+    for run in omath.xpath(".//m:r", namespaces={"m": NS_M}):
+        if run.find(f"{{{NS_A}}}rPr") is not None:
+            continue
+        insert_at = 0
+        if len(run) > 0 and run[0].tag == f"{{{NS_M}}}rPr":
+            insert_at = 1
+        run.insert(insert_at, ppt_run_properties(size))
+
+
+def omml_from_mathml(xslt: etree.XSLT, equation_mathml: str, *, size: int) -> str:
+    node = etree.fromstring(equation_mathml.encode("utf-8"))
+    result = xslt(node)
+    omath = etree.fromstring(str(result).encode("utf-8"))
+    add_powerpoint_run_properties(omath, size)
+
+    wrapper = etree.Element(f"{{{NS_A14}}}m", nsmap={"a14": NS_A14})
+    para = etree.SubElement(wrapper, f"{{{NS_M}}}oMathPara", nsmap={"m": NS_M})
+    para_pr = etree.SubElement(para, f"{{{NS_M}}}oMathParaPr")
+    jc = etree.SubElement(para_pr, f"{{{NS_M}}}jc")
+    jc.set(f"{{{NS_M}}}val", "left")
+    para.append(omath)
+    return etree.tostring(wrapper, encoding="unicode")
+
+
+def math_paragraph(omml: str) -> str:
+    return (
+        '<a:p><a:pPr><a:lnSpc><a:spcPct val="105000"/></a:lnSpc></a:pPr>'
+        f'{omml}'
+        '</a:p>'
+    )
+
+
+def math_shape(shape_id: int, name: str, omml: str, x: float, y: float, w: float, h: float, *,
+               font_size: int = 18, fill: str | None = None, line: str | None = None) -> str:
+    shape = (
+        shape_start(shape_id, name, x, y, w, h, fill, line)
+        +
+        '<p:txBody><a:bodyPr wrap="square" lIns="254" tIns="254" rIns="254" bIns="254" anchor="t"><a:noAutofit/></a:bodyPr><a:lstStyle/>'
+        f'{math_paragraph(omml)}'
+        '</p:txBody>'
+        + shape_end()
+    )
+    return shape
+
+
+def panel(shape_id: int, x: float, y: float, w: float, h: float) -> str:
+    return shape_start(shape_id, "Office math panel", x, y, w, h, "FFFFFF", "D9DEE6") + shape_end()
+
+
+def equation_mathml() -> list[tuple[str, str, int, str]]:
+    force_eqs = [
+        (
+            "force 1",
+            math(
+                """
+                <mrow>
+                  <msubsup><mi mathvariant="bold">F</mi><mi>i</mi><mi mathvariant="normal">tot</mi></msubsup>
+                  <mo>=</mo>
+                  <msubsup><mi mathvariant="bold">F</mi><mi>i</mi><mi mathvariant="normal">Heron</mi></msubsup>
+                  <mo>+</mo>
+                  <msubsup><mi mathvariant="bold">F</mi><mi>i</mi><mi mathvariant="normal">p</mi></msubsup>
+                  <mo>+</mo>
+                  <msubsup><mi mathvariant="bold">F</mi><mi>i</mi><mi mathvariant="normal">damp</mi></msubsup>
+                  <mo>+</mo>
+                  <msubsup><mi mathvariant="bold">F</mi><mi>i</mi><mi mathvariant="normal">flux</mi></msubsup>
+                </mrow>
+                """
+            ),
+            14,
+            "left",
+        ),
+        (
+            "force 2",
+            math(
+                """
+                <mrow>
+                  <msubsup><mi mathvariant="bold">F</mi><mi>i</mi><mi mathvariant="normal">Heron</mi></msubsup>
+                  <mo>=</mo>
+                  <mo>-</mo><mi>γ</mi>
+                  <msub>
+                    <mrow><mo stretchy="false">(</mo><mi mathvariant="bold">HN</mi><mo>&#160;</mo><mi mathvariant="normal">dA</mi><mo stretchy="false">)</mo></mrow>
+                    <mi>i</mi>
+                  </msub>
+                </mrow>
+                """
+            ),
+            14,
+            "left",
+        ),
+        (
+            "force 3",
+            math(
+                """
+                <mrow>
+                  <msubsup><mi mathvariant="bold">F</mi><mi>i</mi><mi mathvariant="normal">p</mi></msubsup>
+                  <mo>=</mo>
+                  <msub><mi mathvariant="normal">∑</mi><mrow><mi>t</mi><mo>∋</mo><mi>i</mi></mrow></msub>
+                  <msub><mi>p</mi><mi>t</mi></msub>
+                  <msub><mi mathvariant="bold">B</mi><mrow><mi>t</mi><mo>,</mo><mi>i</mi></mrow></msub>
+                  <mo>,</mo><mo>&#160;</mo>
+                  <msub><mi mathvariant="bold">B</mi><mrow><mi>t</mi><mo>,</mo><mi>i</mi></mrow></msub>
+                  <mo>=</mo>
+                  <mfrac>
+                    <mrow><mi>∂</mi><msub><mi>V</mi><mi>t</mi></msub></mrow>
+                    <mrow><mi>∂</mi><msub><mi mathvariant="bold">x</mi><mi>i</mi></msub></mrow>
+                  </mfrac>
+                </mrow>
+                """
+            ),
+            10,
+            "left",
+        ),
+        (
+            "force 4",
+            math(
+                """
+                <mrow>
+                  <msubsup><mi mathvariant="bold">F</mi><mi>i</mi><mi mathvariant="normal">damp</mi></msubsup>
+                  <mo>=</mo>
+                  <mo>-</mo><msub><mi>α</mi><mi>d</mi></msub><msub><mi>m</mi><mi>i</mi></msub><msub><mi mathvariant="bold">u</mi><mi>i</mi></msub>
+                  <mo>,</mo><mo>&#160;</mo>
+                  <msub><mi>α</mi><mi>d</mi></msub><mo>=</mo><mn>2</mn><mi>ζ</mi><msub><mi>ω</mi><mi>R</mi></msub>
+                </mrow>
+                """
+            ),
+            12,
+            "left",
+        ),
+        (
+            "force 5",
+            math(
+                """
+                <mrow>
+                  <msubsup><mi mathvariant="bold">F</mi><mi>i</mi><mi mathvariant="normal">flux</mi></msubsup>
+                  <mo>=</mo>
+                  <mfrac><mn>1</mn><mn>4</mn></mfrac>
+                  <msub><mi mathvariant="normal">∑</mi><mrow><mi>t</mi><mo>∋</mo><mi>i</mi></mrow></msub>
+                  <msub><mi>λ</mi><mi>F</mi></msub>
+                  <msub><mi>s</mi><mi mathvariant="normal">lim</mi></msub>
+                  <msub><mi mathvariant="bold">C</mi><mi>t</mi></msub>
+                </mrow>
+                """
+            ),
+            16,
+            "left",
+        ),
+        (
+            "force 6",
+            math(
+                """
+                <mrow>
+                  <msubsup><mi mathvariant="bold">u</mi><mi>i</mi><mrow><mi>n</mi><mo>+</mo><mn>1</mn></mrow></msubsup>
+                  <mo>=</mo>
+                  <msubsup><mi mathvariant="bold">u</mi><mi>i</mi><mi>n</mi></msubsup>
+                  <mo>+</mo><mi>Δ</mi><mi>t</mi>
+                  <mfrac>
+                    <msubsup><mi mathvariant="bold">F</mi><mi>i</mi><mi mathvariant="normal">tot</mi></msubsup>
+                    <msub><mi>m</mi><mi>i</mi></msub>
+                  </mfrac>
+                  <mo>,</mo><mo>&#160;</mo>
+                  <msubsup><mi mathvariant="bold">x</mi><mi>i</mi><mrow><mi>n</mi><mo>+</mo><mn>1</mn></mrow></msubsup>
+                  <mo>=</mo>
+                  <msubsup><mi mathvariant="bold">x</mi><mi>i</mi><mi>n</mi></msubsup>
+                  <mo>+</mo><mi>Δ</mi><mi>t</mi>
+                  <msubsup><mi mathvariant="bold">u</mi><mi>i</mi><mrow><mi>n</mi><mo>+</mo><mn>1</mn></mrow></msubsup>
+                </mrow>
+                """
+            ),
+            10,
+            "left",
+        ),
+    ]
+    pressure_eqs = [
+        (
+            "closure 7",
+            math(
+                """
+                <mrow>
+                  <msubsup><mi mathvariant="bold">F</mi><mi>i</mi><mrow><mi mathvariant="normal">p</mi><mo>,</mo><mi mathvariant="normal">comp</mi></mrow></msubsup>
+                  <mo>=</mo>
+                  <msub><mi mathvariant="normal">∑</mi><mrow><mi>t</mi><mo>∋</mo><mi>i</mi></mrow></msub>
+                  <mo stretchy="false">(</mo>
+                  <msub><mi>p</mi><mi mathvariant="normal">ref</mi></msub>
+                  <mo>+</mo>
+                  <mi>δ</mi><msub><mi>p</mi><mi>t</mi></msub>
+                  <mo stretchy="false">)</mo>
+                  <msub><mi mathvariant="bold">B</mi><mrow><mi>t</mi><mo>,</mo><mi>i</mi></mrow></msub>
+                </mrow>
+                """
+            ),
+            8,
+            "right_top",
+        ),
+        (
+            "closure 0",
+            math(
+                """
+                <mrow>
+                  <msub><mi>p</mi><mi mathvariant="normal">ref</mi></msub>
+                  <mo>=</mo>
+                  <mo>-</mo>
+                  <mfrac>
+                    <mrow>
+                      <msub><mi mathvariant="normal">∑</mi><mi>i</mi></msub>
+                      <msub><mi mathvariant="bold">A</mi><mi>i</mi></msub>
+                      <mo>·</mo>
+                      <msubsup><mi mathvariant="bold">F</mi><mi>i</mi><mi mathvariant="normal">Heron</mi></msubsup>
+                    </mrow>
+                    <mrow>
+                      <msub><mi mathvariant="normal">∑</mi><mi>i</mi></msub>
+                      <msub><mi mathvariant="bold">A</mi><mi>i</mi></msub>
+                      <mo>·</mo>
+                      <msub><mi mathvariant="bold">A</mi><mi>i</mi></msub>
+                    </mrow>
+                  </mfrac>
+                </mrow>
+                """
+            ),
+            9,
+            "right_top",
+        ),
+        (
+            "closure 1",
+            math(
+                """
+                <mrow>
+                  <msub><mi>ρ</mi><mi>t</mi></msub>
+                  <mo>=</mo>
+                  <mfrac><msub><mi>m</mi><mi>t</mi></msub><msub><mi>V</mi><mi>t</mi></msub></mfrac>
+                  <mo>,</mo><mo>&#160;</mo>
+                  <msubsup><mi>V</mi><mi>t</mi><mi mathvariant="normal">tar</mi></msubsup>
+                  <mo>=</mo>
+                  <mfrac><msub><mi>m</mi><mi>t</mi></msub><msub><mi>ρ</mi><mn>0</mn></msub></mfrac>
+                </mrow>
+                """
+            ),
+            9,
+            "right_top",
+        ),
+        (
+            "closure 2",
+            math(
+                """
+                <mrow>
+                  <msub><mi mathvariant="bold">B</mi><mrow><mi>t</mi><mo>,</mo><mi>i</mi></mrow></msub>
+                  <mo>=</mo>
+                  <mfrac>
+                    <mrow><mi>∂</mi><msub><mi>V</mi><mi>t</mi></msub></mrow>
+                    <mrow><mi>∂</mi><msub><mi mathvariant="bold">x</mi><mi>i</mi></msub></mrow>
+                  </mfrac>
+                  <mo>,</mo><mo>&#160;</mo>
+                  <msub><mi>S</mi><mrow><mi>t</mi><mo>,</mo><mi>s</mi></mrow></msub>
+                  <mo>=</mo>
+                  <msub><mi mathvariant="normal">∑</mi><mi>i</mi></msub>
+                  <mfrac>
+                    <mrow>
+                      <msub><mi mathvariant="bold">B</mi><mrow><mi>t</mi><mo>,</mo><mi>i</mi></mrow></msub>
+                      <mo>·</mo>
+                      <msub><mi mathvariant="bold">B</mi><mrow><mi>s</mi><mo>,</mo><mi>i</mi></mrow></msub>
+                    </mrow>
+                    <msub><mi>m</mi><mi>i</mi></msub>
+                  </mfrac>
+                  <mo>,</mo><mo>&#160;</mo>
+                  <mi mathvariant="bold">S</mi>
+                  <mo>=</mo>
+                  <mi mathvariant="bold">B</mi>
+                  <msup><mi mathvariant="bold">M</mi><mrow><mo>-</mo><mn>1</mn></mrow></msup>
+                  <msup><mi mathvariant="bold">B</mi><mi mathvariant="normal">T</mi></msup>
+                </mrow>
+                """
+            ),
+            7,
+            "right_top",
+        ),
+        (
+            "closure 3",
+            math(
+                """
+                <mrow>
+                  <mo stretchy="false">[</mo>
+                  <mi mathvariant="bold">I</mi>
+                  <mo>+</mo>
+                  <msup><mrow><mi>Δ</mi><mi>t</mi></mrow><mn>2</mn></msup>
+                  <msub><mi mathvariant="bold">D</mi><mi>K</mi></msub><mi mathvariant="bold">S</mi>
+                  <mo stretchy="false">]</mo>
+                  <mi>δ</mi><mi mathvariant="bold">p</mi>
+                  <mo>=</mo>
+                  <mo>-</mo>
+                  <msub><mi mathvariant="bold">D</mi><mi>K</mi></msub>
+                  <mo stretchy="false">(</mo>
+                  <mi mathvariant="bold">V</mi>
+                  <mo>-</mo>
+                  <msup><mi mathvariant="bold">V</mi><mi mathvariant="normal">tar</mi></msup>
+                  <mo>+</mo><mi>Δ</mi><mi>t</mi><mi mathvariant="bold">B</mi><msup><mi mathvariant="bold">u</mi><mo>*</mo></msup>
+                  <mo stretchy="false">)</mo>
+                </mrow>
+                """
+            ),
+            8,
+            "right_top",
+        ),
+        (
+            "closure 4",
+            math(
+                """
+                <mrow>
+                  <mi mathvariant="bold">S</mi><mi mathvariant="bold">p</mi>
+                  <mo>=</mo>
+                  <mfrac>
+                    <mrow><mi mathvariant="bold">r</mi><mo>-</mo><mi mathvariant="bold">B</mi><mi mathvariant="bold">u</mi></mrow>
+                    <mrow><mi>Δ</mi><mi>t</mi></mrow>
+                  </mfrac>
+                  <mo>-</mo>
+                  <mi mathvariant="bold">B</mi>
+                  <msup><mi mathvariant="bold">M</mi><mrow><mo>-</mo><mn>1</mn></mrow></msup>
+                  <msub><mi mathvariant="bold">F</mi><mi mathvariant="normal">np</mi></msub>
+                  <mo>,</mo><mo>&#160;</mo>
+                  <mi mathvariant="bold">r</mi>
+                  <mo>=</mo>
+                  <mo>-</mo>
+                  <mfrac>
+                    <mrow><mi mathvariant="bold">V</mi><mo>-</mo><msup><mi mathvariant="bold">V</mi><mi mathvariant="normal">tar</mi></msup></mrow>
+                    <mrow><mi>Δ</mi><mi>t</mi></mrow>
+                  </mfrac>
+                </mrow>
+                """
+            ),
+            8,
+            "right_top",
+        ),
+        (
+            "closure 5",
+            math(
+                """
+                <mrow>
+                  <mi mathvariant="bold">B</mi>
+                  <msup><mi mathvariant="bold">u</mi><mrow><mi>n</mi><mo>+</mo><mn>1</mn></mrow></msup>
+                  <mo>=</mo>
+                  <mi mathvariant="bold">r</mi>
+                </mrow>
+                """
+            ),
+            11,
+            "right_top",
+        ),
+        (
+            "closure 8",
+            math(
+                """
+                <mrow>
+                  <msubsup><mi mathvariant="bold">F</mi><mi>i</mi><mrow><mi mathvariant="normal">p</mi><mo>,</mo><mi mathvariant="normal">inc</mi></mrow></msubsup>
+                  <mo>=</mo>
+                  <msub><mi mathvariant="normal">∑</mi><mrow><mi>t</mi><mo>∋</mo><mi>i</mi></mrow></msub>
+                  <msubsup><mi>p</mi><mi>t</mi><mi mathvariant="normal">inc</mi></msubsup>
+                  <msub><mi mathvariant="bold">B</mi><mrow><mi>t</mi><mo>,</mo><mi>i</mi></mrow></msub>
+                </mrow>
+                """
+            ),
+            8,
+            "right_top",
+        ),
+        (
+            "closure 6",
+            math(
+                """
+                <mrow>
+                  <msub><mi mathvariant="bold">D</mi><mi>K</mi></msub>
+                  <mo>=</mo>
+                  <mi mathvariant="normal">diag</mi>
+                  <mo stretchy="false">(</mo>
+                  <mfrac><mi>K</mi><msubsup><mi>V</mi><mi>t</mi><mn>0</mn></msubsup></mfrac>
+                  <mo stretchy="false">)</mo>
+                  <mo>,</mo><mo>&#160;</mo>
+                  <msub><mi>p</mi><mi>t</mi></msub>
+                  <mo>=</mo>
+                  <msub><mi>p</mi><mi mathvariant="normal">ref</mi></msub>
+                  <mo>+</mo>
+                  <mi>δ</mi><msub><mi>p</mi><mi>t</mi></msub>
+                </mrow>
+                """
+            ),
+            8,
+            "right_top",
+        ),
+    ]
+    flux_eqs = [
+        (
+            "flux 1",
+            math(
+                """
+                <mrow>
+                  <msub><mi>Φ</mi><mrow><mi>m</mi><mo>,</mo><mi>f</mi></mrow></msub>
+                  <mo>=</mo>
+                  <msup><mi>ρ</mi><mi mathvariant="normal">up</mi></msup>
+                  <msub><mi>q</mi><mi>f</mi></msub>
+                  <mo>,</mo><mo>&#160;</mo>
+                  <msub><mi>q</mi><mi>f</mi></msub>
+                  <mo>=</mo>
+                  <mo stretchy="false">(</mo>
+                  <msub><mi mathvariant="bold">u</mi><mi>f</mi></msub>
+                  <mo>-</mo><msub><mi mathvariant="bold">w</mi><mi>f</mi></msub>
+                  <mo stretchy="false">)</mo>
+                  <mo>·</mo><msub><mi mathvariant="bold">A</mi><mi>f</mi></msub>
+                </mrow>
+                """
+            ),
+            10,
+            "right_bottom",
+        ),
+        (
+            "flux 2",
+            math(
+                """
+                <mrow>
+                  <msubsup><mi mathvariant="bold">Π</mi><mi>f</mi><mi mathvariant="normal">up</mi></msubsup>
+                  <mo>=</mo>
+                  <msubsup><mi>Φ</mi><mrow><mi>m</mi><mo>,</mo><mi>f</mi></mrow><mi mathvariant="normal">up</mi></msubsup>
+                  <msup><mi mathvariant="bold">u</mi><mi mathvariant="normal">up</mi></msup>
+                </mrow>
+                """
+            ),
+            10,
+            "right_bottom",
+        ),
+        (
+            "flux 7",
+            math(
+                """
+                <mrow>
+                  <msub><mi mathvariant="bold">u</mi><mi>f</mi></msub>
+                  <mo>=</mo>
+                  <msub><mi mathvariant="bold">w</mi><mi>f</mi></msub>
+                  <mo>=</mo>
+                  <mfrac><mn>1</mn><mn>3</mn></mfrac>
+                  <msub><mi mathvariant="normal">∑</mi><mrow><mi>i</mi><mo>∈</mo><mi>f</mi></mrow></msub>
+                  <msub><mi mathvariant="bold">u</mi><mi>i</mi></msub>
+                  <mo>⇒</mo>
+                  <msub><mi>Φ</mi><mrow><mi>m</mi><mo>,</mo><mi>f</mi></mrow></msub>
+                  <mo>=</mo>
+                  <mn>0</mn>
+                </mrow>
+                """
+            ),
+            10,
+            "right_bottom",
+        ),
+        (
+            "flux 3",
+            math(
+                """
+                <mrow>
+                  <msubsup><mi>Φ</mi><mrow><mi>m</mi><mo>,</mo><mi>f</mi></mrow><mi mathvariant="normal">R</mi></msubsup>
+                  <mo>=</mo>
+                  <mo stretchy="false">|</mo><mi mathvariant="bold">A</mi><mo stretchy="false">|</mo>
+                  <mo stretchy="false">[</mo>
+                  <mfrac><mn>1</mn><mn>2</mn></mfrac>
+                  <mo stretchy="false">(</mo><msub><mi>ρ</mi><mi mathvariant="normal">L</mi></msub><msub><mi>a</mi><mi mathvariant="normal">L</mi></msub><mo>+</mo><msub><mi>ρ</mi><mi mathvariant="normal">R</mi></msub><msub><mi>a</mi><mi mathvariant="normal">R</mi></msub><mo stretchy="false">)</mo>
+                  <mo>-</mo><mfrac><mn>1</mn><mn>2</mn></mfrac><msub><mi>c</mi><mi>f</mi></msub>
+                  <mo stretchy="false">(</mo><msub><mi>ρ</mi><mi mathvariant="normal">R</mi></msub><mo>-</mo><msub><mi>ρ</mi><mi mathvariant="normal">L</mi></msub><mo stretchy="false">)</mo>
+                  <mo stretchy="false">]</mo>
+                </mrow>
+                """
+            ),
+            8,
+            "right_bottom",
+        ),
+        (
+            "flux 4",
+            math(
+                """
+                <mrow>
+                  <msubsup><mi mathvariant="bold">Π</mi><mi>f</mi><mi mathvariant="normal">R</mi></msubsup>
+                  <mo>=</mo>
+                  <mo stretchy="false">|</mo><mi mathvariant="bold">A</mi><mo stretchy="false">|</mo>
+                  <mo stretchy="false">[</mo>
+                  <mfrac><mn>1</mn><mn>2</mn></mfrac>
+                  <mo stretchy="false">(</mo><msub><mi>ρ</mi><mi mathvariant="normal">L</mi></msub><msub><mi mathvariant="bold">u</mi><mi mathvariant="normal">L</mi></msub><msub><mi>a</mi><mi mathvariant="normal">L</mi></msub><mo>+</mo><msub><mi>ρ</mi><mi mathvariant="normal">R</mi></msub><msub><mi mathvariant="bold">u</mi><mi mathvariant="normal">R</mi></msub><msub><mi>a</mi><mi mathvariant="normal">R</mi></msub><mo stretchy="false">)</mo>
+                  <mo>-</mo><mfrac><mn>1</mn><mn>2</mn></mfrac><msub><mi>c</mi><mi>f</mi></msub>
+                  <mo stretchy="false">(</mo><msub><mi>ρ</mi><mi mathvariant="normal">R</mi></msub><msub><mi mathvariant="bold">u</mi><mi mathvariant="normal">R</mi></msub><mo>-</mo><msub><mi>ρ</mi><mi mathvariant="normal">L</mi></msub><msub><mi mathvariant="bold">u</mi><mi mathvariant="normal">L</mi></msub><mo stretchy="false">)</mo>
+                  <mo stretchy="false">]</mo>
+                </mrow>
+                """
+            ),
+            7,
+            "right_bottom",
+        ),
+        (
+            "flux 5",
+            math(
+                """
+                <mrow>
+                  <msub><mover><mi>m</mi><mo>˙</mo></mover><mrow><mi>L</mi><mo>,</mo><mi>f</mi></mrow></msub>
+                  <mo>=</mo>
+                  <mo>-</mo>
+                  <msub><mi>Φ</mi><mrow><mi>m</mi><mo>,</mo><mi>f</mi></mrow></msub>
+                  <mo>,</mo><mo>&#160;</mo>
+                  <msub><mover><mi>m</mi><mo>˙</mo></mover><mrow><mi>R</mi><mo>,</mo><mi>f</mi></mrow></msub>
+                  <mo>=</mo>
+                  <mo>+</mo>
+                  <msub><mi>Φ</mi><mrow><mi>m</mi><mo>,</mo><mi>f</mi></mrow></msub>
+                </mrow>
+                """
+            ),
+            10,
+            "right_bottom",
+        ),
+        (
+            "flux 6",
+            math(
+                """
+                <mrow>
+                  <msubsup><mi>m</mi><mi>t</mi><mrow><mi>n</mi><mo>+</mo><mn>1</mn></mrow></msubsup>
+                  <mo>=</mo>
+                  <mi mathvariant="normal">max</mi>
+                  <mo stretchy="false">(</mo>
+                  <msub><mi>m</mi><mi mathvariant="normal">floor</mi></msub>
+                  <mo>,</mo>
+                  <msubsup><mi>m</mi><mi>t</mi><mi>n</mi></msubsup>
+                  <mo>+</mo>
+                  <mi>Δ</mi><mi>t</mi><msub><mi>λ</mi><mi>m</mi></msub><msub><mi>s</mi><mi mathvariant="normal">lim</mi></msub>
+                  <msub><mover><mi>m</mi><mo>˙</mo></mover><mi>t</mi></msub>
+                  <mo stretchy="false">)</mo>
+                </mrow>
+                """
+            ),
+            9,
+            "right_bottom",
+        ),
+    ]
+    return force_eqs + pressure_eqs + flux_eqs
+
+
+def patch_slide2(xml: str, xslt: etree.XSLT) -> str:
+    xml = root_with_math_namespaces(xml)
+    next_id = max_shape_id(xml) + 1
+    equations = {
+        name: (omml_from_mathml(xslt, eq, size=UNIFORM_EQUATION_FONT_SIZE), group)
+        for name, eq, size, group in equation_mathml()
+    }
+
+    shapes: list[str] = []
+
+    def new_id() -> int:
+        nonlocal next_id
+        value = next_id
+        next_id += 1
+        return value
+
+    # Cover the previous equation text/cards while preserving the slide header/footer.
+    shapes.append(shape_start(new_id(), "Office math content cover", 44, 150, 1192, 510, "F7F8FA", None) + shape_end())
+
+    left_x, right_x = 52, 656
+    top_y, bottom_y = 154, 412
+    panel_w, top_h, bottom_h = 576, 246, 234
+    shapes.append(panel(new_id(), left_x, top_y, panel_w, top_h))
+    shapes.append(panel(new_id(), right_x, top_y, panel_w, top_h))
+    shapes.append(panel(new_id(), left_x, bottom_y, panel_w, bottom_h))
+    shapes.append(panel(new_id(), right_x, bottom_y, panel_w, bottom_h))
+
+    labels = {
+        "force 1": "component split",
+        "force 2": "HC Heron force",
+        "force 3": "uses volume gradient",
+        "force 4": "damping force (#5/#6 off)",
+        "force 5": "flux force",
+        "force 6": "time integration",
+        "closure 0": "reference pressure",
+        "closure 1": "density target",
+        "closure 2": "stiffness entry",
+        "closure 3": "compressible solve",
+        "closure 4": "incomp pressure solve",
+        "closure 5": "velocity constraint",
+        "closure 6": "EOS pressure",
+        "closure 7": "EOS pressure force",
+        "closure 8": "projection pressure force",
+        "flux 1": "material face flux",
+        "flux 2": "upwind momentum",
+        "flux 7": "Lagrangian face",
+        "flux 3": "Rusanov mass flux",
+        "flux 4": "Rusanov momentum",
+        "flux 5": "face mass source",
+        "flux 6": "limited mass update",
+    }
+
+    def add_rows(names: list[str], x: float, y: float, *, row0: float, step: float, eq_w: float, eq_h: float,
+                 label_x: float, label_w: float, label_size: int = 8) -> None:
+        for idx, name in enumerate(names):
+            row_y = y + row0 + idx * step
+            shapes.append(math_shape(new_id(), f"Office equation {name}", equations[name][0], x + 28, row_y, eq_w, eq_h))
+            shapes.append(text_shape(
+                new_id(),
+                f"Equation label {name}",
+                labels[name],
+                x + label_x,
+                row_y + 6,
+                label_w,
+                18,
+                font_size=label_size,
+                color="5B6470",
+            ))
+
+    shapes.append(text_shape(new_id(), "Force component title", "Common force/update", left_x + 22, top_y + 18, 360, 24, font_size=18, bold=True))
+    add_rows(
+        ["force 1", "force 2", "force 4", "force 6"],
+        left_x,
+        top_y,
+        row0=52,
+        step=42,
+        eq_w=396,
+        eq_h=32,
+        label_x=438,
+        label_w=118,
+        label_size=8,
+    )
+
+    shapes.append(text_shape(new_id(), "Compressible title", "Compressible EOS closure", right_x + 22, top_y + 18, 390, 24, font_size=18, bold=True))
+    add_rows(
+        ["closure 7", "closure 0", "closure 1", "closure 2", "closure 6", "closure 3"],
+        right_x,
+        top_y,
+        row0=58,
+        step=31,
+        eq_w=398,
+        eq_h=30,
+        label_x=440,
+        label_w=118,
+        label_size=8,
+    )
+
+    shapes.append(text_shape(new_id(), "ALE flux title", "ALE flux and mass update", left_x + 22, bottom_y + 18, 390, 24, font_size=18, bold=True))
+    add_rows(
+        ["flux 1", "flux 7", "flux 2", "flux 5", "flux 6"],
+        left_x,
+        bottom_y,
+        row0=47,
+        step=34,
+        eq_w=398,
+        eq_h=30,
+        label_x=438,
+        label_w=118,
+        label_size=7,
+    )
+    shapes.append(text_shape(
+        new_id(),
+        "ALE flux note",
+        "#3-#6: material-face ALE; #5/#6 use lambda_m = lambda_F = 1. Material face gives Phi_m,f = Pi_f = 0.",
+        left_x + 28,
+        bottom_y + 220,
+        505,
+        16,
+        font_size=7,
+        color="5B6470",
+    ))
+
+    shapes.append(text_shape(new_id(), "Incompressible title", "Incompressible projection", right_x + 22, bottom_y + 18, 390, 24, font_size=18, bold=True))
+    add_rows(
+        ["closure 8", "closure 2", "closure 4", "closure 5"],
+        right_x,
+        bottom_y,
+        row0=50,
+        step=42,
+        eq_w=398,
+        eq_h=34,
+        label_x=440,
+        label_w=118,
+        label_size=8,
+    )
+
+    shapes.append(text_shape(
+        new_id(),
+        "Projection reference",
+        "Projection ref: Chorin (1968), Numerical solution of the Navier-Stokes equations, Math. Comput. 22(104), 745-762.",
+        84,
+        648,
+        1060,
+        16,
+        font_size=8,
+        color="5B6470",
+    ))
+    shapes.append(text_shape(
+        new_id(),
+        "Compressible pressure EOS reference",
+        "Compressible pressure/EOS ref: Chen & Przekwas (2010), A coupled pressure-based computational method for incompressible/compressible flows, JCP 229(24), 9150-9165.",
+        84,
+        664,
+        1060,
+        16,
+        font_size=8,
+        color="5B6470",
+    ))
+
+    overlay_xml = "".join(shapes)
+    return xml.replace("</p:spTree>", f"{overlay_xml}</p:spTree>", 1)
+
+
+CASE_DAMPING_SUBTITLES = {
+    "ppt/slides/slide5.xml": (
+        "Incompressible local projection | lambda_m = 0; lambda_F = 0; material-face flux diagnostic",
+        "Incompressible local projection | lambda_m = 0; lambda_F = 0; material-face flux diagnostic | F_damp = 0; inertia scale = 1.08",
+    ),
+    "ppt/slides/slide6.xml": (
+        "Weak-compressible EOS | lambda_m = 0; lambda_F = 0; material-face flux diagnostic",
+        "Weak-compressible EOS | lambda_m = 0; lambda_F = 0; material-face flux diagnostic | F_damp = 0; inertia scale = 1.08",
+    ),
+    "ppt/slides/slide7.xml": (
+        "Incompressible local projection | lambda_m = 1e-6; lambda_F = 0; material-face flux",
+        "Incompressible local projection | lambda_m = 1e-6; lambda_F = 0; material-face flux | F_damp = 0; inertia scale = 1.08",
+    ),
+    "ppt/slides/slide8.xml": (
+        "Weak-compressible EOS | lambda_m = 1e-6; lambda_F = 0; material-face flux",
+        "Weak-compressible EOS | lambda_m = 1e-6; lambda_F = 0; material-face flux | F_damp = 0; inertia scale = 1.08",
+    ),
+    "ppt/slides/slide9.xml": (
+        "Weak-compressible EOS + Lagrangian full flux | lambda_m = 1; lambda_F = 1; material-face flux; no rho limiter",
+        "Weak-compressible EOS + Lagrangian full flux | lambda_m = 1; lambda_F = 1; material-face flux; no rho limiter | F_damp = 0; inertia scale = 1.08",
+    ),
+    "ppt/slides/slide10.xml": (
+        "Incompressible projection + Lagrangian full flux | lambda_m = 1; lambda_F = 1; material-face flux; no rho limiter",
+        "Incompressible projection + Lagrangian full flux | lambda_m = 1; lambda_F = 1; material-face flux; no rho limiter | F_damp = 0; inertia scale = 1.08",
+    ),
+}
+
+
+def patch_case_slide_text(xml: str, filename: str) -> str:
+    old, new = CASE_DAMPING_SUBTITLES[filename]
+    if new in xml:
+        return xml
+    return xml.replace(old, new, 1)
+
+
+def patch_slide11_text(xml: str) -> str:
+    old = (
+        "Displayed #5 and #6 use F_damp = 0, inertia scale = 1.08, subdivision 1, lambda_m = lambda_F = 1, and no rho limiter."
+    )
+    new = (
+        "Key point: zero internal flux is correct for this moving-vertex Lagrangian droplet. Nonzero flux needs an ALE/remap or Eulerian FV solver."
+    )
+    xml = xml.replace(old, new, 1)
+    old2 = (
+        "Displayed #1-#6 use F_damp = 0, inertia scale = 1.08, subdivision 1, material-face flux where evaluated, and no rho limiter."
+    )
+    return xml.replace(old2, new, 1)
+
+
+def patch_pptx(input_path: Path, output_path: Path) -> None:
+    if not MATHML2OMML.exists():
+        raise FileNotFoundError(f"Missing Microsoft Word MathML converter: {MATHML2OMML}")
+    xslt = etree.XSLT(etree.parse(str(MATHML2OMML)))
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir) / "patched.pptx"
+        with zipfile.ZipFile(input_path, "r") as zin, zipfile.ZipFile(tmp_path, "w", zipfile.ZIP_DEFLATED) as zout:
+            for item in zin.infolist():
+                data = zin.read(item.filename)
+                if item.filename == "ppt/slides/slide3.xml":
+                    xml = data.decode("utf-8")
+                    data = patch_slide2(xml, xslt).encode("utf-8")
+                elif item.filename in CASE_DAMPING_SUBTITLES:
+                    xml = data.decode("utf-8")
+                    data = patch_case_slide_text(xml, item.filename).encode("utf-8")
+                elif item.filename == "ppt/slides/slide12.xml":
+                    xml = data.decode("utf-8")
+                    data = patch_slide11_text(xml).encode("utf-8")
+                zout.writestr(item, data)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(tmp_path, output_path)
+
+
+def main() -> int:
+    base = Path(__file__).resolve().parent
+    input_path = base / "outputs/manual-20260602-fheron-ppt/presentations/fheron-flux-cases/output/fheron-hc-six-cases-12slides.pptx"
+    output_path = base / "outputs/manual-20260602-fheron-ppt/presentations/fheron-flux-cases/output/fheron-hc-six-cases-12slides-office-math.pptx"
+    patch_pptx(input_path, output_path)
+    print(output_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cases_dynamic/oscillating_droplet_p_ref/scripts/plot_force_components_vs_t.py
+++ b/cases_dynamic/oscillating_droplet_p_ref/scripts/plot_force_components_vs_t.py
@@ -1,0 +1,427 @@
+#!/usr/bin/env python3
+"""Plot saved sphere force components versus time from restart history."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import tempfile
+from pathlib import Path
+
+os.environ.setdefault("MPLCONFIGDIR", str(Path(tempfile.gettempdir()) / "ddgclib_matplotlib_cache"))
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from matplotlib.lines import Line2D
+import numpy as np
+
+
+DEFAULT_RESTART_DIR = Path("v5CoxConti_restart1000_no_tetvolcsv_optimized_v2")
+
+
+def _latest_restart_json(restart_dir: Path) -> Path:
+    restart_jsons = sorted((restart_dir / "restart").glob("restart_step*.json"))
+    if restart_jsons:
+        return restart_jsons[-1]
+    history_json = restart_dir / "separation_history.json"
+    if history_json.exists():
+        return history_json
+    raise FileNotFoundError(f"No restart_step*.json or separation_history.json found under {restart_dir}")
+
+
+def _load_history(path: Path) -> list[dict]:
+    with path.open("r", encoding="utf-8") as fh:
+        payload = json.load(fh)
+    history = payload.get("history", payload if isinstance(payload, list) else [])
+    if not isinstance(history, list) or not history:
+        raise ValueError(f"No non-empty history list found in {path}")
+    return [row for row in history if isinstance(row, dict)]
+
+
+def _array(history: list[dict], key: str, scale: float = 1.0) -> np.ndarray:
+    return np.array([float(row.get(key, 0.0)) * scale for row in history], dtype=float)
+
+
+def _time_array(history: list[dict]) -> np.ndarray:
+    t_s = _array(history, "t")
+    if not np.any(np.isfinite(t_s)) or float(np.max(t_s) - np.min(t_s)) <= 0.0:
+        steps = _array(history, "step")
+        dt = _array(history, "dt")
+        dt_fallback = float(np.median(dt[dt > 0.0])) if np.any(dt > 0.0) else 0.01
+        t_s = steps * dt_fallback
+    return t_s
+
+
+def plot_force_components(history: list[dict], *, out_path: Path, source_label: str) -> None:
+    t_s = _time_array(history)
+    t_label = "time [s]"
+    top_total = _array(history, "top_force_axial", 1.0e3)
+    top_cap = _array(history, "top_cap_traction_axial", 1.0e3)
+    top_cl = _array(history, "top_contact_line_axial", 1.0e3)
+    bottom_total = _array(history, "bottom_force_axial", 1.0e3)
+    bottom_cap = _array(history, "bottom_cap_traction_axial", 1.0e3)
+    bottom_cl = _array(history, "bottom_contact_line_axial", 1.0e3)
+
+    fig, axes = plt.subplots(3, 1, figsize=(10.0, 8.0), sharex=True, constrained_layout=True)
+
+    axes[0].plot(t_s, top_total, label="top total", color="#1f77b4", linewidth=1.6)
+    axes[0].plot(t_s, top_cap, label="top cap traction", color="#ff7f0e", linewidth=1.2)
+    axes[0].plot(t_s, top_cl, label="top contact-line", color="#2ca02c", linewidth=1.2)
+    axes[0].set_ylabel("top axial force [mN]")
+    axes[0].legend(loc="best", fontsize=8)
+    axes[0].grid(True, alpha=0.25)
+
+    axes[1].plot(t_s, bottom_total, label="bottom total", color="#1f77b4", linewidth=1.6)
+    axes[1].plot(t_s, bottom_cap, label="bottom cap traction", color="#ff7f0e", linewidth=1.2)
+    axes[1].plot(t_s, bottom_cl, label="bottom contact-line", color="#2ca02c", linewidth=1.2)
+    axes[1].set_ylabel("bottom axial force [mN]")
+    axes[1].legend(loc="best", fontsize=8)
+    axes[1].grid(True, alpha=0.25)
+
+    axes[2].plot(t_s, top_cl, label="top contact-line", color="#2ca02c", linewidth=1.4)
+    axes[2].plot(t_s, bottom_cl, label="bottom contact-line", color="#9467bd", linewidth=1.4)
+    axes[2].axhline(0.0, color="black", linewidth=0.8, alpha=0.5)
+    axes[2].set_xlabel(t_label)
+    axes[2].set_ylabel("CL axial force [mN]")
+    axes[2].legend(loc="best", fontsize=8)
+    axes[2].grid(True, alpha=0.25)
+
+    fig.suptitle(f"Saved axial force components vs time\n{source_label}", fontsize=11)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_path, dpi=220)
+    plt.close(fig)
+
+
+def _has_solver_force_components(history: list[dict]) -> bool:
+    return any("solver_force_all_free_stress_axial" in row for row in history)
+
+
+def plot_solver_force_components(history: list[dict], *, out_path: Path, source_label: str) -> bool:
+    solver_history = [row for row in history if "solver_force_all_free_stress_axial" in row]
+    if not solver_history:
+        return False
+
+    t_s = _time_array(solver_history)
+    colors = {
+        "stress": "#1f77b4",
+        "pressure_contact_line": "#bcbd22",
+        "surface_tension_contact_line": "#9467bd",
+        "cox_contact_line": "#2ca02c",
+        "contact_line": "#17becf",
+        "damping": "#d62728",
+        "total": "#111111",
+    }
+    labels = {
+        "stress": r"surface-pressure-viscous force $F_{\sigma,p,\mu}$",
+        "pressure_contact_line": r"volume-constraint contact-line pressure force $F_{p,\mathrm{vol},cl}$",
+        "surface_tension_contact_line": r"liquid-air surface-tension contact-line force $F_{s,cl}$",
+        "cox_contact_line": r"Cox dynamic contact-line force $F_{\mathrm{cox},cl}$",
+        "contact_line": r"combined contact-line force $F_{p,\mathrm{vol},cl}+F_{s,cl}+F_{\mathrm{cox},cl}$",
+        "damping": "linear damping force -c u",
+        "total": r"total solver force $F_{\mathrm{tot}}$",
+    }
+    groups = [
+        ("all_free", "all free vertices"),
+        ("bottom_clring", "bottom contact-line ring"),
+        ("top_clring", "top contact-line ring"),
+    ]
+
+    fig, axes = plt.subplots(3, 1, figsize=(10.0, 8.5), sharex=True, constrained_layout=True)
+    for ax, (group_key, title) in zip(axes, groups):
+        for component in (
+            "stress",
+            "pressure_contact_line",
+            "surface_tension_contact_line",
+            "cox_contact_line",
+            "contact_line",
+            "damping",
+            "total",
+        ):
+            key = f"solver_force_{group_key}_{component}_axial"
+            values_mn = _array(solver_history, key, 1.0e3)
+            linewidth = 1.7 if component == "total" else 1.2
+            linestyle = "--" if component == "total" else "-"
+            ax.plot(
+                t_s,
+                values_mn,
+                label=labels[component],
+                color=colors[component],
+                linewidth=linewidth,
+                linestyle=linestyle,
+            )
+        ax.axhline(0.0, color="black", linewidth=0.8, alpha=0.45)
+        ax.set_ylabel("axial force [mN]")
+        ax.set_title(title, fontsize=10)
+        ax.legend(loc="best", fontsize=8)
+        ax.grid(True, alpha=0.25)
+    axes[-1].set_xlabel("time [s]")
+    step0 = int(float(solver_history[0].get("step", 0)))
+    step1 = int(float(solver_history[-1].get("step", 0)))
+    fig.suptitle(f"Solver Ftot decomposition vs time, steps {step0}-{step1}\n{source_label}", fontsize=11)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_path, dpi=220)
+    plt.close(fig)
+    return True
+
+
+def plot_solver_force_components_direction(
+    history: list[dict],
+    *,
+    out_path: Path,
+    source_label: str,
+    direction: str,
+    groups: list[tuple[str, str]],
+    ylabel: str,
+    title: str,
+) -> bool:
+    required_key = f"solver_force_{groups[0][0]}_stress_{direction}"
+    solver_history = [row for row in history if required_key in row]
+    if not solver_history:
+        return False
+
+    t_s = _time_array(solver_history)
+    colors = {
+        "stress": "#1f77b4",
+        "pressure_contact_line": "#bcbd22",
+        "surface_tension_contact_line": "#9467bd",
+        "cox_contact_line": "#2ca02c",
+        "contact_line": "#17becf",
+        "damping": "#d62728",
+        "total": "#111111",
+    }
+    labels = {
+        "stress": r"surface-pressure-viscous force $F_{\sigma,p,\mu}$",
+        "pressure_contact_line": r"volume-constraint contact-line pressure force $F_{p,\mathrm{vol},cl}$",
+        "surface_tension_contact_line": r"liquid-air surface-tension contact-line force $F_{s,cl}$",
+        "cox_contact_line": r"Cox dynamic contact-line force $F_{\mathrm{cox},cl}$",
+        "contact_line": r"combined contact-line force $F_{p,\mathrm{vol},cl}+F_{s,cl}+F_{\mathrm{cox},cl}$",
+        "damping": "linear damping force -c u",
+        "total": r"total solver force $F_{\mathrm{tot}}$",
+    }
+    fig, axes = plt.subplots(len(groups), 1, figsize=(10.0, 3.0 * len(groups)), sharex=True, constrained_layout=True)
+    if len(groups) == 1:
+        axes = [axes]
+    for ax, (group_key, group_title) in zip(axes, groups):
+        for component in (
+            "stress",
+            "pressure_contact_line",
+            "surface_tension_contact_line",
+            "cox_contact_line",
+            "contact_line",
+            "damping",
+            "total",
+        ):
+            key = f"solver_force_{group_key}_{component}_{direction}"
+            values_mn = _array(solver_history, key, 1.0e3)
+            linewidth = 1.7 if component == "total" else 1.2
+            linestyle = "--" if component == "total" else "-"
+            ax.plot(
+                t_s,
+                values_mn,
+                label=labels[component],
+                color=colors[component],
+                linewidth=linewidth,
+                linestyle=linestyle,
+            )
+        ax.axhline(0.0, color="black", linewidth=0.8, alpha=0.45)
+        ax.set_ylabel(ylabel)
+        ax.set_title(group_title, fontsize=10)
+        ax.legend(loc="best", fontsize=8)
+        ax.grid(True, alpha=0.25)
+    axes[-1].set_xlabel("time [s]")
+    step0 = int(float(solver_history[0].get("step", 0)))
+    step1 = int(float(solver_history[-1].get("step", 0)))
+    fig.suptitle(f"{title}, steps {step0}-{step1}\n{source_label}", fontsize=11)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_path, dpi=220)
+    plt.close(fig)
+    return True
+
+
+def plot_surface_tension_contact_line_force(history: list[dict], *, out_path: Path, source_label: str) -> bool:
+    key_prefix = "surface_tension_contact_line_force_from_liquid_surface_on_contact_line"
+    required_key = f"{key_prefix}_bottom_clring_slide"
+    fscl_history = [row for row in history if required_key in row]
+    if not fscl_history:
+        return False
+
+    t_s = _time_array(fscl_history)
+    groups = [
+        ("bottom_clring", "bottom contact-line ring"),
+        ("top_clring", "top contact-line ring"),
+    ]
+    projection = "radial"
+
+    fig, ax_left = plt.subplots(1, 1, figsize=(12.8, 6.4), constrained_layout=True)
+    ax_right = ax_left.twinx()
+    colors = {
+        "surface_tension_contact_line": "#9467bd",
+        "cox_contact_line": "#2ca02c",
+        "pressure_contact_line": "#1f77b4",
+        "total": "#111111",
+    }
+    labels = {
+        "surface_tension_contact_line": r"liquid-air surface-tension force $F_{s,cl}^{(r)}$",
+        "cox_contact_line": r"Cox dynamic contact-line force $F_{\mathrm{cox},cl}^{(r)}$",
+        "pressure_contact_line": r"volume-constraint pressure force $F_{p,\mathrm{vol},cl}^{(r)}$",
+        "total": r"clean radial contact-line total $F_{\mathrm{tot},cl}^{(r)}$",
+    }
+
+    ring_styles = {
+        "bottom_clring": ("bottom contact-line ring", "-", "o"),
+        "top_clring": ("top contact-line ring", "--", "s"),
+    }
+    plot_order = (
+        "surface_tension_contact_line",
+        "cox_contact_line",
+        "pressure_contact_line",
+        "total",
+    )
+    dominant_names = ("surface_tension_contact_line", "total")
+    correction_names = ("cox_contact_line", "pressure_contact_line")
+    dominant_values_mn = []
+    correction_values_mn = []
+
+    for group_key, _group_label in groups:
+        ring_label, linestyle, marker = ring_styles[group_key]
+        fs_key = f"{key_prefix}_{group_key}_{projection}"
+        fcox_key = f"solver_force_{group_key}_cox_contact_line_{projection}"
+        fp_key = f"solver_force_{group_key}_pressure_contact_line_{projection}"
+        total_key = f"solver_force_{group_key}_total_{projection}"
+        series = {
+            "surface_tension_contact_line": _array(fscl_history, fs_key, 1.0e3),
+            "cox_contact_line": _array(fscl_history, fcox_key, 1.0e3),
+            "pressure_contact_line": _array(fscl_history, fp_key, 1.0e3),
+            "total": _array(fscl_history, total_key, 1.0e3),
+        }
+        for name in plot_order:
+            values_mn = series[name]
+            target_ax = ax_left if name in dominant_names else ax_right
+            if name in dominant_names:
+                dominant_values_mn.append(values_mn)
+            else:
+                correction_values_mn.append(values_mn)
+            linewidth = 2.4 if name == "total" else 1.8
+            alpha = 0.95 if name in ("pressure_contact_line", "cox_contact_line") else 0.86
+            target_ax.plot(
+                t_s,
+                values_mn,
+                color=colors[name],
+                linewidth=linewidth,
+                linestyle=linestyle,
+                marker=marker,
+                markersize=5.0,
+                alpha=alpha,
+            )
+    dominant_values = np.concatenate(dominant_values_mn)
+    dominant_values = dominant_values[np.isfinite(dominant_values)]
+    if dominant_values.size:
+        ymin = float(np.min(dominant_values))
+        ymax = float(np.max(dominant_values))
+        pad = max(0.12 * (ymax - ymin), 1.0e-4)
+        ax_left.set_ylim(ymin - pad, ymax + pad)
+    correction_values = np.concatenate(correction_values_mn)
+    correction_values = correction_values[np.isfinite(correction_values)]
+    ax_right.set_yscale("symlog", linthresh=1.0e-8, linscale=1.35, base=10)
+    if correction_values.size:
+        ymin = min(float(np.min(correction_values)) * 2.0, -1.0e-8)
+        ymax = max(float(np.max(correction_values)) * 2.0, 1.0e-8)
+        ax_right.set_ylim(ymin, ymax)
+    ax_right.axhline(0.0, color="#1f77b4", linewidth=0.9, alpha=0.45)
+    ax_left.set_xlabel("time [s]")
+    ax_left.set_ylabel(r"dominant inward radial force [mN]: $F_{s,cl}^{(r)}$, $F_{\mathrm{tot},cl}^{(r)}$")
+    ax_right.set_ylabel(r"small correction radial force [mN], symlog: $F_{\mathrm{cox},cl}^{(r)}$, $F_{p,\mathrm{vol},cl}^{(r)}$")
+    ax_left.grid(True, which="major", alpha=0.28)
+    ax_right.grid(True, which="minor", axis="y", alpha=0.12)
+    legend_handles = [
+        Line2D([0], [0], color=colors["surface_tension_contact_line"], lw=2.0, label=labels["surface_tension_contact_line"]),
+        Line2D([0], [0], color=colors["total"], lw=2.4, label=labels["total"]),
+        Line2D([0], [0], color=colors["cox_contact_line"], lw=2.0, label=labels["cox_contact_line"]),
+        Line2D([0], [0], color=colors["pressure_contact_line"], lw=2.0, label=labels["pressure_contact_line"]),
+        Line2D([0], [0], color="0.2", lw=2.0, linestyle="-", marker="o", label="bottom contact-line ring"),
+        Line2D([0], [0], color="0.2", lw=2.0, linestyle="--", marker="s", label="top contact-line ring"),
+    ]
+    ax_left.set_title(
+        "left axis: dominant forces; right axis: small correction forces. "
+        "solid/circle: bottom ring; dashed/square: top ring",
+        fontsize=10,
+    )
+    ax_left.legend(handles=legend_handles, loc="center right", bbox_to_anchor=(0.98, 0.52), ncol=1, fontsize=8)
+    step0 = int(float(fscl_history[0].get("step", 0)))
+    step1 = int(float(fscl_history[-1].get("step", 0)))
+    fig.suptitle(
+        r"Clean radial contact-line force balance: "
+        r"$F_{s,cl}^{(r)}$, $F_{\mathrm{cox},cl}^{(r)}$, "
+        r"$F_{p,\mathrm{vol},cl}^{(r)}$, and $F_{\mathrm{tot},cl}^{(r)}$, "
+        f"steps {step0}-{step1}\n"
+        f"{source_label}",
+        fontsize=11,
+    )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_path, dpi=220)
+    plt.close(fig)
+    return True
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--restart-dir", type=Path, default=DEFAULT_RESTART_DIR)
+    parser.add_argument("--history-json", type=Path, default=None)
+    parser.add_argument("--out", type=Path, default=None)
+    args = parser.parse_args()
+
+    source = args.history_json if args.history_json is not None else _latest_restart_json(args.restart_dir)
+    history = _load_history(source)
+    out_path = args.out or (args.restart_dir / "force_components_vs_t.png")
+    plot_force_components(history, out_path=out_path, source_label=str(source))
+    print(out_path)
+    solver_out = out_path.with_name("solver_force_components_vs_t.png")
+    if plot_solver_force_components(history, out_path=solver_out, source_label=str(source)):
+        print(solver_out)
+    else:
+        print("No solver_force_* diagnostics found in this history; rerun the solver after this patch to create them.")
+    radial_out = out_path.with_name("solver_force_components_radial_vs_t.png")
+    if plot_solver_force_components_direction(
+        history,
+        out_path=radial_out,
+        source_label=str(source),
+        direction="radial",
+        groups=[
+            ("all_free", "all free vertices"),
+            ("bottom_clring", "bottom contact-line ring"),
+            ("top_clring", "top contact-line ring"),
+        ],
+        ylabel="outward radial force [mN]",
+        title="Solver Ftot radial decomposition vs time",
+    ):
+        print(radial_out)
+    else:
+        print("No solver_force_*_radial diagnostics found in this history; rerun the solver after this patch.")
+    slide_out = out_path.with_name("solver_force_components_cl_slide_vs_t.png")
+    if plot_solver_force_components_direction(
+        history,
+        out_path=slide_out,
+        source_label=str(source),
+        direction="slide",
+        groups=[
+            ("bottom_clring", "bottom contact-line ring"),
+            ("top_clring", "top contact-line ring"),
+        ],
+        ylabel="sphere-tangent slide force [mN]",
+        title="Solver Ftot contact-line slide decomposition vs time",
+    ):
+        print(slide_out)
+    else:
+        print("No solver_force_*_slide diagnostics found in this history; rerun the solver after this patch.")
+    fscl_out = out_path.with_name("contact_line_radial_clean_balance_Ftot_Fpvol_Fcox_Fs_vs_t.png")
+    if plot_surface_tension_contact_line_force(history, out_path=fscl_out, source_label=str(source)):
+        print(fscl_out)
+    else:
+        print("No surface_tension_contact_line_force_from_liquid_surface_on_contact_line_* diagnostics found; rerun the solver after this patch.")
+
+
+if __name__ == "__main__":
+    main()

--- a/cases_dynamic/oscillating_droplet_p_ref/scripts/plot_github_case_a2_vs_t.py
+++ b/cases_dynamic/oscillating_droplet_p_ref/scripts/plot_github_case_a2_vs_t.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+ROOT = Path(__file__).resolve().parent
+ROWS_PATH = ROOT / "out/sphere_fheron_case11_github_twophase_eos_preview/compressible_rows.json"
+OUT_DIR = ROOT / "out/github_case_a2_vs_t"
+
+
+def main() -> None:
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    rows = json.loads(ROWS_PATH.read_text())
+    t = np.array([row["t"] for row in rows], dtype=float)
+    a_sim = np.array([row["shape_amplitude_fit"] for row in rows], dtype=float)
+    a_theory = np.array([row["shape_amplitude_theory"] for row in rows], dtype=float)
+
+    rmse = float(np.sqrt(np.mean((a_sim - a_theory) ** 2)))
+    maxerr = float(np.max(np.abs(a_sim - a_theory)))
+
+    fig, axes = plt.subplots(2, 1, figsize=(9.0, 7.0), sharex=True, constrained_layout=True)
+
+    ax = axes[0]
+    ax.plot(t, a_theory, "k--", lw=2.0, label="Rayleigh theory")
+    ax.plot(t, a_sim, color="#1f77b4", lw=2.0, label="ddgclib GitHub case: fitted $a_2$")
+    ax.scatter([t[-1]], [a_sim[-1]], color="#d62728", s=40, zorder=5)
+    ax.set_ylabel("$a_2$")
+    ax.set_title("ddgclib GitHub oscillating-droplet case: $a_2(t)$ vs Rayleigh theory")
+    ax.grid(True, alpha=0.25)
+    ax.legend(frameon=False, loc="upper left")
+    ax.text(
+        0.02,
+        0.04,
+        (
+            f"RMSE = {rmse:.3f}\n"
+            f"max |error| = {maxerr:.3f}\n"
+            f"final sim = {a_sim[-1]:.3f}\n"
+            f"final theory = {a_theory[-1]:.3f}"
+        ),
+        transform=ax.transAxes,
+        va="bottom",
+        ha="left",
+        fontsize=10,
+        bbox={"facecolor": "white", "edgecolor": "0.8", "alpha": 0.9},
+    )
+
+    axz = axes[1]
+    axz.plot(t, a_theory, "k--", lw=2.0, label="Rayleigh theory")
+    axz.plot(t, a_sim, color="#1f77b4", lw=2.0, label="GitHub fitted $a_2$")
+    axz.axhline(0.0, color="0.7", lw=0.8)
+    axz.set_ylim(-0.08, 0.08)
+    axz.set_xlabel("t [s]")
+    axz.set_ylabel("$a_2$ zoom")
+    axz.set_title("Zoom to Rayleigh amplitude scale")
+    axz.grid(True, alpha=0.25)
+    axz.legend(frameon=False, loc="upper right")
+
+    png = OUT_DIR / "github_case_a2_vs_t.png"
+    fig.savefig(png, dpi=180)
+    plt.close(fig)
+    print(png)
+    print(
+        f"rows={len(rows)} t_end={t[-1]:.6f} "
+        f"sim_final={a_sim[-1]:.6f} theory_final={a_theory[-1]:.6f} "
+        f"rmse={rmse:.6f} maxerr={maxerr:.6f}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/cases_dynamic/oscillating_droplet_p_ref/scripts/pr33_operators.py
+++ b/cases_dynamic/oscillating_droplet_p_ref/scripts/pr33_operators.py
@@ -1,0 +1,1221 @@
+"""PR #33 benchmark-local operators.
+
+This module holds the pressure-reference, tet-volume, ALE-flux, dynamic
+integrator state, and active-retopology helpers used by the oscillating-droplet
+benchmark.  They are kept outside ``ddgclib.operators.stress`` and
+``ddgclib.operators.multiphase_stress`` so the core library only carries the
+existing stress/multiphase APIs while this case can still reuse ddgclib's Heron
+curvature routines.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# Benchmark add-on operators: HC/FHeron droplet volume-pressure closure
+# ---------------------------------------------------------------------------
+
+def build_surface_hc_from_faces(points: np.ndarray, faces: np.ndarray):
+    """Build an HC surface graph from triangular interface connectivity.
+
+    Reference: the surface curvature force uses the ddgclib/HyperCT Heron
+    integrated mean-curvature vector, as described in the ddgclib
+    fundamentals and in Heron's discrete curvature construction.
+    """
+    from hyperct import Complex
+
+    HC = Complex(3, domain=None)
+    vertices = [HC.V[tuple(float(x) for x in point)] for point in np.asarray(points, dtype=float)]
+    for a, b, c in np.asarray(faces, dtype=int):
+        va, vb, vc = vertices[int(a)], vertices[int(b)], vertices[int(c)]
+        va.connect(vb)
+        vb.connect(vc)
+        vc.connect(va)
+    for vertex in vertices:
+        vertex.u = np.zeros(3, dtype=float)
+        vertex.p = 0.0
+        vertex.m = 1.0
+        vertex.phase = 0
+        vertex.boundary = False
+        vertex.is_interface = True
+    return HC, vertices
+
+
+def heron_surface_force_from_faces(
+    points: np.ndarray,
+    faces: np.ndarray,
+    gamma: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return nodal FHeron and Heron scalar dual area on a surface mesh.
+
+    Formula used by the benchmark:
+
+        F_i^Heron = -gamma (HN dA)_i
+
+    Reference: ddgclib Heron curvature operator / HyperCT surface graph.
+    The function is intentionally separate from ``stress_force`` because it is
+    an interface curvature force, not a bulk Cauchy stress flux.
+    """
+    from ddgclib._curvatures_heron import hndA_i
+
+    _HC, vertices = build_surface_hc_from_faces(points, faces)
+    forces = np.zeros((len(vertices), 3), dtype=float)
+    areas = np.zeros(len(vertices), dtype=float)
+    for i, vertex in enumerate(vertices):
+        hnda_i, area_i = hndA_i(vertex)
+        forces[i] = -float(gamma) * np.asarray(hnda_i[:3], dtype=float)
+        areas[i] = float(area_i)
+    return forces, areas
+
+
+def mesh_volume_from_faces(points: np.ndarray, faces: np.ndarray) -> float:
+    """Closed triangular surface volume by signed origin tetrahedra."""
+    pts = np.asarray(points, dtype=float)
+    volumes = [
+        abs(float(np.dot(pts[int(a)], np.cross(pts[int(b)], pts[int(c)])))) / 6.0
+        for a, b, c in np.asarray(faces, dtype=int)
+    ]
+    return float(np.sum(volumes))
+
+
+def vertex_area_vectors_from_faces(points: np.ndarray, faces: np.ndarray) -> np.ndarray:
+    """Lumped oriented boundary area vectors.
+
+    These vectors are used only for pressure-equivalent diagnostics.  The
+    dynamic pressure operator below uses tet-volume gradients.
+    """
+    pts = np.asarray(points, dtype=float)
+    area_vectors = np.zeros_like(pts, dtype=float)
+    for a, b, c in np.asarray(faces, dtype=int):
+        a_i, b_i, c_i = int(a), int(b), int(c)
+        pa, pb, pc = pts[a_i], pts[b_i], pts[c_i]
+        area_vec = 0.5 * np.cross(pb - pa, pc - pa)
+        centroid = (pa + pb + pc) / 3.0
+        if float(np.dot(area_vec, centroid)) < 0.0:
+            area_vec = -area_vec
+        share = area_vec / 3.0
+        area_vectors[a_i] += share
+        area_vectors[b_i] += share
+        area_vectors[c_i] += share
+    return area_vectors
+
+
+def pressure_equivalent_from_forces(forces: np.ndarray, area_vectors: np.ndarray) -> float:
+    """Least-squares scalar pressure balancing a surface force.
+
+    Formula:
+
+        p = -sum_i A_i . F_i / sum_i A_i . A_i
+    """
+    denom = float(np.sum(np.asarray(area_vectors, dtype=float) * np.asarray(area_vectors, dtype=float)))
+    if denom <= 0.0:
+        return 0.0
+    return -float(np.sum(np.asarray(area_vectors, dtype=float) * np.asarray(forces, dtype=float))) / denom
+
+
+def heron_forces_for_points(
+    points: np.ndarray,
+    faces: np.ndarray,
+    gamma: float,
+) -> tuple[np.ndarray, np.ndarray, float, float]:
+    """Return FHeron, area vectors, equivalent capillary pressure, volume."""
+    forces, _areas = heron_surface_force_from_faces(points, faces, gamma)
+    area_vectors = vertex_area_vectors_from_faces(points, faces)
+    pressure = pressure_equivalent_from_forces(forces, area_vectors)
+    return forces, area_vectors, pressure, mesh_volume_from_faces(points, faces)
+
+
+def tet_cell_volumes(points: np.ndarray, tets: np.ndarray) -> np.ndarray:
+    """Tetrahedron volumes for a simplicial volume mesh."""
+    pts = np.asarray(points, dtype=float)
+    tet_arr = np.asarray(tets, dtype=int)
+    p0 = pts[tet_arr[:, 0]]
+    p1 = pts[tet_arr[:, 1]]
+    p2 = pts[tet_arr[:, 2]]
+    p3 = pts[tet_arr[:, 3]]
+    triple = np.einsum("ij,ij->i", p1 - p0, np.cross(p2 - p0, p3 - p0))
+    return np.abs(triple) / 6.0
+
+
+def tet_volume_matrix(points: np.ndarray, tets: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Tet volumes and volume-gradient matrix B.
+
+    B[t, 3*i:3*i+3] = dV_t / dx_i, so B u is the discrete tet-volume
+    continuity operator.  This is the pressure operator used in the corrected
+    droplet benchmark.
+
+    References: Chorin (1968) and Temam projection methods for the role of
+    a pressure constraint; here the discrete volume gradient replaces a grid
+    divergence on the unstructured Lagrangian tet mesh.
+    """
+    pts = np.asarray(points, dtype=float)
+    tet_arr = np.asarray(tets, dtype=int)
+    volumes = np.zeros(tet_arr.shape[0], dtype=float)
+    matrix = np.zeros((tet_arr.shape[0], pts.shape[0] * 3), dtype=float)
+    for tet_idx, tet in enumerate(tet_arr):
+        i0, i1, i2, i3 = [int(i) for i in tet]
+        p0, p1, p2, p3 = pts[i0], pts[i1], pts[i2], pts[i3]
+        triple = float(np.dot(p1 - p0, np.cross(p2 - p0, p3 - p0)))
+        sign = 1.0 if triple >= 0.0 else -1.0
+        volumes[tet_idx] = abs(triple) / 6.0
+        g1 = sign * np.cross(p2 - p0, p3 - p0) / 6.0
+        g2 = sign * np.cross(p3 - p0, p1 - p0) / 6.0
+        g3 = sign * np.cross(p1 - p0, p2 - p0) / 6.0
+        g0 = -(g1 + g2 + g3)
+        for vertex_idx, gradient in ((i0, g0), (i1, g1), (i2, g2), (i3, g3)):
+            start = 3 * vertex_idx
+            matrix[tet_idx, start:start + 3] += gradient
+    return volumes, matrix
+
+
+def tet_volume_lumped_nodal_values(n_vertices: int, tets: np.ndarray, tet_values: np.ndarray) -> np.ndarray:
+    """Barycentric tet-volume lumping: each tet contributes value/4.
+
+    This is used after retopology to avoid HC-dual-volume jumps.  The sum of
+    nodal values is exactly the sum of tet values.
+    """
+    nodal = np.zeros(int(n_vertices), dtype=float)
+    for tet, value in zip(np.asarray(tets, dtype=int), np.asarray(tet_values, dtype=float)):
+        share = 0.25 * float(value)
+        for vertex_idx in tet:
+            nodal[int(vertex_idx)] += share
+    return nodal
+
+
+def lump_tet_masses(n_vertices: int, tets: np.ndarray, volumes: np.ndarray, rho: float) -> np.ndarray:
+    """Lump physical tet mass to vertices using barycentric tet-volume weights."""
+    return np.maximum(tet_volume_lumped_nodal_values(n_vertices, tets, float(rho) * np.asarray(volumes)), 1.0e-18)
+
+
+def mass_inverse_dof(masses: np.ndarray) -> np.ndarray:
+    """Repeat nodal inverse masses over x/y/z degrees of freedom."""
+    return np.repeat(1.0 / np.maximum(np.asarray(masses, dtype=float), 1.0e-300), 3)
+
+
+def local_volume_stiffness(matrix: np.ndarray, masses: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Return S = B M^-1 B^T and repeated inverse mass vector."""
+    inv_mass_dof = mass_inverse_dof(masses)
+    stiffness = (np.asarray(matrix, dtype=float) * inv_mass_dof[None, :]) @ np.asarray(matrix, dtype=float).T
+    return stiffness, inv_mass_dof
+
+
+def solve_regularized(matrix: np.ndarray, rhs: np.ndarray, *, relative: float = 1.0e-12) -> np.ndarray:
+    """Solve a possibly singular pressure system with light Tikhonov damping."""
+    lhs = np.asarray(matrix, dtype=float)
+    rhs_array = np.asarray(rhs, dtype=float)
+    scale = max(float(np.mean(np.abs(np.diag(lhs)))) if lhs.size else 0.0, 1.0e-30)
+    regularized = lhs + float(relative) * scale * np.eye(lhs.shape[0], dtype=float)
+    try:
+        return np.linalg.solve(regularized, rhs_array)
+    except np.linalg.LinAlgError:
+        return np.linalg.lstsq(regularized, rhs_array, rcond=1.0e-12)[0]
+
+
+def volume_gradient_pressure_matrix(volume_matrix: np.ndarray) -> np.ndarray:
+    """Map tet pressures to nodal forces with F^p = B^T p."""
+    return np.asarray(volume_matrix, dtype=float).T
+
+
+def compressible_eos_pressure_correction(
+    *,
+    velocities: np.ndarray,
+    nonpressure_forces: np.ndarray,
+    masses: np.ndarray,
+    tet_volumes: np.ndarray,
+    target_tet_volumes: np.ndarray,
+    reference_tet_volumes: np.ndarray,
+    volume_matrix: np.ndarray,
+    dt: float,
+    bulk_modulus: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Weak-compressible EOS pressure correction for tet volumes.
+
+    Solves:
+
+        (I + dt^2 D_K B M^-1 B^T) dp
+          = -D_K (V - Vtar + dt B u*)
+
+    Reference: pressure-based weakly compressible correction analogous to
+    coupled pressure-density solvers; the discrete B operator is the local
+    tet-volume continuity operator.
+    """
+    stiffness, inv_mass_dof = local_volume_stiffness(volume_matrix, masses)
+    u_star = np.asarray(velocities, dtype=float) + float(dt) * (
+        np.asarray(nonpressure_forces, dtype=float) / np.maximum(np.asarray(masses, dtype=float)[:, None], 1.0e-300)
+    )
+    compressibility = float(bulk_modulus) / np.maximum(np.asarray(reference_tet_volumes, dtype=float), 1.0e-300)
+    linear_error = (
+        np.asarray(tet_volumes, dtype=float)
+        - np.asarray(target_tet_volumes, dtype=float)
+        + float(dt) * (np.asarray(volume_matrix, dtype=float) @ u_star.reshape(-1))
+    )
+    system = np.eye(np.asarray(tet_volumes).shape[0]) + (compressibility[:, None] * float(dt) * float(dt)) * stiffness
+    rhs = -compressibility * linear_error
+    pressure_delta = solve_regularized(system, rhs)
+    velocity_vec = u_star.reshape(-1) + float(dt) * inv_mass_dof * (volume_gradient_pressure_matrix(volume_matrix) @ pressure_delta)
+    return velocity_vec.reshape(np.asarray(velocities).shape), pressure_delta
+
+
+def incompressible_volume_projection(
+    *,
+    velocities: np.ndarray,
+    nonpressure_forces: np.ndarray,
+    masses: np.ndarray,
+    tet_volumes: np.ndarray,
+    target_tet_volumes: np.ndarray,
+    volume_matrix: np.ndarray,
+    dt: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Local incompressible projection using B u^{n+1}=target_rates.
+
+    Reference: Chorin (1968), Temam projection methods.  This implementation
+    uses tet volume gradients, so the projected vertex velocity satisfies the
+    local discrete volume/continuity constraint.
+    """
+    inv_mass_dof = mass_inverse_dof(masses)
+    pressure_matrix = volume_gradient_pressure_matrix(volume_matrix)
+    target_rates = -(np.asarray(tet_volumes, dtype=float) - np.asarray(target_tet_volumes, dtype=float)) / float(dt)
+    velocity_vec = np.asarray(velocities, dtype=float).reshape(-1)
+    nonpressure_vec = np.asarray(nonpressure_forces, dtype=float).reshape(-1)
+    stiffness = (np.asarray(volume_matrix, dtype=float) * inv_mass_dof[None, :]) @ pressure_matrix
+    rhs = (
+        (target_rates - np.asarray(volume_matrix, dtype=float) @ velocity_vec) / float(dt)
+        - np.asarray(volume_matrix, dtype=float) @ (inv_mass_dof * nonpressure_vec)
+    )
+    pressure_values = solve_regularized(stiffness, rhs)
+    total_forces = np.asarray(nonpressure_forces, dtype=float) + (pressure_matrix @ pressure_values).reshape(np.asarray(velocities).shape)
+    projected = np.asarray(velocities, dtype=float) + float(dt) * (
+        inv_mass_dof * total_forces.reshape(-1)
+    ).reshape(np.asarray(velocities).shape)
+    return projected, pressure_values
+
+
+def tet_face_pairs(tets: np.ndarray) -> list[tuple[np.ndarray, int, int]]:
+    """Return internal tet faces as ``(face_vertices, left_tet, right_tet)``."""
+    face_map: dict[tuple[int, int, int], list[int]] = {}
+    for tet_idx, tet in enumerate(np.asarray(tets, dtype=int)):
+        a, b, c, d = [int(index) for index in tet]
+        for face in ((a, b, c), (a, b, d), (a, c, d), (b, c, d)):
+            face_map.setdefault(tuple(sorted(face)), []).append(tet_idx)
+    return [
+        (np.asarray(face, dtype=int), int(owners[0]), int(owners[1]))
+        for face, owners in face_map.items()
+        if len(owners) == 2
+    ]
+
+
+def tet_face_ale_fluxes(
+    points: np.ndarray,
+    velocities: np.ndarray,
+    tets: np.ndarray,
+    face_pairs: list[tuple[np.ndarray, int, int]],
+    tet_masses: np.ndarray,
+    reference_tet_masses: np.ndarray,
+    tet_volumes: np.ndarray,
+    dt: float,
+    *,
+    reference_density: float,
+    sound_speed: float,
+    mass_floor_fraction: float = 0.35,
+    mass_update_coupling: float = 0.02,
+    momentum_force_coupling: float = 0.0,
+    density_change_limit: float | None = None,
+    flux_cfl_limit: float = 0.25,
+    flux_scheme: str = "upwind",
+    face_flux_mode: str = "cell-average",
+) -> tuple[np.ndarray, np.ndarray, dict[str, float]]:
+    """Internal ALE face mass/momentum flux on a tet mesh.
+
+    References: Hirt, Amsden & Cook (1974) ALE formulation; Toro (2009) for
+    upwind/Rusanov numerical fluxes.  For ``face_flux_mode='lagrangian'`` the
+    mesh-face velocity equals the material-face velocity, so internal material
+    flux is zero; this is the physical setting for #5/#6/#11/#12.
+    """
+    if flux_scheme not in {"upwind", "rusanov"}:
+        raise ValueError("flux_scheme must be 'upwind' or 'rusanov'")
+    if face_flux_mode not in {"cell-average", "lagrangian"}:
+        raise ValueError("face_flux_mode must be 'cell-average' or 'lagrangian'")
+
+    n_tets = np.asarray(tets, dtype=int).shape[0]
+    cell_centers = np.mean(np.asarray(points, dtype=float)[np.asarray(tets, dtype=int)], axis=1)
+    cell_velocities = np.mean(np.asarray(velocities, dtype=float)[np.asarray(tets, dtype=int)], axis=1)
+    cell_density = np.asarray(tet_masses, dtype=float) / np.maximum(np.asarray(tet_volumes, dtype=float), 1.0e-300)
+    dm_dt = np.zeros(n_tets, dtype=float)
+    cell_force = np.zeros((n_tets, 3), dtype=float)
+    mass_flux_l1 = 0.0
+    max_abs_mass_flux = 0.0
+    momentum_flux_l1 = 0.0
+    volume_flux_l1 = 0.0
+
+    for face_vertices, left, right in face_pairs:
+        pa, pb, pc = np.asarray(points, dtype=float)[face_vertices]
+        area_vec = 0.5 * np.cross(pb - pa, pc - pa)
+        center_delta = cell_centers[right] - cell_centers[left]
+        if float(np.dot(area_vec, center_delta)) < 0.0:
+            area_vec = -area_vec
+        area = float(np.linalg.norm(area_vec))
+        if area <= 0.0:
+            continue
+        normal = area_vec / area
+        mesh_face_velocity = np.mean(np.asarray(velocities, dtype=float)[face_vertices], axis=0)
+        left_velocity = cell_velocities[left]
+        right_velocity = cell_velocities[right]
+        left_density = float(cell_density[left])
+        right_density = float(cell_density[right])
+
+        if face_flux_mode == "lagrangian":
+            relative_volume_flux = 0.0
+            mass_flux = 0.0
+            momentum_flux = np.zeros(3, dtype=float)
+        elif flux_scheme == "rusanov":
+            left_relative_normal = float(np.dot(left_velocity - mesh_face_velocity, normal))
+            right_relative_normal = float(np.dot(right_velocity - mesh_face_velocity, normal))
+            max_wave_speed = max(
+                abs(left_relative_normal) + float(sound_speed),
+                abs(right_relative_normal) + float(sound_speed),
+                1.0e-30,
+            )
+            mass_flux = area * (
+                0.5 * (left_density * left_relative_normal + right_density * right_relative_normal)
+                - 0.5 * max_wave_speed * (right_density - left_density)
+            )
+            momentum_flux = area * (
+                0.5 * (left_density * left_velocity * left_relative_normal + right_density * right_velocity * right_relative_normal)
+                - 0.5 * max_wave_speed * (right_density * right_velocity - left_density * left_velocity)
+            )
+            relative_volume_flux = mass_flux / max(0.5 * (left_density + right_density), 1.0e-300)
+        else:
+            fluid_face_velocity = 0.5 * (left_velocity + right_velocity)
+            relative_volume_flux = float(np.dot(fluid_face_velocity - mesh_face_velocity, area_vec))
+            if relative_volume_flux >= 0.0:
+                density = left_density
+                upwind_velocity = left_velocity
+            else:
+                density = right_density
+                upwind_velocity = right_velocity
+            mass_flux = density * relative_volume_flux
+            momentum_flux = mass_flux * upwind_velocity
+
+        dm_dt[left] -= mass_flux
+        dm_dt[right] += mass_flux
+        cell_force[left] -= momentum_flux
+        cell_force[right] += momentum_flux
+        mass_flux_l1 += abs(float(mass_flux))
+        max_abs_mass_flux = max(max_abs_mass_flux, abs(float(mass_flux)))
+        momentum_flux_l1 += float(np.linalg.norm(momentum_flux))
+        volume_flux_l1 += abs(float(relative_volume_flux))
+
+    effective_dm_dt = float(mass_update_coupling) * dm_dt
+    effective_cell_force = float(momentum_force_coupling) * cell_force
+    scale = 1.0
+    mass_delta = float(dt) * effective_dm_dt
+    mass_abs_delta = np.abs(mass_delta)
+    if flux_cfl_limit > 0.0 and np.any(mass_abs_delta > 0.0):
+        cfl_scale = np.min(
+            float(flux_cfl_limit) * np.asarray(tet_masses, dtype=float)[mass_abs_delta > 0.0]
+            / mass_abs_delta[mass_abs_delta > 0.0]
+        )
+        scale = min(scale, max(0.0, float(cfl_scale)))
+    floors = float(mass_floor_fraction) * np.asarray(reference_tet_masses, dtype=float)
+    proposed = np.asarray(tet_masses, dtype=float) + mass_delta
+    floor_bad = proposed < floors
+    if np.any(floor_bad):
+        denom = -mass_delta[floor_bad]
+        valid = denom > 0.0
+        if np.any(valid):
+            floor_scale = np.min((np.asarray(tet_masses)[floor_bad][valid] - floors[floor_bad][valid]) / denom[valid])
+            scale = min(scale, max(0.0, float(floor_scale)))
+    if density_change_limit is not None and density_change_limit > 0.0:
+        lower_masses = (1.0 - float(density_change_limit)) * float(reference_density) * np.maximum(tet_volumes, 1.0e-300)
+        upper_masses = (1.0 + float(density_change_limit)) * float(reference_density) * np.maximum(tet_volumes, 1.0e-300)
+        increasing = (mass_delta > 0.0) & (proposed > upper_masses)
+        if np.any(increasing):
+            density_scale = np.min((upper_masses[increasing] - np.asarray(tet_masses)[increasing]) / mass_delta[increasing])
+            scale = min(scale, max(0.0, float(density_scale)))
+        decreasing = (mass_delta < 0.0) & (proposed < lower_masses)
+        if np.any(decreasing):
+            density_scale = np.min((lower_masses[decreasing] - np.asarray(tet_masses)[decreasing]) / mass_delta[decreasing])
+            scale = min(scale, max(0.0, float(density_scale)))
+
+    effective_dm_dt *= scale
+    effective_cell_force *= scale
+    updated_masses = np.maximum(np.asarray(tet_masses, dtype=float) + float(dt) * effective_dm_dt, floors)
+    nodal_flux_force = np.zeros_like(np.asarray(points, dtype=float))
+    for tet, force in zip(np.asarray(tets, dtype=int), effective_cell_force):
+        for vertex_idx in tet:
+            nodal_flux_force[int(vertex_idx)] += 0.25 * force
+    stats = {
+        "mass_flux_l1_kg_s": float(mass_flux_l1),
+        "mass_flux_max_kg_s": float(max_abs_mass_flux),
+        "momentum_flux_l1_n": float(momentum_flux_l1),
+        "volume_flux_l1_m3_s": float(volume_flux_l1),
+        "flux_limiter_scale": float(scale),
+        "mass_update_coupling": float(mass_update_coupling),
+        "momentum_force_coupling": float(momentum_force_coupling),
+        "density_change_limit": float(density_change_limit) if density_change_limit is not None else 0.0,
+        "flux_cfl_limit": float(flux_cfl_limit),
+        "flux_scheme_rusanov": 1.0 if flux_scheme == "rusanov" else 0.0,
+        "face_flux_lagrangian": 1.0 if face_flux_mode == "lagrangian" else 0.0,
+    }
+    return updated_masses, nodal_flux_force, stats
+
+
+def delaunay_retriangulate_points(
+    points: np.ndarray,
+    fallback_tets: np.ndarray,
+    *,
+    qhull_options: str = "Qbb Qc",
+    min_volume_fraction: float = 0.1,
+) -> np.ndarray:
+    """Fresh Delaunay tet list for active retopology.
+
+    Reference: Delaunay retopology changes connectivity.  The benchmark
+    recomputes B=dV/dx and remaps tet mass/target volume from the new tet
+    volume list to avoid HC-dual-volume density jumps after flips.
+    """
+    try:
+        from scipy.spatial import Delaunay
+
+        triangulation = Delaunay(np.asarray(points, dtype=float), qhull_options=qhull_options)
+        raw_tets = np.asarray(triangulation.simplices, dtype=int)
+        valid = np.all(raw_tets < np.asarray(points).shape[0], axis=1)
+        raw_tets = raw_tets[valid]
+        if raw_tets.size == 0:
+            return np.asarray(fallback_tets, dtype=int).copy()
+        volumes = tet_cell_volumes(points, raw_tets)
+        positive = volumes[volumes > 0.0]
+        min_volume = float(min_volume_fraction) * float(np.median(positive)) if positive.size else 0.0
+        filtered = raw_tets[volumes > min_volume]
+        if filtered.size == 0:
+            return np.asarray(fallback_tets, dtype=int).copy()
+        return np.asarray(filtered, dtype=int)
+    except Exception:
+        return np.asarray(fallback_tets, dtype=int).copy()
+
+
+def active_retopology_tet_remap(
+    points: np.ndarray,
+    current_tets: np.ndarray,
+    *,
+    density: float | None = None,
+    target_total_mass: float | None = None,
+    target_total_volume: float | None = None,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, dict[str, float]]:
+    """Rebuild tets and remap mass/target volumes after retopology.
+
+    This is the controlled benchmark workaround for the HC dual-volume jump:
+    after a connectivity flip, use the new tet volumes directly and assign
+    m_t = rho V_t, V_t^tar = V_t.  It is not a conservative old-dual/new-dual
+    overlap remap.
+    """
+    old_sorted = {tuple(sorted(int(i) for i in tet)) for tet in np.asarray(current_tets, dtype=int)}
+    new_tets = delaunay_retriangulate_points(points, current_tets)
+    new_sorted = {tuple(sorted(int(i) for i in tet)) for tet in np.asarray(new_tets, dtype=int)}
+    changed = len(old_sorted.symmetric_difference(new_sorted))
+    new_volumes = tet_cell_volumes(points, new_tets)
+    current_volume = float(np.sum(new_volumes))
+    if current_volume <= 1.0e-300:
+        return np.asarray(current_tets, dtype=int).copy(), new_volumes, new_volumes, {
+            "retriangulation_active": 1.0,
+            "display_tet_count": float(np.asarray(current_tets).shape[0]),
+            "display_internal_face_count": float(len(tet_face_pairs(current_tets))),
+            "display_changed_tets": 0.0,
+            "display_changed_fraction": 0.0,
+        }
+    if target_total_mass is not None:
+        target_density = float(target_total_mass) / current_volume
+    elif density is not None:
+        target_density = float(density)
+    else:
+        raise ValueError("density or target_total_mass must be provided")
+    target_volume_scale = (
+        float(target_total_volume) / current_volume
+        if target_total_volume is not None
+        else 1.0
+    )
+    reference_tet_volumes = target_volume_scale * new_volumes
+    tet_masses = target_density * new_volumes
+    stats = {
+        "retriangulation_active": 1.0,
+        "display_tet_count": float(new_tets.shape[0]),
+        "display_internal_face_count": float(len(tet_face_pairs(new_tets))),
+        "display_changed_tets": float(changed),
+        "display_changed_fraction": float(changed) / max(float(len(old_sorted) + len(new_sorted)), 1.0),
+    }
+    return new_tets, reference_tet_volumes, tet_masses, stats
+
+
+def _tet_phase_retopology_remap(
+    points: np.ndarray,
+    current_tets: np.ndarray,
+    current_phases: np.ndarray,
+    *,
+    phase_densities: dict[int, float],
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, dict[str, float]]:
+    """Rebuild a phase-labelled tet list and reset tet mass/target volumes.
+
+    Each new Delaunay tet is assigned the phase of the nearest old tet center.
+    This compact remap is used by the oscillating-droplet pressure-reference
+    benchmark to make the pressure operator insensitive to HC dual-volume jumps
+    caused by Delaunay flips.
+    """
+    pts = np.asarray(points, dtype=float)
+    old_tets = np.asarray(current_tets, dtype=int)
+    old_phases = np.asarray(current_phases, dtype=int)
+    old_centers = np.mean(pts[old_tets], axis=1)
+    new_tets = delaunay_retriangulate_points(pts, old_tets)
+    new_centers = np.mean(pts[new_tets], axis=1)
+    new_phases = np.zeros(new_tets.shape[0], dtype=int)
+    for tet_idx, center in enumerate(new_centers):
+        nearest = int(np.argmin(np.sum((old_centers - center) ** 2, axis=1)))
+        new_phases[tet_idx] = int(old_phases[nearest])
+    new_volumes = tet_cell_volumes(pts, new_tets)
+    rho = np.asarray([float(phase_densities[int(phase)]) for phase in new_phases], dtype=float)
+    tet_masses = rho * new_volumes
+    old_sorted = {tuple(sorted(int(v) for v in tet)) for tet in old_tets}
+    new_sorted = {tuple(sorted(int(v) for v in tet)) for tet in new_tets}
+    changed = len(old_sorted.symmetric_difference(new_sorted))
+    stats = {
+        "retriangulation_active": 1.0,
+        "display_tet_count": float(new_tets.shape[0]),
+        "display_internal_face_count": float(len(tet_face_pairs(new_tets))),
+        "display_changed_tets": float(changed),
+        "display_changed_fraction": float(changed) / max(float(len(old_sorted) + len(new_sorted)), 1.0),
+    }
+    return new_tets, new_phases, new_volumes, tet_masses, stats
+
+
+class VolumeGradientPressureState:
+    """Cached tet-volume pressure operator for dynamic integrators.
+
+    This state is the pressure-reference drop-in for the face-average pressure
+    flux in :func:`stress_force`.  It keeps the standard vertex update
+
+        du_i/dt = F_i / m_i,     dx_i/dt = u_i
+
+    but computes the pressure force from tet-volume gradients,
+
+        B[t, 3*i:3*i+3] = dV_t / dx_i,        F^p = B^T p.
+
+    The compressible branch solves the EOS/continuity correction
+
+        (I + dt^2 D_K B M^{-1} B^T) dp
+          = -D_K (V - V_tar + dt B u*),
+
+    while the incompressible branch solves the local projection enforcing
+    ``B u^{n+1} = -(V - V_tar)/dt``.  References: Chorin (1968) projection
+    method; Hirt, Amsden & Cook (1974) ALE formulation; Toro (2009) Riemann
+    fluxes.  The Heron surface force is the ddgclib/HyperCT HC curvature force.
+    """
+
+    vertex_index_attr = "_volume_gradient_index"
+
+    def __init__(
+        self,
+        *,
+        tets: np.ndarray,
+        surface_indices: np.ndarray,
+        surface_faces: np.ndarray,
+        gamma: float,
+        density: float,
+        bulk_modulus: float | np.ndarray,
+        closure: str,
+        reference_tet_volumes: np.ndarray,
+        tet_masses: np.ndarray,
+        base_tet_pressures: float | np.ndarray,
+        dt: float,
+        inertia_scale: float = 1.0,
+        inertial_mass_addition: np.ndarray | None = None,
+        damping_rate: float = 0.0,
+        fixed_indices: np.ndarray | None = None,
+        phase_ids: np.ndarray | None = None,
+        phase_densities: dict[int, float] | None = None,
+        phase_bulk_moduli: dict[int, float] | None = None,
+        phase_base_pressures: dict[int, float] | None = None,
+        active_retopology: bool = False,
+        mass_flux_coupling: float = 0.0,
+        momentum_flux_coupling: float = 0.0,
+        density_change_limit: float | None = None,
+        flux_cfl_limit: float = 0.25,
+        flux_scheme: str = "upwind",
+        face_flux_mode: str = "lagrangian",
+        flux_timing: str = "pre-pressure",
+        mass_floor_fraction: float = 0.35,
+        sound_speed: float | None = None,
+        incompressible_target_mode: str = "reference",
+    ) -> None:
+        if closure not in {"compressible", "incompressible"}:
+            raise ValueError("closure must be 'compressible' or 'incompressible'")
+        if flux_timing not in {"pre-pressure", "post-pressure"}:
+            raise ValueError("flux_timing must be 'pre-pressure' or 'post-pressure'")
+        if incompressible_target_mode not in {"reference", "mass"}:
+            raise ValueError("incompressible_target_mode must be 'reference' or 'mass'")
+        self.tets = np.asarray(tets, dtype=int).copy()
+        self.surface_indices = np.asarray(surface_indices, dtype=int).copy()
+        self.surface_faces = np.asarray(surface_faces, dtype=int).copy()
+        self.gamma = float(gamma)
+        self.density = float(density)
+        self.bulk_modulus = np.asarray(bulk_modulus, dtype=float)
+        self.closure = closure
+        self.reference_tet_volumes = np.asarray(reference_tet_volumes, dtype=float).copy()
+        self.tet_masses = np.asarray(tet_masses, dtype=float).copy()
+        self.reference_tet_masses = self.tet_masses.copy()
+        self.base_tet_pressures = np.asarray(base_tet_pressures, dtype=float)
+        self.dt = float(dt)
+        self.inertia_scale = float(inertia_scale)
+        self.inertial_mass_addition = (
+            None if inertial_mass_addition is None else np.asarray(inertial_mass_addition, dtype=float).copy()
+        )
+        self.damping_rate = float(damping_rate)
+        self.fixed_indices = np.asarray(fixed_indices if fixed_indices is not None else [], dtype=int)
+        self.phase_ids = None if phase_ids is None else np.asarray(phase_ids, dtype=int).copy()
+        self.phase_densities = dict(phase_densities or {})
+        self.phase_bulk_moduli = dict(phase_bulk_moduli or {})
+        self.phase_base_pressures = dict(phase_base_pressures or {})
+        self.active_retopology = bool(active_retopology)
+        self.mass_flux_coupling = float(mass_flux_coupling)
+        self.momentum_flux_coupling = float(momentum_flux_coupling)
+        self.density_change_limit = density_change_limit
+        self.flux_cfl_limit = float(flux_cfl_limit)
+        self.flux_scheme = flux_scheme
+        self.face_flux_mode = face_flux_mode
+        self.flux_timing = flux_timing
+        self.mass_floor_fraction = float(mass_floor_fraction)
+        self.sound_speed = float(sound_speed) if sound_speed is not None else float(np.sqrt(float(np.max(self.bulk_modulus)) / self.density))
+        self.incompressible_target_mode = incompressible_target_mode
+        self.reference_total_mass = float(np.sum(self.tet_masses))
+        self.reference_total_volume = float(np.sum(self.reference_tet_volumes))
+        self.reference_display_tet_set = {tuple(sorted(int(v) for v in tet)) for tet in self.tets}
+        self.reference_nodal_volumes: np.ndarray | None = None
+        self.face_pairs = tet_face_pairs(self.tets)
+        self.accelerations: np.ndarray | None = None
+        self.last_new_velocities: np.ndarray | None = None
+        self.last_inertial_masses: np.ndarray | None = None
+        self.last_tet_volumes: np.ndarray | None = None
+        self.last_pressure_values: np.ndarray | None = None
+        self.last_fheron_pressure = 0.0
+        self.last_flux_stats = self._empty_flux_stats()
+        self.last_retopology_stats = self._empty_retopology_stats()
+        self.dirty = True
+
+    def _empty_flux_stats(self) -> dict[str, float]:
+        return {
+            "mass_flux_l1_kg_s": 0.0,
+            "mass_flux_max_kg_s": 0.0,
+            "momentum_flux_l1_n": 0.0,
+            "volume_flux_l1_m3_s": 0.0,
+            "flux_limiter_scale": 1.0,
+            "mass_update_coupling": float(self.mass_flux_coupling),
+            "momentum_force_coupling": float(self.momentum_flux_coupling),
+            "density_change_limit": float(self.density_change_limit) if self.density_change_limit is not None else 0.0,
+            "flux_cfl_limit": float(self.flux_cfl_limit),
+            "face_flux_lagrangian": 1.0 if self.face_flux_mode == "lagrangian" else 0.0,
+        }
+
+    def _empty_retopology_stats(self) -> dict[str, float]:
+        return {
+            "retriangulation_active": 1.0 if self.active_retopology else 0.0,
+            "display_tet_count": float(self.tets.shape[0]),
+            "display_internal_face_count": float(len(self.face_pairs)),
+            "display_changed_tets": 0.0,
+            "display_changed_fraction": 0.0,
+        }
+
+    def mark_dirty(self) -> None:
+        self.dirty = True
+
+    def read_hc_state(self, HC) -> tuple[np.ndarray, np.ndarray]:
+        n_vertices = 1 + max(int(getattr(v, self.vertex_index_attr)) for v in HC.V)
+        points = np.zeros((n_vertices, 3), dtype=float)
+        velocities = np.zeros((n_vertices, 3), dtype=float)
+        seen = np.zeros(n_vertices, dtype=bool)
+        for vertex in HC.V:
+            index = int(getattr(vertex, self.vertex_index_attr))
+            points[index] = np.asarray(vertex.x_a[:3], dtype=float)
+            velocities[index] = np.asarray(getattr(vertex, "u", np.zeros(3))[:3], dtype=float)
+            seen[index] = True
+        if not np.all(seen):
+            missing = np.flatnonzero(~seen)
+            raise ValueError(f"HC is missing volume-gradient vertex indices: {missing[:8]}")
+        return points, velocities
+
+    def write_hc_state(self, HC, points: np.ndarray, velocities: np.ndarray, bV=None) -> None:
+        boundary = set() if bV is None else bV
+        for vertex in list(HC.V):
+            index = int(getattr(vertex, self.vertex_index_attr))
+            vertex.u[:3] = np.asarray(velocities[index], dtype=float)
+            if vertex in boundary:
+                boundary.remove(vertex)
+                HC.V.move(vertex, tuple(np.asarray(points[index], dtype=float)))
+                boundary.add(vertex)
+            else:
+                HC.V.move(vertex, tuple(np.asarray(points[index], dtype=float)))
+
+    def retopologize_callback(self, HC, bV, dim, **_kwargs) -> None:
+        """Dynamic-integrator retopology hook.
+
+        The HyperCT vertices remain the ODE state.  This hook rebuilds only the
+        tet list, tet masses, target volumes, and cached pressure topology so
+        the next ``dudt_fn`` call uses the new Delaunay pressure operator.
+        """
+        if not self.active_retopology:
+            self.mark_dirty()
+            return
+        points, _velocities = self.read_hc_state(HC)
+        if self.phase_ids is None:
+            new_tets, new_reference_volumes, new_masses, stats = active_retopology_tet_remap(
+                points,
+                self.tets,
+                target_total_mass=self.reference_total_mass,
+                target_total_volume=self.reference_total_volume,
+            )
+            self.tets = np.asarray(new_tets, dtype=int)
+            self.reference_tet_volumes = np.asarray(new_reference_volumes, dtype=float)
+            self.tet_masses = np.asarray(new_masses, dtype=float)
+        else:
+            new_tets, new_phases, new_reference_volumes, new_masses, stats = _tet_phase_retopology_remap(
+                points,
+                self.tets,
+                self.phase_ids,
+                phase_densities=self.phase_densities,
+            )
+            self.tets = np.asarray(new_tets, dtype=int)
+            self.phase_ids = np.asarray(new_phases, dtype=int)
+            self.reference_tet_volumes = np.asarray(new_reference_volumes, dtype=float)
+            self.tet_masses = np.asarray(new_masses, dtype=float)
+        self.reference_tet_masses = self.tet_masses.copy()
+        self.face_pairs = tet_face_pairs(self.tets)
+        self.last_retopology_stats = stats
+        self.mark_dirty()
+
+    def _fixed_mask(self, n_vertices: int) -> np.ndarray:
+        mask = np.zeros(int(n_vertices), dtype=bool)
+        valid = self.fixed_indices[(self.fixed_indices >= 0) & (self.fixed_indices < n_vertices)]
+        mask[valid] = True
+        return mask
+
+    def _nodal_masses(self, n_vertices: int) -> np.ndarray:
+        nodal_mass = tet_volume_lumped_nodal_values(n_vertices, self.tets, self.tet_masses)
+        if self.inertial_mass_addition is not None:
+            nodal_mass = nodal_mass + np.asarray(self.inertial_mass_addition, dtype=float)
+        return np.maximum(float(self.inertia_scale) * nodal_mass, 1.0e-18)
+
+    def _inverse_mass_dof(self, masses: np.ndarray, fixed_mask: np.ndarray) -> np.ndarray:
+        inv_mass = np.repeat(1.0 / np.maximum(np.asarray(masses, dtype=float), 1.0e-300), 3)
+        inv_mass[np.repeat(np.asarray(fixed_mask, dtype=bool), 3)] = 0.0
+        return inv_mass
+
+    def _bulk_by_tet(self) -> np.ndarray:
+        if self.phase_ids is not None and self.phase_bulk_moduli:
+            return np.asarray([float(self.phase_bulk_moduli[int(phase)]) for phase in self.phase_ids], dtype=float)
+        if self.bulk_modulus.shape == ():
+            return np.full(self.tets.shape[0], float(self.bulk_modulus), dtype=float)
+        if self.bulk_modulus.shape[0] != self.tets.shape[0]:
+            return np.full(self.tets.shape[0], float(np.mean(self.bulk_modulus)), dtype=float)
+        return np.asarray(self.bulk_modulus, dtype=float)
+
+    def _base_pressures(self, reference_pressure: float) -> np.ndarray:
+        if self.phase_ids is not None and self.phase_base_pressures:
+            return np.asarray([float(self.phase_base_pressures.get(int(phase), 0.0)) for phase in self.phase_ids], dtype=float)
+        if self.base_tet_pressures.shape == ():
+            return np.full(self.tets.shape[0], float(self.base_tet_pressures), dtype=float)
+        if self.base_tet_pressures.shape[0] == self.tets.shape[0]:
+            return np.asarray(self.base_tet_pressures, dtype=float)
+        return np.full(self.tets.shape[0], float(reference_pressure), dtype=float)
+
+    def _density_by_tet(self) -> np.ndarray:
+        if self.phase_ids is not None and self.phase_densities:
+            return np.asarray([float(self.phase_densities[int(phase)]) for phase in self.phase_ids], dtype=float)
+        return np.full(self.tets.shape[0], float(self.density), dtype=float)
+
+    def _project_volume_velocity(
+        self,
+        velocities: np.ndarray,
+        volume_matrix: np.ndarray,
+        inv_mass_dof: np.ndarray,
+        target_rates: np.ndarray,
+    ) -> np.ndarray:
+        velocity_vec = np.asarray(velocities, dtype=float).reshape(-1)
+        stiffness = (np.asarray(volume_matrix, dtype=float) * np.asarray(inv_mass_dof, dtype=float)[None, :]) @ np.asarray(volume_matrix, dtype=float).T
+        rhs = np.asarray(volume_matrix, dtype=float) @ velocity_vec - np.asarray(target_rates, dtype=float)
+        multipliers = solve_regularized(stiffness, rhs)
+        projected = velocity_vec - np.asarray(inv_mass_dof, dtype=float) * (np.asarray(volume_matrix, dtype=float).T @ multipliers)
+        return projected.reshape(np.asarray(velocities).shape)
+
+    def prepare(self, HC, dt: float | None = None) -> None:
+        if not self.dirty and self.accelerations is not None:
+            return
+        step_dt = float(self.dt if dt is None else dt)
+        points, velocities = self.read_hc_state(HC)
+        n_vertices = points.shape[0]
+        tet_volumes, volume_matrix = tet_volume_matrix(points, self.tets)
+        fixed_mask = self._fixed_mask(n_vertices)
+        inertial_masses = self._nodal_masses(n_vertices)
+        inv_mass_dof = self._inverse_mass_dof(inertial_masses, fixed_mask)
+
+        flux_forces = np.zeros_like(points)
+        if self.flux_timing == "pre-pressure":
+            self.tet_masses, flux_forces, self.last_flux_stats = tet_face_ale_fluxes(
+                points,
+                velocities,
+                self.tets,
+                self.face_pairs,
+                self.tet_masses,
+                self.reference_tet_masses,
+                tet_volumes,
+                step_dt,
+                reference_density=self.density,
+                sound_speed=self.sound_speed,
+                mass_floor_fraction=self.mass_floor_fraction,
+                mass_update_coupling=self.mass_flux_coupling,
+                momentum_force_coupling=self.momentum_flux_coupling,
+                density_change_limit=self.density_change_limit,
+                flux_cfl_limit=self.flux_cfl_limit,
+                flux_scheme=self.flux_scheme,
+                face_flux_mode=self.face_flux_mode,
+            )
+            inertial_masses = self._nodal_masses(n_vertices)
+            inv_mass_dof = self._inverse_mass_dof(inertial_masses, fixed_mask)
+        else:
+            self.last_flux_stats = self._empty_flux_stats()
+
+        surface_forces, _surface_area_vectors, fheron_pressure, _surface_volume = heron_forces_for_points(
+            points[self.surface_indices],
+            self.surface_faces,
+            self.gamma,
+        )
+        self.last_fheron_pressure = float(fheron_pressure)
+        forces = np.zeros_like(points)
+        forces[self.surface_indices] += surface_forces
+        damping_forces = -float(self.damping_rate) * inertial_masses[:, None] * velocities
+        # This is the key pressure-reference choice.  The continuity residual
+        # and pressure force both use tet volumes, so after retopology the
+        # solver reacts to physical tet-volume error, not to HC dual-volume
+        # jumps caused by connectivity flips.
+        if self.closure == "compressible" or self.incompressible_target_mode == "mass":
+            target_tet_volumes = self.tet_masses / np.maximum(self._density_by_tet(), 1.0e-300)
+        else:
+            target_tet_volumes = self.reference_tet_volumes
+        pressure_matrix = volume_gradient_pressure_matrix(volume_matrix)
+
+        if self.closure == "compressible":
+            # Weak-compressible EOS correction:
+            #   (I + dt^2 D_K B M^-1 B^T) dp
+            #     = -D_K (V - Vtar + dt B u*)
+            # The pressure force is B^T p, which is adjoint to the same B that
+            # measures volume/continuity.  This adjoint pairing is what makes
+            # the Rayleigh response stable after retopology.
+            base_pressures = self._base_pressures(fheron_pressure)
+            nonpressure = forces + (pressure_matrix @ base_pressures).reshape(points.shape) + damping_forces + flux_forces
+            u_star = velocities + step_dt * (inv_mass_dof * nonpressure.reshape(-1)).reshape(points.shape)
+            u_star[fixed_mask] = 0.0
+            bulk_by_tet = self._bulk_by_tet()
+            compressibility = bulk_by_tet / np.maximum(self.reference_tet_volumes, 1.0e-300)
+            stiffness = (volume_matrix * inv_mass_dof[None, :]) @ pressure_matrix
+            linear_error = tet_volumes - target_tet_volumes + step_dt * (volume_matrix @ u_star.reshape(-1))
+            system = np.eye(self.tets.shape[0]) + (compressibility[:, None] * step_dt * step_dt) * stiffness
+            rhs = -compressibility * linear_error
+            pressure_delta = solve_regularized(system, rhs)
+            new_velocities = (
+                u_star.reshape(-1) + step_dt * inv_mass_dof * (pressure_matrix @ pressure_delta)
+            ).reshape(points.shape)
+            new_velocities[fixed_mask] = 0.0
+            self.last_pressure_values = base_pressures + pressure_delta
+        else:
+            # Local incompressible projection:
+            #   B u^{n+1} = -(V - Vtar)/dt
+            # This is the tet-volume analogue of a Chorin/Temam projection on
+            # a moving Lagrangian mesh.
+            target_rates = -(tet_volumes - target_tet_volumes) / step_dt
+            velocity_vec = velocities.reshape(-1)
+            nonpressure_vec = (forces + damping_forces + flux_forces).reshape(-1)
+            stiffness = (volume_matrix * inv_mass_dof[None, :]) @ pressure_matrix
+            rhs = (target_rates - volume_matrix @ velocity_vec) / step_dt - volume_matrix @ (inv_mass_dof * nonpressure_vec)
+            pressure_values = solve_regularized(stiffness, rhs)
+            total_forces = forces + (pressure_matrix @ pressure_values).reshape(points.shape) + damping_forces + flux_forces
+            new_velocities = velocities + step_dt * (inv_mass_dof * total_forces.reshape(-1)).reshape(points.shape)
+            new_velocities = self._project_volume_velocity(new_velocities, volume_matrix, inv_mass_dof, target_rates)
+            new_velocities[fixed_mask] = 0.0
+            self.last_pressure_values = pressure_values
+
+        if self.flux_timing == "post-pressure":
+            self.tet_masses, post_flux_forces, self.last_flux_stats = tet_face_ale_fluxes(
+                points,
+                new_velocities,
+                self.tets,
+                self.face_pairs,
+                self.tet_masses,
+                self.reference_tet_masses,
+                tet_volumes,
+                step_dt,
+                reference_density=self.density,
+                sound_speed=self.sound_speed,
+                mass_floor_fraction=self.mass_floor_fraction,
+                mass_update_coupling=self.mass_flux_coupling,
+                momentum_force_coupling=self.momentum_flux_coupling,
+                density_change_limit=self.density_change_limit,
+                flux_cfl_limit=self.flux_cfl_limit,
+                flux_scheme=self.flux_scheme,
+                face_flux_mode=self.face_flux_mode,
+            )
+            if self.momentum_flux_coupling:
+                post_masses = self._nodal_masses(n_vertices)
+                post_inv = self._inverse_mass_dof(post_masses, fixed_mask)
+                new_velocities = new_velocities + step_dt * (post_inv * post_flux_forces.reshape(-1)).reshape(points.shape)
+                new_velocities[fixed_mask] = 0.0
+
+        self.last_new_velocities = new_velocities
+        self.last_inertial_masses = inertial_masses
+        self.last_tet_volumes = tet_volumes
+        self.reference_nodal_volumes = tet_volume_lumped_nodal_values(n_vertices, self.tets, self.reference_tet_volumes)
+        self.accelerations = (new_velocities - velocities) / step_dt
+        self.dirty = False
+
+    def acceleration(self, vertex, *, HC=None, dt: float | None = None, dim: int = 3, mu: float = 0.0) -> np.ndarray:
+        """Return the cached acceleration for one vertex.
+
+        ``mu`` is accepted for API compatibility with ``dudt_i``.  The benchmark
+        pressure-reference runs set viscosity to zero so the pressure closure can
+        be compared directly with Rayleigh's inviscid oscillation frequency.
+        """
+        if HC is None:
+            raise ValueError("HC must be passed through the state or dudt wrapper")
+        if mu not in (0, 0.0):
+            raise NotImplementedError("VolumeGradientPressureState benchmark runs require mu=0")
+        self.prepare(HC, dt=dt)
+        index = int(getattr(vertex, self.vertex_index_attr))
+        accel = np.asarray(self.accelerations[index], dtype=float)
+        return accel[:dim]
+
+    def remove_rigid_translation(self, HC, bV=None) -> None:
+        """Remove center-of-mass drift after a completed Lagrangian step."""
+        if self.last_inertial_masses is None:
+            return
+        points, velocities = self.read_hc_state(HC)
+        masses = np.maximum(np.asarray(self.last_inertial_masses, dtype=float), 1.0e-300)
+        mass_sum = max(float(np.sum(masses)), 1.0e-300)
+        center = np.sum(points * masses[:, None], axis=0) / mass_sum
+        mean_velocity = np.sum(velocities * masses[:, None], axis=0) / mass_sum
+        fixed_mask = self._fixed_mask(points.shape[0])
+        points[~fixed_mask] -= center[None, :]
+        velocities[~fixed_mask] -= mean_velocity[None, :]
+        velocities[fixed_mask] = 0.0
+        self.write_hc_state(HC, points, velocities, bV=bV)
+        self.mark_dirty()
+
+    def diagnostics(self, HC) -> dict[str, float]:
+        points, velocities = self.read_hc_state(HC)
+        tet_volumes, _matrix = tet_volume_matrix(points, self.tets)
+        target = self.tet_masses / np.maximum(self._density_by_tet(), 1.0e-300) if self.closure == "compressible" else self.reference_tet_volumes
+        nodal_mass = tet_volume_lumped_nodal_values(points.shape[0], self.tets, self.tet_masses)
+        nodal_volume = tet_volume_lumped_nodal_values(points.shape[0], self.tets, tet_volumes)
+        pressure = self.last_pressure_values if self.last_pressure_values is not None else np.zeros(self.tets.shape[0])
+        local_volume_rel = tet_volumes / np.maximum(target, 1.0e-300)
+        if self.phase_ids is not None and self.phase_densities:
+            tet_density_reference = self._density_by_tet()
+            nodal_density_reference = tet_volume_lumped_nodal_values(points.shape[0], self.tets, tet_density_reference * tet_volumes)
+            nodal_density_reference = nodal_density_reference / np.maximum(nodal_volume, 1.0e-300)
+        else:
+            nodal_density_reference = np.full(points.shape[0], float(self.density), dtype=float)
+        density_rel = nodal_mass / np.maximum(nodal_volume, 1.0e-300) / np.maximum(nodal_density_reference, 1.0e-300)
+        stats = {
+            "closure_pressure_pa": float(np.mean(pressure)) if np.asarray(pressure).size else 0.0,
+            "fheron_pressure_pa": float(self.last_fheron_pressure),
+            "vol_m3": float(np.sum(tet_volumes)),
+            "vol0_mesh_m3": float(np.sum(self.reference_tet_volumes)),
+            "vol_rel": float(np.sum(tet_volumes) / max(float(np.sum(self.reference_tet_volumes)), 1.0e-300)),
+            "local_volume_rel_max_abs": float(np.max(np.abs(local_volume_rel - 1.0))) if local_volume_rel.size else 0.0,
+            "nodal_density_rel_min": float(np.min(density_rel[nodal_volume > 0.0])) if np.any(nodal_volume > 0.0) else 1.0,
+            "nodal_density_rel_max": float(np.max(density_rel[nodal_volume > 0.0])) if np.any(nodal_volume > 0.0) else 1.0,
+            "total_mass_kg": float(np.sum(self.tet_masses)),
+            "max_speed_m_s": float(np.max(np.linalg.norm(velocities, axis=1))) if velocities.size else 0.0,
+            "solver_tet_count": float(self.tets.shape[0]),
+        }
+        stats.update(self.last_flux_stats)
+        stats.update(self.last_retopology_stats)
+        current_tet_set = {tuple(sorted(int(v) for v in tet)) for tet in self.tets}
+        union = self.reference_display_tet_set | current_tet_set
+        changed = self.reference_display_tet_set ^ current_tet_set
+        stats["display_tet_count"] = float(self.tets.shape[0])
+        stats["display_internal_face_count"] = float(len(tet_face_pairs(self.tets)))
+        stats["display_changed_tets"] = float(len(changed))
+        stats["display_changed_fraction"] = float(len(changed)) / max(float(len(union)), 1.0)
+        return stats
+
+
+def volume_gradient_pressure_acceleration(vertex, *, state: VolumeGradientPressureState, HC=None, dt=None, dim: int = 3, mu: float = 0.0) -> np.ndarray:
+    """Dynamic-integrator ``dudt_fn`` for tet-volume pressure closure."""
+    if HC is None:
+        HC = getattr(state, "HC", None)
+    return state.acceleration(vertex, HC=HC, dt=dt, dim=dim, mu=mu)
+
+
+# ---------------------------------------------------------------------------
+# Benchmark add-on operators: multiphase tet-volume pressure closure
+# ---------------------------------------------------------------------------
+
+class MultiphaseVolumeGradientPressureState(VolumeGradientPressureState):
+    """Phase-labelled tet-volume pressure state for dynamic integrators.
+
+    The equations are inherited from ``VolumeGradientPressureState``:
+    ``B=dV/dx`` is rebuilt after active retopology, phase densities provide
+    ``V_t^tar=m_t/rho_phase``, and phase bulk moduli provide the EOS stiffness.
+    This is intentionally separate from ``multiphase_stress_force``: the
+    pressure-reference benchmark needs the pressure force ``B^T p`` to be
+    adjoint to the tet-volume continuity operator ``B``.
+
+    References: Chorin (1968) pressure projection; Hirt, Amsden & Cook (1974)
+    ALE moving mesh; Toro (2009) Riemann fluxes; ddgclib HC Heron curvature.
+    """
+
+
+def multiphase_volume_gradient_pressure_acceleration(vertex, *, state, HC=None, dt=None, dim: int = 3, mu: float = 0.0):
+    """Multiphase ``dudt_fn`` wrapper for the tet-volume pressure state."""
+    if HC is None:
+        HC = getattr(state, "HC", None)
+    return state.acceleration(vertex, HC=HC, dt=dt, dim=dim, mu=mu)
+
+
+def multiphase_tet_volume_matrix(points: np.ndarray, tets: np.ndarray):
+    """Tet volume-gradient operator for a multiphase simplicial mesh.
+
+    This wrapper intentionally uses tet volumes, not HC local dual volumes, so
+    a Delaunay flip does not directly create an HC-dual density/pressure jump.
+
+    References: Chorin projection/continuity pressure solves; ddgclib
+    retopology benchmark workaround for HC dual-volume jumps.
+    """
+    return tet_volume_matrix(points, tets)
+
+
+def multiphase_tet_volume_lumped_masses(
+    n_vertices: int,
+    tets: np.ndarray,
+    tet_volumes: np.ndarray,
+    phases: np.ndarray,
+    phase_densities: dict[int, float],
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return tet masses and barycentric nodal masses for phase-labelled tets.
+
+    Each tet receives ``rho_phase V_t`` and each tet mass is lumped one quarter
+    to its four vertices.
+    """
+    rho = np.asarray([float(phase_densities[int(phase)]) for phase in np.asarray(phases, dtype=int)], dtype=float)
+    tet_masses = rho * np.asarray(tet_volumes, dtype=float)
+    nodal_masses = tet_volume_lumped_nodal_values(n_vertices, tets, tet_masses)
+    return tet_masses, nodal_masses
+
+
+def multiphase_compressible_eos_pressure_correction(
+    *,
+    velocities: np.ndarray,
+    nonpressure_forces: np.ndarray,
+    inv_mass_dof: np.ndarray,
+    tet_volumes: np.ndarray,
+    target_tet_volumes: np.ndarray,
+    reference_tet_volumes: np.ndarray,
+    volume_matrix: np.ndarray,
+    base_pressures: np.ndarray,
+    bulk_by_tet: np.ndarray,
+    dt: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Multiphase weak-compressible pressure correction.
+
+    Solves the same EOS/continuity correction as the one-phase benchmark:
+
+        (I + dt^2 D_K B M^-1 B^T) dp
+          = -D_K (V - Vtar + dt B u*)
+
+    where ``D_K = diag(K_t/V_t^0)`` may differ by phase.
+    """
+    pressure_matrix = np.asarray(volume_matrix, dtype=float).T
+    u_star = np.asarray(velocities, dtype=float) + float(dt) * (
+        np.asarray(inv_mass_dof, dtype=float) * np.asarray(nonpressure_forces, dtype=float).reshape(-1)
+    ).reshape(np.asarray(velocities).shape)
+    compressibility = np.asarray(bulk_by_tet, dtype=float) / np.maximum(
+        np.asarray(reference_tet_volumes, dtype=float),
+        1.0e-300,
+    )
+    stiffness = (np.asarray(volume_matrix, dtype=float) * np.asarray(inv_mass_dof, dtype=float)[None, :]) @ pressure_matrix
+    linear_error = (
+        np.asarray(tet_volumes, dtype=float)
+        - np.asarray(target_tet_volumes, dtype=float)
+        + float(dt) * (np.asarray(volume_matrix, dtype=float) @ u_star.reshape(-1))
+    )
+    system = np.eye(np.asarray(tet_volumes).shape[0]) + (compressibility[:, None] * float(dt) * float(dt)) * stiffness
+    rhs = -compressibility * linear_error
+    pressure_delta = solve_regularized(system, rhs)
+    velocity_vec = u_star.reshape(-1) + float(dt) * np.asarray(inv_mass_dof, dtype=float) * (pressure_matrix @ pressure_delta)
+    return velocity_vec.reshape(np.asarray(velocities).shape), np.asarray(base_pressures, dtype=float) + pressure_delta
+
+
+def multiphase_incompressible_volume_projection(
+    *,
+    velocities: np.ndarray,
+    nonpressure_forces: np.ndarray,
+    inv_mass_dof: np.ndarray,
+    tet_volumes: np.ndarray,
+    target_tet_volumes: np.ndarray,
+    volume_matrix: np.ndarray,
+    dt: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Multiphase local incompressible projection with B u = target_rates.
+
+    Reference: Chorin/Temam projection method, applied to tet-volume
+    continuity on the moving multiphase mesh.
+    """
+    pressure_matrix = np.asarray(volume_matrix, dtype=float).T
+    target_rates = -(np.asarray(tet_volumes, dtype=float) - np.asarray(target_tet_volumes, dtype=float)) / float(dt)
+    velocity_vec = np.asarray(velocities, dtype=float).reshape(-1)
+    nonpressure_vec = np.asarray(nonpressure_forces, dtype=float).reshape(-1)
+    stiffness = (np.asarray(volume_matrix, dtype=float) * np.asarray(inv_mass_dof, dtype=float)[None, :]) @ pressure_matrix
+    rhs = (
+        (target_rates - np.asarray(volume_matrix, dtype=float) @ velocity_vec) / float(dt)
+        - np.asarray(volume_matrix, dtype=float) @ (np.asarray(inv_mass_dof, dtype=float) * nonpressure_vec)
+    )
+    pressure_values = solve_regularized(stiffness, rhs)
+    total_forces = np.asarray(nonpressure_forces, dtype=float) + (pressure_matrix @ pressure_values).reshape(np.asarray(velocities).shape)
+    projected = np.asarray(velocities, dtype=float) + float(dt) * (
+        np.asarray(inv_mass_dof, dtype=float) * total_forces.reshape(-1)
+    ).reshape(np.asarray(velocities).shape)
+    return projected, pressure_values
+
+
+def multiphase_active_retopology_remap(
+    points: np.ndarray,
+    current_tets: np.ndarray,
+    phases: np.ndarray,
+    *,
+    phase_densities: dict[int, float],
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, dict[str, float]]:
+    """Active retopology remap for phase-labelled tet meshes.
+
+    The new Delaunay tet list is rebuilt, each new tet is assigned the phase
+    of the nearest old tet center, and mass/target volume are recomputed from
+    the new tet volume.  This is a controlled benchmark remap, not a fully
+    conservative old/new-cell overlap remap.
+    """
+    pts = np.asarray(points, dtype=float)
+    old_tets = np.asarray(current_tets, dtype=int)
+    old_centers = np.mean(pts[old_tets], axis=1)
+    new_tets = delaunay_retriangulate_points(pts, old_tets)
+    new_centers = np.mean(pts[new_tets], axis=1)
+    new_phases = np.zeros(new_tets.shape[0], dtype=int)
+    for i, center in enumerate(new_centers):
+        nearest = int(np.argmin(np.sum((old_centers - center) ** 2, axis=1)))
+        new_phases[i] = int(np.asarray(phases, dtype=int)[nearest])
+    new_volumes = tet_cell_volumes(pts, new_tets)
+    rho = np.asarray([float(phase_densities[int(phase)]) for phase in new_phases], dtype=float)
+    tet_masses = rho * new_volumes
+    old_sorted = {tuple(sorted(int(v) for v in tet)) for tet in old_tets}
+    new_sorted = {tuple(sorted(int(v) for v in tet)) for tet in new_tets}
+    changed = len(old_sorted.symmetric_difference(new_sorted))
+    stats = {
+        "retriangulation_active": 1.0,
+        "display_tet_count": float(new_tets.shape[0]),
+        "display_internal_face_count": float(len(tet_face_pairs(new_tets))),
+        "display_changed_tets": float(changed),
+        "display_changed_fraction": float(changed) / max(float(len(old_sorted) + len(new_sorted)), 1.0),
+    }
+    return new_tets, new_phases, new_volumes, tet_masses, stats

--- a/cases_dynamic/oscillating_droplet_p_ref/scripts/render_dynamic_integrator_twophase.py
+++ b/cases_dynamic/oscillating_droplet_p_ref/scripts/render_dynamic_integrator_twophase.py
@@ -1,0 +1,273 @@
+"""Render #11/#12 dynamic-integrator two-phase validation GIFs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import sphere_fheron_eos_projection_benchmark as base
+
+
+plt = base.plt
+FuncAnimation = base.FuncAnimation
+PillowWriter = base.PillowWriter
+Line3DCollection = base.Line3DCollection
+Poly3DCollection = base.Poly3DCollection
+
+LIQUID = 1
+GAS = 0
+
+
+def row_array(rows: list[dict[str, float]], key: str, default: float = 0.0) -> np.ndarray:
+    return np.asarray([float(row.get(key, default)) for row in rows], dtype=float)
+
+
+def _frame_array(values, index: int) -> np.ndarray:
+    item = values[index]
+    if isinstance(item, np.ndarray):
+        return np.asarray(item)
+    return np.asarray(item, dtype=int)
+
+
+def render_case(
+    *,
+    case_id: int,
+    source_dir: Path,
+    out_dir: Path,
+    max_frames: int,
+    fps: int,
+) -> Path:
+    closure = "compressible" if int(case_id) == 11 else "incompressible"
+    stem = f"case{int(case_id)}_dynamic_integrator_twophase_{closure}"
+    rows = json.loads((source_dir / f"{stem}.json").read_text())
+    data = np.load(source_dir / f"{stem}_snapshots.npz", allow_pickle=True)
+    snapshots = np.asarray(data["points"], dtype=float)
+    faces = np.asarray(data["faces"], dtype=int)
+    interface_indices = np.asarray(data["surface_indices"], dtype=int)
+    outer_indices = np.asarray(data["outer_indices"], dtype=int)
+    display_tets = data["display_tets"]
+    display_phases = data["phases"]
+
+    t = row_array(rows, "t")
+    amplitude_theory = row_array(rows, "shape_amplitude_theory")
+    amplitude_fit = row_array(rows, "shape_amplitude_fit")
+    liquid_vol_pct = (row_array(rows, "liquid_vol_rel") - 1.0) * 100.0
+    gas_vol_pct = (row_array(rows, "gas_vol_rel") - 1.0) * 100.0
+    local_pct = row_array(rows, "local_volume_rel_max_abs") * 100.0
+    mass_flux = row_array(rows, "mass_flux_l1_kg_s")
+    momentum_flux = row_array(rows, "momentum_flux_l1_n")
+    pressure = row_array(rows, "closure_pressure_pa")
+    fheron = row_array(rows, "fheron_pressure_pa")
+    cpu_time = row_array(rows, "cpu_time_s")
+    cpu_ms = row_array(rows, "cpu_ms_per_substep")
+    changed_tets = row_array(rows, "display_changed_tets")
+    changed_fraction = row_array(rows, "display_changed_fraction")
+
+    frame_indices = np.unique(np.linspace(0, len(rows) - 1, min(len(rows), int(max_frames)), dtype=int))
+    max_radius = float(np.max(np.linalg.norm(snapshots.reshape((-1, 3)), axis=1)))
+    limit = 1.08 * max_radius
+    time_ticks = np.linspace(float(t[0]), float(t[-1]), 5)
+
+    if closure == "compressible":
+        liquid_color = "#1f77b4"
+        surface_face = "#9ecae1"
+        title = "#11 ddgclib two-phase mesh + multiphase EOS solve"
+    else:
+        liquid_color = "#ff7f0e"
+        surface_face = "#fdd0a2"
+        title = "#12 ddgclib two-phase mesh + multiphase projection"
+
+    fig = plt.figure(figsize=(10.4, 7.2))
+    grid = fig.add_gridspec(3, 2, width_ratios=(1.35, 1.0), wspace=0.27, hspace=0.50)
+    ax3d = fig.add_subplot(grid[:2, 0], projection="3d")
+    ax_info = fig.add_subplot(grid[2, 0])
+    ax_amp = fig.add_subplot(grid[0, 1])
+    ax_vol = fig.add_subplot(grid[1, 1])
+    ax_flux = fig.add_subplot(grid[2, 1])
+    ax_flux_twin = ax_flux.twinx()
+
+    def draw(frame_pos: int) -> None:
+        row_idx = int(frame_indices[frame_pos])
+        points = snapshots[row_idx]
+        tets = np.asarray(_frame_array(display_tets, row_idx), dtype=int)
+        phases = np.asarray(_frame_array(display_phases, row_idx), dtype=int)
+        liquid_tets = tets[phases == LIQUID]
+        gas_tets = tets[phases == GAS]
+        liquid_edges = base.tet_edge_indices(liquid_tets, max_edges=260) if liquid_tets.size else np.empty((0, 2), dtype=int)
+        gas_edges = base.tet_edge_indices(gas_tets, max_edges=420) if gas_tets.size else np.empty((0, 2), dtype=int)
+        interface_surface = points[interface_indices]
+        outer_surface = points[outer_indices] if outer_indices.size else np.empty((0, 3), dtype=float)
+
+        ax3d.cla()
+        ax_info.cla()
+        ax_amp.cla()
+        ax_vol.cla()
+        ax_flux.cla()
+        ax_flux_twin.cla()
+
+        if outer_surface.size:
+            ax3d.add_collection3d(
+                Poly3DCollection(
+                    outer_surface[faces],
+                    facecolor=(0.52, 0.70, 0.88, 0.075),
+                    edgecolor=(0.22, 0.34, 0.50, 0.18),
+                    linewidth=0.26,
+                )
+            )
+        if gas_edges.size:
+            ax3d.add_collection3d(Line3DCollection(points[gas_edges], colors=(0.20, 0.35, 0.55, 0.18), linewidths=0.30))
+        ax3d.add_collection3d(
+            Poly3DCollection(
+                interface_surface[faces],
+                facecolor=surface_face,
+                edgecolor=liquid_color,
+                linewidth=0.38,
+                alpha=0.54,
+            )
+        )
+        if liquid_edges.size:
+            ax3d.add_collection3d(Line3DCollection(points[liquid_edges], colors=(0.05, 0.05, 0.05, 0.30), linewidths=0.34))
+
+        gas_vertices = np.setdiff1d(np.unique(gas_tets.reshape(-1)) if gas_tets.size else np.array([], dtype=int), interface_indices)
+        liquid_vertices = np.setdiff1d(np.unique(liquid_tets.reshape(-1)) if liquid_tets.size else np.array([], dtype=int), interface_indices)
+        if gas_vertices.size:
+            ax3d.scatter(points[gas_vertices, 0], points[gas_vertices, 1], points[gas_vertices, 2], s=5, c="#8fb8de", alpha=0.45, edgecolors="none", depthshade=False)
+        if liquid_vertices.size:
+            ax3d.scatter(points[liquid_vertices, 0], points[liquid_vertices, 1], points[liquid_vertices, 2], s=7, c="#2ca02c", alpha=0.65, edgecolors="none", depthshade=False)
+        ax3d.scatter(interface_surface[:, 0], interface_surface[:, 1], interface_surface[:, 2], s=11, c=liquid_color, alpha=0.86, edgecolors="white", linewidths=0.20, depthshade=False)
+
+        ax3d.set_xlim(-limit, limit)
+        ax3d.set_ylim(-limit, limit)
+        ax3d.set_zlim(-limit, limit)
+        ax3d.set_box_aspect((1.0, 1.0, 1.0))
+        ax3d.set_xticks([])
+        ax3d.set_yticks([])
+        ax3d.set_zticks([])
+        ax3d.view_init(elev=20.0, azim=32.0 + 24.0 * float(t[row_idx]) / max(float(t[-1]), 1.0e-30))
+        ax3d.set_title(title, fontsize=10, pad=0)
+
+        ax_info.axis("off")
+        density_spread_ppm = (row_array(rows, "nodal_density_rel_max")[row_idx] - row_array(rows, "nodal_density_rel_min")[row_idx]) * 1.0e6
+        left = (
+            f"t = {t[row_idx]:.5f} s\n"
+            f"theory a2 = {amplitude_theory[row_idx]:+.4f}\n"
+            f"fit a2 = {amplitude_fit[row_idx]:+.4f}\n"
+            f"liquid dV/V0 = {liquid_vol_pct[row_idx]:+.3e} %\n"
+            f"gas dV/V0 = {gas_vol_pct[row_idx]:+.3e} %\n"
+            f"max liquid tet = {local_pct[row_idx]:.3e} %\n"
+            f"rho spread = {density_spread_ppm:.3f} ppm\n"
+            f"mass flux L1 = {mass_flux[row_idx]:.3e} kg/s\n"
+            f"mom flux L1 = {momentum_flux[row_idx]:.3e} N"
+        )
+        right = (
+            f"mesh = {points.shape[0]} verts, {tets.shape[0]} tets\n"
+            f"liquid/gas tets = {liquid_tets.shape[0]}/{gas_tets.shape[0]}\n"
+            f"interface vertices = {interface_indices.shape[0]}\n"
+            f"Delaunay flips = {changed_tets[row_idx]:.0f} ({100.0 * changed_fraction[row_idx]:.1f}%)\n"
+            f"integrator = symplectic Euler\n"
+            f"flux = Lagrangian material face\n"
+            f"Fp = multiphase tet-volume Bt\n"
+            f"p = {pressure[row_idx]:.2f} Pa\n"
+            f"FHeron = {fheron[row_idx]:.2f} Pa\n"
+            f"CPU = {cpu_time[row_idx]:.2f}/{cpu_time[-1]:.1f} s\n"
+            f"CPU/step = {cpu_ms[row_idx]:.2f} ms"
+        )
+        ax_info.text(0.02, 0.98, left, transform=ax_info.transAxes, va="top", ha="left", family="monospace", fontsize=7.4)
+        ax_info.text(0.52, 0.98, right, transform=ax_info.transAxes, va="top", ha="left", family="monospace", fontsize=7.4)
+
+        pad = max(0.1 * float(np.ptp(amplitude_theory)), 0.004)
+        ax_amp.plot(t, amplitude_theory, "k--", lw=1.4, label="Rayleigh theory")
+        ax_amp.plot(t, amplitude_fit, color=liquid_color, lw=1.7, label="simulation")
+        ax_amp.plot(t[row_idx], amplitude_fit[row_idx], "o", color="#d62728", ms=4.2)
+        ax_amp.set_xlim(float(t[0]), float(t[-1]))
+        ax_amp.set_ylim(float(min(np.min(amplitude_theory), np.min(amplitude_fit)) - pad), float(max(np.max(amplitude_theory), np.max(amplitude_fit)) + pad))
+        ax_amp.set_xticks(time_ticks)
+        ax_amp.set_ylabel("a2")
+        ax_amp.set_title("Shape amplitude")
+        ax_amp.grid(True, alpha=0.25)
+        ax_amp.legend(frameon=False, fontsize=8, loc="upper right")
+
+        ax_vol.plot(t, liquid_vol_pct, color=liquid_color, lw=1.5, label="liquid global dV/V")
+        ax_vol.plot(t, gas_vol_pct, color="#4c78a8", lw=1.2, ls="--", label="gas global dV/V")
+        ax_vol.plot(t, local_pct, color="#111111", lw=1.0, ls=":", label="liquid local max")
+        ax_vol.plot(t[row_idx], liquid_vol_pct[row_idx], "o", color="#d62728", ms=4.0)
+        ax_vol.set_xlim(float(t[0]), float(t[-1]))
+        ax_vol.set_xticks(time_ticks)
+        ax_vol.set_ylabel("percent")
+        ax_vol.set_title("Global and local volume error")
+        ax_vol.grid(True, alpha=0.25)
+        ax_vol.legend(frameon=False, fontsize=7, loc="upper right")
+
+        mass_flux_plot = np.maximum(mass_flux, 1.0e-30)
+        momentum_flux_plot = np.maximum(momentum_flux, 1.0e-30)
+        ax_flux.plot(t, mass_flux_plot, color=liquid_color, lw=1.8, label="mass flux L1")
+        ax_flux_twin.plot(t, momentum_flux_plot, color="0.25", lw=1.2, ls=":", label="momentum flux L1")
+        ax_flux.plot(t[row_idx], max(mass_flux[row_idx], 1.0e-30), "o", color="#d62728", ms=4.0)
+        ax_flux.set_yscale("log")
+        ax_flux_twin.set_yscale("log")
+        mass_flux_max = max(float(np.max(mass_flux_plot)), 1.0e-30)
+        momentum_flux_max = max(float(np.max(momentum_flux_plot)), 1.0e-30)
+        ax_flux.set_ylim(max(mass_flux_max * 1.0e-6, 1.0e-30), mass_flux_max * 5.0)
+        ax_flux_twin.set_ylim(max(momentum_flux_max * 1.0e-6, 1.0e-30), momentum_flux_max * 5.0)
+        ax_flux.set_xlim(float(t[0]), float(t[-1]))
+        ax_flux.set_xticks(time_ticks)
+        ax_flux.set_xlabel("t [s]")
+        ax_flux.set_ylabel("kg/s")
+        ax_flux_twin.set_ylabel("N")
+        ax_flux.set_title("Internal face fluxes")
+        ax_flux.grid(True, alpha=0.25)
+        lines, labels = ax_flux.get_legend_handles_labels()
+        lines2, labels2 = ax_flux_twin.get_legend_handles_labels()
+        ax_flux.legend(lines + lines2, labels + labels2, frameon=False, fontsize=8, loc="upper right")
+
+        fig.suptitle(
+            f"{closure.capitalize()} ddgclib two-phase run, CPU {cpu_time[-1]:.1f} s ({cpu_ms[-1]:.1f} ms/step)",
+            y=0.985,
+        )
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    fig.subplots_adjust(left=0.05, right=0.90, top=0.90, bottom=0.07)
+    animation = FuncAnimation(fig, draw, frames=len(frame_indices), interval=1000.0 / max(1, int(fps)))
+    gif_path = out_dir / f"case{int(case_id)}_ddgclib_twophase_multiphase_layout.gif"
+    animation.save(gif_path, writer=PillowWriter(fps=max(1, int(fps))))
+    draw(len(frame_indices) - 1)
+    fig.savefig(gif_path.with_suffix(".preview.png"), dpi=150)
+    plt.close(fig)
+    return gif_path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Render #11/#12 dynamic-integrator two-phase GIFs.")
+    parser.add_argument("--case-id", type=int, choices=(11, 12), required=True)
+    parser.add_argument("--source-dir", type=Path, required=True)
+    parser.add_argument("--out-dir", type=Path, default=None)
+    parser.add_argument("--max-frames", type=int, default=32)
+    parser.add_argument("--fps", type=int, default=12)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    out_dir = args.out_dir or args.source_dir
+    gif_path = render_case(
+        case_id=args.case_id,
+        source_dir=args.source_dir,
+        out_dir=out_dir,
+        max_frames=args.max_frames,
+        fps=args.fps,
+    )
+    print(f"gif: {gif_path}")
+    print(f"preview: {gif_path.with_suffix('.preview.png')}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cases_dynamic/oscillating_droplet_p_ref/scripts/render_free_surface_air_mesh_preview.py
+++ b/cases_dynamic/oscillating_droplet_p_ref/scripts/render_free_surface_air_mesh_preview.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+
+import sphere_fheron_eos_projection_benchmark as base
+
+plt = base.plt
+FuncAnimation = base.FuncAnimation
+PillowWriter = base.PillowWriter
+Line3DCollection = base.Line3DCollection
+Poly3DCollection = base.Poly3DCollection
+
+
+ROOT = Path(__file__).resolve().parent
+
+
+def row_array(rows: list[dict[str, float]], key: str) -> np.ndarray:
+    return np.asarray([float(row[key]) for row in rows], dtype=float)
+
+
+def surface_edge_indices(faces: np.ndarray) -> np.ndarray:
+    edges: set[tuple[int, int]] = set()
+    for tri in np.asarray(faces, dtype=int):
+        a, b, c = [int(index) for index in tri]
+        edges.update(tuple(sorted(edge)) for edge in ((a, b), (b, c), (c, a)))
+    return np.asarray(sorted(edges), dtype=int)
+
+
+def normalised(points: np.ndarray) -> np.ndarray:
+    norms = np.linalg.norm(points, axis=1)
+    return points / np.maximum(norms[:, None], 1.0e-300)
+
+
+def render_case(
+    *,
+    case_dir: Path,
+    closure: str,
+    output_name: str,
+    liquid_color: str,
+    outer_radius_scale: float = 1.65,
+    max_frames: int = 32,
+    fps: int = 12,
+) -> Path:
+    rows = json.loads((case_dir / f"flux_{closure}_timeseries.json").read_text())
+    data = np.load(case_dir / f"flux_{closure}_snapshots.npz", allow_pickle=True)
+    snapshots = np.asarray(data["points"], dtype=float)
+    faces = np.asarray(data["faces"], dtype=int)
+    solver_tets = np.asarray(data["tets"], dtype=int)
+    surface_indices = np.asarray(data["surface_indices"], dtype=int)
+    if "display_tets" in data.files:
+        display_tets = [np.asarray(item, dtype=int) for item in data["display_tets"]]
+    else:
+        display_tets = [solver_tets for _ in range(snapshots.shape[0])]
+
+    t = row_array(rows, "t")
+    amplitude_theory = row_array(rows, "shape_amplitude_theory")
+    amplitude_fit = row_array(rows, "shape_amplitude_fit")
+    cpu_time = row_array(rows, "cpu_time_s")
+    display_changed = row_array(rows, "display_changed_tets")
+    p_gas = float(rows[0].get("ambient_pressure_pa", 101325.0))
+    p_gauge = row_array(rows, "closure_pressure_pa")
+
+    reference_surface = snapshots[0, surface_indices]
+    radius = float(np.mean(np.linalg.norm(reference_surface, axis=1)))
+    outer_radius = float(outer_radius_scale) * radius
+    outer_surface = normalised(reference_surface) * outer_radius
+    air_edges = surface_edge_indices(faces)
+    frame_indices = np.unique(np.linspace(0, len(rows) - 1, min(len(rows), max_frames), dtype=int))
+
+    if closure == "compressible":
+        title = "#11 compressible: one-phase droplet + passive ambient gas boundary"
+    else:
+        title = "#12 incompressible: one-phase droplet + passive ambient gas boundary"
+
+    fig = plt.figure(figsize=(4.8, 7.0))
+    grid = fig.add_gridspec(2, 1, height_ratios=(3.15, 1.0), hspace=0.08)
+    ax3d = fig.add_subplot(grid[0], projection="3d")
+    ax_amp = fig.add_subplot(grid[1])
+    limit = outer_radius * 1.08
+    time_ticks = np.linspace(float(t[0]), float(t[-1]), 5)
+
+    def draw(frame_pos: int) -> None:
+        row_idx = int(frame_indices[frame_pos])
+        points = snapshots[row_idx]
+        surface = points[surface_indices]
+        liquid_edges = base.tet_edge_indices(display_tets[row_idx], max_edges=260)
+
+        ax3d.cla()
+        ax_amp.cla()
+
+        ax3d.add_collection3d(
+            Poly3DCollection(
+                outer_surface[faces],
+                facecolor=(0.45, 0.66, 0.88, 0.055),
+                edgecolor=(0.22, 0.35, 0.52, 0.18),
+                linewidth=0.35,
+            )
+        )
+        ax3d.add_collection3d(
+            Line3DCollection(
+                outer_surface[air_edges],
+                colors=(0.20, 0.33, 0.48, 0.26),
+                linewidths=0.45,
+            )
+        )
+        radial_segments = np.stack([surface, outer_surface], axis=1)
+        keep = np.linspace(0, radial_segments.shape[0] - 1, min(42, radial_segments.shape[0]), dtype=int)
+        ax3d.add_collection3d(
+            Line3DCollection(
+                radial_segments[keep],
+                colors=(0.20, 0.33, 0.48, 0.20),
+                linewidths=0.42,
+            )
+        )
+
+        ax3d.add_collection3d(
+            Poly3DCollection(
+                surface[faces],
+                facecolor=liquid_color,
+                edgecolor=liquid_color,
+                linewidth=0.38,
+                alpha=0.50,
+            )
+        )
+        ax3d.add_collection3d(
+            Line3DCollection(points[liquid_edges], colors=(0.05, 0.05, 0.05, 0.28), linewidths=0.36)
+        )
+
+        interior = np.setdiff1d(np.arange(points.shape[0], dtype=int), surface_indices)
+        if interior.size:
+            interior_points = points[interior]
+            ax3d.scatter(
+                interior_points[:, 0],
+                interior_points[:, 1],
+                interior_points[:, 2],
+                s=6,
+                c="#2ca02c",
+                alpha=0.62,
+                edgecolors="none",
+                depthshade=False,
+            )
+
+        ax3d.set_xlim(-limit, limit)
+        ax3d.set_ylim(-limit, limit)
+        ax3d.set_zlim(-limit, limit)
+        ax3d.set_box_aspect((1.0, 1.0, 1.0))
+        ax3d.set_xticks([])
+        ax3d.set_yticks([])
+        ax3d.set_zticks([])
+        ax3d.view_init(elev=19.0, azim=30.0 + 24.0 * float(t[row_idx]) / max(float(t[-1]), 1.0e-30))
+        ax3d.set_title(title, fontsize=8.6, pad=4)
+        ax3d.text2D(
+            0.02,
+            0.96,
+            (
+                f"t = {t[row_idx]:.4f} s\n"
+                f"p_gas = {p_gas:.0f} Pa passive\n"
+                f"p_gauge = {p_gauge[row_idx]:.1f} Pa\n"
+                f"air mesh = visual boundary\n"
+                f"Delaunay changes = {display_changed[row_idx]:.0f} tets"
+            ),
+            transform=ax3d.transAxes,
+            va="top",
+            ha="left",
+            fontsize=7.4,
+            family="monospace",
+            color="#17202A",
+        )
+
+        pad = max(0.1 * float(np.ptp(amplitude_theory)), 0.004)
+        ax_amp.plot(t, amplitude_theory, "k--", lw=1.4, label="Rayleigh theory")
+        ax_amp.plot(t, amplitude_fit, color=liquid_color, lw=1.7, label="simulation")
+        ax_amp.plot(t[row_idx], amplitude_fit[row_idx], "o", color="#d62728", ms=4.0)
+        ax_amp.set_xlim(float(t[0]), float(t[-1]))
+        ax_amp.set_ylim(
+            float(min(np.min(amplitude_theory), np.min(amplitude_fit)) - pad),
+            float(max(np.max(amplitude_theory), np.max(amplitude_fit)) + pad),
+        )
+        ax_amp.set_xticks(time_ticks)
+        ax_amp.set_xlabel("t [s]", fontsize=8)
+        ax_amp.set_ylabel("a2", fontsize=8)
+        ax_amp.tick_params(labelsize=7)
+        ax_amp.set_title(f"Shape amplitude, CPU {cpu_time[-1]:.1f} s", fontsize=8)
+        ax_amp.grid(True, alpha=0.25)
+        ax_amp.legend(frameon=False, fontsize=7, loc="upper right")
+
+    fig.subplots_adjust(left=0.05, right=0.98, top=0.97, bottom=0.07)
+    animation = FuncAnimation(fig, draw, frames=len(frame_indices), interval=1000.0 / max(1, int(fps)))
+    output = case_dir / output_name
+    animation.save(output, writer=PillowWriter(fps=max(1, int(fps))))
+    plt.close(fig)
+    return output
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Render one-phase droplet previews with a passive ambient-gas boundary mesh.")
+    parser.add_argument("--max-frames", type=int, default=32)
+    parser.add_argument("--fps", type=int, default=12)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    cases = [
+        (
+            ROOT / "out/sphere_fheron_case11_compressible_free_surface_retriang_diag",
+            "compressible",
+            "flux_compressible_sphere_air_boundary_preview.gif",
+            "#1f77b4",
+        ),
+        (
+            ROOT / "out/sphere_fheron_case12_incompressible_free_surface_retriang_diag",
+            "incompressible",
+            "flux_incompressible_sphere_air_boundary_preview.gif",
+            "#ff7f0e",
+        ),
+    ]
+    for case_dir, closure, output_name, color in cases:
+        print(render_case(case_dir=case_dir, closure=closure, output_name=output_name, liquid_color=color, max_frames=args.max_frames, fps=args.fps))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cases_dynamic/oscillating_droplet_p_ref/scripts/render_github_twophase_triangulation_active_retopology.py
+++ b/cases_dynamic/oscillating_droplet_p_ref/scripts/render_github_twophase_triangulation_active_retopology.py
@@ -1,0 +1,361 @@
+"""Render #11/#12 using the upstream GitHub two-phase droplet mesh.
+
+This file is intentionally a renderer/diagnostic: it uses the successful
+active-retopology FHeron time series for the Rayleigh response, but the
+displayed phase mesh is created by the GitHub oscillating-droplet setup
+(`setup_oscillating_droplet` -> `droplet_in_box_3d`).  The point is to make
+the comparison foundation visible: phase 0 is gas/outer fluid, phase 1 is
+liquid, and phase -1 is the shared interface subcomplex.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+import numpy as np
+
+import run_github_twophase_oscillating_preview as github_case
+import sphere_fheron_eos_projection_benchmark as base
+
+
+plt = base.plt
+FuncAnimation = base.FuncAnimation
+PillowWriter = base.PillowWriter
+Line3DCollection = base.Line3DCollection
+Poly3DCollection = base.Poly3DCollection
+
+ROOT = Path(__file__).resolve().parent
+RADIUS = 1.0e-3
+DOMAIN_HALF_WIDTH = 5.0e-3
+
+
+def row_array(rows: list[dict[str, float]], key: str) -> np.ndarray:
+    return np.asarray([float(row[key]) for row in rows], dtype=float)
+
+
+def load_github_twophase_mesh() -> dict[str, np.ndarray]:
+    HC, _bV, _mps, _bc_set, _dudt_fn, _retopo_fn, _params = github_case.setup_oscillating_droplet(
+        dim=3,
+        R0=RADIUS,
+        epsilon=0.0,
+        l=2,
+        rho_d=1000.0,
+        rho_o=1.225,
+        mu_d=0.001,
+        mu_o=1.81e-5,
+        gamma=0.072,
+        K_d=1000.0,
+        K_o=1.225,
+        L_domain=DOMAIN_HALF_WIDTH,
+        refinement_outer=1,
+        refinement_droplet=1,
+    )
+    snap = github_case.snapshot_from_hc(HC, 3)
+    verts = github_case.ordered_vertices(HC)
+    index_by_coord = {tuple(v.x): i for i, v in enumerate(verts)}
+    interface_edges: list[tuple[int, int]] = []
+    for edge in getattr(HC, "interface_edges", set()):
+        ids = [index_by_coord.get(tuple(coord)) for coord in edge]
+        if len(ids) == 2 and all(i is not None for i in ids):
+            interface_edges.append(tuple(sorted((int(ids[0]), int(ids[1])))))
+    interface_triangles: list[tuple[int, int, int]] = []
+    for tri in getattr(HC, "interface_triangles", set()):
+        ids = [index_by_coord.get(tuple(coord)) for coord in tri]
+        if all(i is not None for i in ids):
+            interface_triangles.append(tuple(int(i) for i in ids))
+    snap["interface_edges"] = np.asarray(sorted(set(interface_edges)), dtype=int).reshape((-1, 2))
+    snap["interface_triangles"] = np.asarray(interface_triangles, dtype=int).reshape((-1, 3))
+    return snap
+
+
+def p2_basis(points: np.ndarray) -> np.ndarray:
+    r = np.linalg.norm(points, axis=1)
+    mu = np.divide(points[:, 2], r, out=np.zeros_like(r), where=r > 1.0e-300)
+    return 0.5 * (3.0 * mu * mu - 1.0)
+
+
+def wall_radius_along_direction(directions: np.ndarray) -> np.ndarray:
+    max_abs = np.max(np.abs(directions), axis=1)
+    return DOMAIN_HALF_WIDTH / np.maximum(max_abs, 1.0e-300)
+
+
+def deform_github_mesh(mesh: dict[str, np.ndarray], amplitude: float) -> np.ndarray:
+    reference = np.asarray(mesh["points"], dtype=float)
+    phases = np.asarray(mesh["phases"], dtype=int)
+    radii = np.linalg.norm(reference, axis=1)
+    directions = np.divide(reference, radii[:, None], out=np.zeros_like(reference), where=radii[:, None] > 1.0e-300)
+    basis = p2_basis(reference)
+    interface_radius = RADIUS * (1.0 + float(amplitude) * basis)
+
+    deformed = reference.copy()
+    liquid_or_interface = phases != 0
+    deformed[liquid_or_interface] = directions[liquid_or_interface] * (
+        (radii[liquid_or_interface] / RADIUS)[:, None] * interface_radius[liquid_or_interface, None]
+    )
+
+    gas = phases == 0
+    if np.any(gas):
+        wall_r = wall_radius_along_direction(directions[gas])
+        s = (radii[gas] - RADIUS) / np.maximum(wall_r - RADIUS, 1.0e-300)
+        s = np.clip(s, 0.0, 1.0)
+        gas_r = (1.0 - s) * interface_radius[gas] + s * wall_r
+        deformed[gas] = directions[gas] * gas_r[:, None]
+    return deformed
+
+
+def phase_edges(edges: np.ndarray, phases: np.ndarray, interface_edges: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    if edges.size == 0:
+        empty = np.empty((0, 2), dtype=int)
+        return empty, empty, empty
+    gas_edges = edges[np.all(phases[edges] == 0, axis=1)]
+    liquid_edges = edges[np.all(phases[edges] == 1, axis=1)]
+    return gas_edges, liquid_edges, interface_edges
+
+
+def render_case(
+    *,
+    source_dir: Path,
+    out_dir: Path,
+    mesh: dict[str, np.ndarray],
+    closure: str,
+    max_frames: int,
+    fps: int,
+) -> Path:
+    rows = json.loads((source_dir / f"flux_{closure}_timeseries.json").read_text())
+    t = row_array(rows, "t")
+    a2 = row_array(rows, "shape_amplitude_fit")
+    a_theory = row_array(rows, "shape_amplitude_theory")
+    cpu = row_array(rows, "cpu_time_s")
+    cpu_ms = row_array(rows, "cpu_ms_per_substep")
+    pressure = row_array(rows, "closure_pressure_pa")
+    fheron = row_array(rows, "fheron_pressure_pa")
+    ambient_pressure = row_array(rows, "ambient_pressure_pa")
+    vol_pct = (row_array(rows, "vol_rel") - 1.0) * 100.0
+    local_volume_pct = row_array(rows, "local_volume_rel_max_abs") * 100.0
+    density_spread_ppm = (row_array(rows, "nodal_density_rel_max") - row_array(rows, "nodal_density_rel_min")) * 1.0e6
+    mass_flux = row_array(rows, "mass_flux_l1_kg_s")
+    momentum_flux = row_array(rows, "momentum_flux_l1_n")
+    limiter_scale = row_array(rows, "flux_limiter_scale")
+    density_limit = float(rows[0].get("density_change_limit", 0.0))
+    display_tet_count = row_array(rows, "display_tet_count")
+    display_face_count = row_array(rows, "display_internal_face_count")
+    display_changed_tets = row_array(rows, "display_changed_tets")
+    display_changed_fraction = row_array(rows, "display_changed_fraction")
+    flux_scheme = "Rusanov" if float(rows[0].get("flux_scheme_rusanov", 0.0)) > 0.5 else "upwind"
+    face_flux_mode = "Lagrangian face" if float(rows[0].get("face_flux_lagrangian", 0.0)) > 0.5 else "cell-average face"
+
+    phases = np.asarray(mesh["phases"], dtype=int)
+    interface = np.asarray(mesh["is_interface"], dtype=bool)
+    edges = np.asarray(mesh["edges"], dtype=int)
+    mesh_interface_edges = np.asarray(mesh["interface_edges"], dtype=int)
+    interface_triangles = np.asarray(mesh["interface_triangles"], dtype=int)
+    gas_edges, liquid_edges, interface_edges = phase_edges(edges, phases, mesh_interface_edges)
+
+    frame_indices = np.unique(np.linspace(0, len(rows) - 1, min(len(rows), max(2, int(max_frames))), dtype=int))
+    limit = DOMAIN_HALF_WIDTH * 1.03
+    time_ticks = np.linspace(float(t[0]), float(t[-1]), 5)
+    time_tick_labels = [f"{value:.3f}" for value in time_ticks]
+    cpu_total = float(cpu[-1])
+    cpu_avg = float(cpu_ms[-1])
+
+    if closure == "compressible":
+        liquid_color = "#1f77b4"
+        liquid_face = "#9ecae1"
+        gif_name = "flux_compressible_github_twophase_triangulation.gif"
+        title = "#11 GitHub two-phase mesh + FHeron EOS"
+    else:
+        liquid_color = "#ff7f0e"
+        liquid_face = "#fdd0a2"
+        gif_name = "flux_incompressible_github_twophase_triangulation.gif"
+        title = "#12 GitHub two-phase mesh + projection"
+
+    fig = plt.figure(figsize=(10.4, 7.2))
+    grid = fig.add_gridspec(3, 2, width_ratios=(1.35, 1.0), wspace=0.27, hspace=0.50)
+    ax3d = fig.add_subplot(grid[:2, 0], projection="3d")
+    ax_info = fig.add_subplot(grid[2, 0])
+    ax_amp = fig.add_subplot(grid[0, 1])
+    ax_vol = fig.add_subplot(grid[1, 1])
+    ax_flux = fig.add_subplot(grid[2, 1])
+    ax_flux_twin = ax_flux.twinx()
+
+    def draw(frame_pos: int) -> None:
+        row_idx = int(frame_indices[frame_pos])
+        points = deform_github_mesh(mesh, float(a2[row_idx]))
+
+        ax3d.cla()
+        ax_info.cla()
+        ax_amp.cla()
+        ax_vol.cla()
+        ax_flux.cla()
+        ax_flux_twin.cla()
+
+        if gas_edges.size:
+            ax3d.add_collection3d(Line3DCollection(points[gas_edges], colors=(0.25, 0.42, 0.65, 0.20), linewidths=0.30))
+        if liquid_edges.size:
+            ax3d.add_collection3d(Line3DCollection(points[liquid_edges], colors=(0.05, 0.05, 0.05, 0.24), linewidths=0.34))
+        if interface_edges.size:
+            ax3d.add_collection3d(Line3DCollection(points[interface_edges], colors=(0.85, 0.28, 0.10, 0.72), linewidths=0.72))
+        if interface_triangles.size:
+            ax3d.add_collection3d(
+                Poly3DCollection(
+                    points[interface_triangles],
+                    facecolor=liquid_face,
+                    edgecolor=(0.85, 0.28, 0.10, 0.48),
+                    linewidth=0.32,
+                    alpha=0.42,
+                )
+            )
+
+        gas_vertices = phases == 0
+        liquid_vertices = phases == 1
+        if np.any(gas_vertices):
+            ax3d.scatter(points[gas_vertices, 0], points[gas_vertices, 1], points[gas_vertices, 2], s=5, c="#8fb8de", alpha=0.34, edgecolors="none", depthshade=False)
+        if np.any(liquid_vertices):
+            ax3d.scatter(points[liquid_vertices, 0], points[liquid_vertices, 1], points[liquid_vertices, 2], s=9, c=liquid_color, alpha=0.60, edgecolors="none", depthshade=False)
+        if np.any(interface):
+            ax3d.scatter(points[interface, 0], points[interface, 1], points[interface, 2], s=15, c="#d62728", alpha=0.94, edgecolors="white", linewidths=0.2, depthshade=False)
+
+        ax3d.set_xlim(-limit, limit)
+        ax3d.set_ylim(-limit, limit)
+        ax3d.set_zlim(-limit, limit)
+        ax3d.set_box_aspect((1, 1, 1))
+        ax3d.set_xticks([])
+        ax3d.set_yticks([])
+        ax3d.set_zticks([])
+        ax3d.view_init(elev=20.0, azim=34.0 + 26.0 * float(t[row_idx]) / max(float(t[-1]), 1.0e-30))
+        ax3d.set_title(title, fontsize=10)
+
+        ax_info.axis("off")
+        left = (
+            f"t = {t[row_idx]:.5f} s\n"
+            f"theory a2 = {a_theory[row_idx]:+.4f}\n"
+            f"fit a2 = {a2[row_idx]:+.4f}\n"
+            f"global dV/V0 = {vol_pct[row_idx]:+.3e} %\n"
+            f"max tet |dV|/V = {local_volume_pct[row_idx]:.3e} %\n"
+            f"rho spread = {density_spread_ppm[row_idx]:.3f} ppm\n"
+            f"mass flux L1 = {mass_flux[row_idx]:.3e} kg/s\n"
+            f"mom flux L1 = {momentum_flux[row_idx]:.3e} N\n"
+            f"flux limiter = {limiter_scale[row_idx]:.3e}\n"
+            f"visual mesh = GitHub two-phase"
+        )
+        right = (
+            f"GitHub verts = {points.shape[0]}, edges = {edges.shape[0]}\n"
+            f"gas/liquid/interface = {int(np.sum(gas_vertices))}/{int(np.sum(liquid_vertices))}/{int(np.sum(interface))}\n"
+            f"interface tris = {interface_triangles.shape[0]}\n"
+            f"solver display tets = {display_tet_count[row_idx]:.0f}\n"
+            f"Delaunay flips = {display_changed_tets[row_idx]:.0f} ({100.0 * display_changed_fraction[row_idx]:.1f}%)\n"
+            f"internal faces = {display_face_count[row_idx]:.0f}\n"
+            f"flux = {flux_scheme}, {face_flux_mode}\n"
+            f"Fp = volume-gradient Bt\n"
+            f"rho limit = {100.0 * density_limit:.2f} %\n"
+            f"p_gas = {ambient_pressure[row_idx]:.0f} Pa\n"
+            f"p_gauge = {pressure[row_idx]:.3f} Pa\n"
+            f"FHeron = {fheron[row_idx]:.3f} Pa\n"
+            f"CPU = {cpu[row_idx]:.2f}/{cpu_total:.1f} s\n"
+            f"CPU/step = {cpu_ms[row_idx]:.2f} ms"
+        )
+        ax_info.text(0.02, 0.98, left, transform=ax_info.transAxes, va="top", ha="left", family="monospace", fontsize=7.6)
+        ax_info.text(0.52, 0.98, right, transform=ax_info.transAxes, va="top", ha="left", family="monospace", fontsize=7.6)
+
+        pad = max(0.12 * float(np.ptp(a_theory)), 0.004)
+        ax_amp.plot(t, a_theory, "k--", lw=1.6, label="Rayleigh theory")
+        ax_amp.plot(t, a2, color=liquid_color, lw=1.8, label="Ftot + flux")
+        ax_amp.plot(t[row_idx], a2[row_idx], "o", color="#d62728", ms=5.0)
+        ax_amp.set_xlim(float(t[0]), float(t[-1]))
+        ax_amp.set_xticks(time_ticks)
+        ax_amp.set_xticklabels(time_tick_labels)
+        ax_amp.set_ylim(float(min(np.min(a_theory), np.min(a2)) - pad), float(max(np.max(a_theory), np.max(a2)) + pad))
+        ax_amp.set_ylabel("a2")
+        ax_amp.set_title("Shape amplitude")
+        ax_amp.grid(True, alpha=0.25)
+        ax_amp.legend(frameon=False, fontsize=8, loc="upper right")
+
+        ax_vol.plot(t, vol_pct, color=liquid_color, lw=1.8, label="global dV/V0")
+        ax_vol.plot(t, local_volume_pct, color="0.3", lw=1.2, ls=":", label="max local tet")
+        ax_vol.plot(t[row_idx], vol_pct[row_idx], "o", color="#d62728", ms=5.0)
+        ax_vol.set_xlim(float(t[0]), float(t[-1]))
+        ax_vol.set_xticks(time_ticks)
+        ax_vol.set_xticklabels(time_tick_labels)
+        ymin = min(float(np.min(vol_pct)), float(np.min(local_volume_pct)))
+        ymax = max(float(np.max(vol_pct)), float(np.max(local_volume_pct)))
+        ypad = max(0.12 * (ymax - ymin), 1.0e-8)
+        ax_vol.set_ylim(ymin - ypad, ymax + ypad)
+        ax_vol.set_ylabel("percent")
+        ax_vol.set_title("Global and local volume error")
+        ax_vol.grid(True, alpha=0.25)
+        ax_vol.legend(frameon=False, fontsize=8, loc="upper right")
+
+        mass_flux_plot = np.maximum(mass_flux, 1.0e-30)
+        momentum_flux_plot = np.maximum(momentum_flux, 1.0e-30)
+        ax_flux.plot(t, mass_flux_plot, color=liquid_color, lw=1.8, label="mass flux L1")
+        ax_flux_twin.plot(t, momentum_flux_plot, color="0.25", lw=1.2, ls=":", label="momentum flux L1")
+        ax_flux.plot(t[row_idx], max(mass_flux[row_idx], 1.0e-30), "o", color="#d62728", ms=5.0)
+        ax_flux.set_yscale("log")
+        ax_flux_twin.set_yscale("log")
+        mass_flux_max = max(float(np.max(mass_flux_plot)), 1.0e-30)
+        momentum_flux_max = max(float(np.max(momentum_flux_plot)), 1.0e-30)
+        ax_flux.set_ylim(max(mass_flux_max * 1.0e-6, 1.0e-30), mass_flux_max * 5.0)
+        ax_flux_twin.set_ylim(max(momentum_flux_max * 1.0e-6, 1.0e-30), momentum_flux_max * 5.0)
+        ax_flux.set_xlim(float(t[0]), float(t[-1]))
+        ax_flux.set_xticks(time_ticks)
+        ax_flux.set_xticklabels(time_tick_labels)
+        ax_flux.set_xlabel("t [s]")
+        ax_flux.set_ylabel("kg/s")
+        ax_flux_twin.set_ylabel("N")
+        ax_flux.set_title("Internal face fluxes")
+        ax_flux.grid(True, alpha=0.25)
+        lines, labels = ax_flux.get_legend_handles_labels()
+        lines2, labels2 = ax_flux_twin.get_legend_handles_labels()
+        ax_flux.legend(lines + lines2, labels + labels2, frameon=False, fontsize=8, loc="upper right")
+
+        fig.suptitle(
+            f"{closure.capitalize()} GitHub-mesh flux-aware run, CPU {cpu_total:.1f} s ({cpu_avg:.1f} ms/step)",
+            y=0.985,
+        )
+
+    fig.subplots_adjust(left=0.06, right=0.91, top=0.93, bottom=0.08)
+    animation = FuncAnimation(fig, draw, frames=len(frame_indices), interval=1000.0 / max(1, int(fps)))
+    out_dir.mkdir(parents=True, exist_ok=True)
+    path = out_dir / gif_name
+    animation.save(path, writer=PillowWriter(fps=max(1, int(fps))))
+    draw(len(frame_indices) // 2)
+    fig.savefig(out_dir / f"{path.stem}.midframe.png", dpi=180)
+    plt.close(fig)
+    return path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Render stable #11/#12 results on the GitHub two-phase triangulation.")
+    parser.add_argument("--source-dir", type=Path, default=ROOT / "out" / "sphere_fheron_case11_12_active_retopology_full")
+    parser.add_argument("--out-dir", type=Path, default=ROOT / "out" / "sphere_fheron_case11_12_github_twophase_triangulation")
+    parser.add_argument("--closure", choices=("compressible", "incompressible", "both"), default="both")
+    parser.add_argument("--max-frames", type=int, default=32)
+    parser.add_argument("--fps", type=int, default=12)
+    args = parser.parse_args()
+
+    mesh = load_github_twophase_mesh()
+    phases = np.asarray(mesh["phases"], dtype=int)
+    print("GitHub droplet_in_box_3d mesh source")
+    print(f"vertices={mesh['points'].shape[0]}, edges={mesh['edges'].shape[0]}")
+    print(f"phase0_gas={int(np.sum(phases == 0))}, phase1_liquid={int(np.sum(phases == 1))}, interface={int(np.sum(mesh['is_interface']))}")
+    print(f"interface_triangles={mesh['interface_triangles'].shape[0]}")
+
+    closures = ("compressible", "incompressible") if args.closure == "both" else (args.closure,)
+    for closure in closures:
+        path = render_case(
+            source_dir=args.source_dir,
+            out_dir=args.out_dir,
+            mesh=mesh,
+            closure=closure,
+            max_frames=args.max_frames,
+            fps=args.fps,
+        )
+        print(path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cases_dynamic/oscillating_droplet_p_ref/scripts/render_twophase_gasmesh_active_retopology.py
+++ b/cases_dynamic/oscillating_droplet_p_ref/scripts/render_twophase_gasmesh_active_retopology.py
@@ -1,0 +1,268 @@
+"""Render active-retopology FHeron runs with an explicit passive gas mesh.
+
+The matching #11/#12 dynamics are computed by ``sphere_fheron_flux_fv_benchmark``
+using the stable liquid free-surface FHeron closure.  This renderer adds a
+GitHub-style two-phase triangulation view: phase 1 is the solved liquid mesh,
+phase 0 is a passive outer gas mesh connected to the moving interface and a
+fixed outer shell.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+
+import sphere_fheron_eos_projection_benchmark as base
+
+
+plt = base.plt
+FuncAnimation = base.FuncAnimation
+PillowWriter = base.PillowWriter
+Line3DCollection = base.Line3DCollection
+Poly3DCollection = base.Poly3DCollection
+
+
+ROOT = Path(__file__).resolve().parent
+
+
+def row_array(rows: list[dict[str, float]], key: str) -> np.ndarray:
+    return np.asarray([float(row[key]) for row in rows], dtype=float)
+
+
+def gas_tets_for_surface(surface_indices: np.ndarray, faces: np.ndarray, outer_offset: int) -> np.ndarray:
+    gas_tets: list[list[int]] = []
+    for a, b, c in np.asarray(faces, dtype=int):
+        ia = int(surface_indices[int(a)])
+        ib = int(surface_indices[int(b)])
+        ic = int(surface_indices[int(c)])
+        oa = int(outer_offset + int(a))
+        ob = int(outer_offset + int(b))
+        oc = int(outer_offset + int(c))
+        gas_tets.extend(
+            [
+                [ia, ib, ic, oc],
+                [ia, ib, ob, oc],
+                [ia, oa, ob, oc],
+            ]
+        )
+    return np.asarray(gas_tets, dtype=int)
+
+
+def shifted_surface_edges(faces: np.ndarray, offset: int, *, max_edges: int = 220) -> np.ndarray:
+    edges = sorted(
+        {
+            tuple(sorted((int(offset + int(i)), int(offset + int(j)))))
+            for tri in np.asarray(faces, dtype=int)
+            for i, j in ((tri[0], tri[1]), (tri[1], tri[2]), (tri[2], tri[0]))
+        }
+    )
+    if len(edges) > int(max_edges):
+        keep = np.linspace(0, len(edges) - 1, int(max_edges), dtype=int)
+        edges = [edges[int(index)] for index in keep]
+    return np.asarray(edges, dtype=int).reshape((-1, 2))
+
+
+def fixed_outer_shell(surface0: np.ndarray, radius: float, outer_scale: float) -> np.ndarray:
+    directions = np.asarray(surface0, dtype=float).copy()
+    norms = np.linalg.norm(directions, axis=1)
+    directions /= np.maximum(norms[:, None], 1.0e-300)
+    return directions * (float(outer_scale) * float(radius))
+
+
+def render_case(
+    *,
+    source_dir: Path,
+    out_dir: Path,
+    closure: str,
+    radius: float,
+    outer_scale: float,
+    max_frames: int,
+    fps: int,
+) -> Path:
+    rows = json.loads((source_dir / f"flux_{closure}_timeseries.json").read_text())
+    data = np.load(source_dir / f"flux_{closure}_snapshots.npz", allow_pickle=True)
+    snapshots = np.asarray(data["points"], dtype=float)
+    faces = np.asarray(data["faces"], dtype=int)
+    surface_indices = np.asarray(data["surface_indices"], dtype=int)
+    display_tets = data["display_tets"] if "display_tets" in data.files else None
+
+    t = row_array(rows, "t")
+    amplitude_theory = row_array(rows, "shape_amplitude_theory")
+    amplitude_fit = row_array(rows, "shape_amplitude_fit")
+    cpu_time = row_array(rows, "cpu_time_s")
+    pressure = row_array(rows, "closure_pressure_pa")
+    fheron = row_array(rows, "fheron_pressure_pa")
+    global_volume_pct = (row_array(rows, "vol_rel") - 1.0) * 100.0
+
+    outer = fixed_outer_shell(snapshots[0, surface_indices], radius, outer_scale)
+    outer_offset = snapshots.shape[1]
+    gas_tets = gas_tets_for_surface(surface_indices, faces, outer_offset)
+    gas_edges = base.tet_edge_indices(gas_tets, max_edges=520)
+    outer_edges = shifted_surface_edges(faces, outer_offset, max_edges=220)
+
+    frame_indices = np.unique(np.linspace(0, len(rows) - 1, min(len(rows), max(2, int(max_frames))), dtype=int))
+    limit = float(outer_scale) * float(radius) * 1.08
+    time_ticks = np.linspace(float(t[0]), float(t[-1]), 5)
+    time_tick_labels = [f"{value:.3f}" for value in time_ticks]
+
+    if closure == "compressible":
+        liquid_color = "#1f77b4"
+        gif_name = "flux_compressible_twophase_gasmesh_sphere.gif"
+        title = "#11 compressible: phase-1 liquid + passive phase-0 gas mesh"
+    else:
+        liquid_color = "#ff7f0e"
+        gif_name = "flux_incompressible_twophase_gasmesh_sphere.gif"
+        title = "#12 incompressible: phase-1 liquid + passive phase-0 gas mesh"
+
+    fig = plt.figure(figsize=(5.35, 7.35))
+    grid = fig.add_gridspec(2, 1, height_ratios=(3.5, 1.05), hspace=0.16)
+    ax3d = fig.add_subplot(grid[0], projection="3d")
+    ax_amp = fig.add_subplot(grid[1])
+
+    def draw(frame_pos: int) -> None:
+        row_idx = int(frame_indices[frame_pos])
+        liquid_points = snapshots[row_idx]
+        combined = np.vstack([liquid_points, outer])
+        surface = liquid_points[surface_indices]
+        liquid_tets = (
+            np.asarray(display_tets[row_idx], dtype=int)
+            if display_tets is not None
+            else np.asarray(data["tets"], dtype=int)
+        )
+        liquid_edges = base.tet_edge_indices(liquid_tets, max_edges=360)
+        interior = np.setdiff1d(np.arange(liquid_points.shape[0], dtype=int), surface_indices)
+
+        ax3d.cla()
+        ax_amp.cla()
+
+        ax3d.add_collection3d(
+            Poly3DCollection(
+                outer[faces],
+                facecolor=(0.32, 0.58, 0.84, 0.070),
+                edgecolor=(0.20, 0.38, 0.60, 0.18),
+                linewidth=0.28,
+            )
+        )
+        if gas_edges.size:
+            ax3d.add_collection3d(
+                Line3DCollection(combined[gas_edges], colors=(0.20, 0.38, 0.62, 0.26), linewidths=0.30)
+            )
+        if outer_edges.size:
+            ax3d.add_collection3d(
+                Line3DCollection(combined[outer_edges], colors=(0.14, 0.30, 0.50, 0.18), linewidths=0.22)
+            )
+        ax3d.add_collection3d(
+            Poly3DCollection(
+                surface[faces],
+                facecolor=liquid_color,
+                edgecolor=liquid_color,
+                linewidth=0.34,
+                alpha=0.58,
+            )
+        )
+        if liquid_edges.size:
+            ax3d.add_collection3d(
+                Line3DCollection(liquid_points[liquid_edges], colors=(0.04, 0.04, 0.04, 0.26), linewidths=0.30)
+            )
+        if interior.size:
+            shell_points = liquid_points[interior]
+            ax3d.scatter(
+                shell_points[:, 0],
+                shell_points[:, 1],
+                shell_points[:, 2],
+                s=7,
+                c="#2ca02c",
+                alpha=0.75,
+                edgecolors="none",
+                depthshade=False,
+            )
+
+        ax3d.set_xlim(-limit, limit)
+        ax3d.set_ylim(-limit, limit)
+        ax3d.set_zlim(-limit, limit)
+        ax3d.set_box_aspect((1.0, 1.0, 1.0))
+        ax3d.set_xticks([])
+        ax3d.set_yticks([])
+        ax3d.set_zticks([])
+        ax3d.view_init(elev=20.0, azim=32.0 + 24.0 * float(t[row_idx]) / max(float(t[-1]), 1.0e-30))
+        ax3d.set_title(title, fontsize=8.8, pad=4)
+        ax3d.text2D(
+            0.02,
+            0.97,
+            (
+                f"t = {t[row_idx]:.5f} s\n"
+                f"phase 1 liquid verts = {liquid_points.shape[0]}\n"
+                f"phase 0 gas verts = {outer.shape[0]}\n"
+                f"liquid tets = {liquid_tets.shape[0]}\n"
+                f"gas tets = {gas_tets.shape[0]}\n"
+                f"p_gauge = {pressure[row_idx]:.2f} Pa\n"
+                f"FHeron = {fheron[row_idx]:.2f} Pa\n"
+                f"dV/V0 = {global_volume_pct[row_idx]:+.2e} %\n"
+                f"CPU = {cpu_time[row_idx]:.1f}/{cpu_time[-1]:.1f} s"
+            ),
+            transform=ax3d.transAxes,
+            va="top",
+            ha="left",
+            fontsize=6.8,
+            family="monospace",
+        )
+
+        pad = max(0.12 * float(np.ptp(amplitude_theory)), 0.004)
+        ax_amp.plot(t, amplitude_theory, "k--", lw=1.35, label="Rayleigh theory")
+        ax_amp.plot(t, amplitude_fit, color=liquid_color, lw=1.7, label="simulation")
+        ax_amp.plot(t[row_idx], amplitude_fit[row_idx], "o", color="#d62728", ms=4.2)
+        ax_amp.set_xlim(float(t[0]), float(t[-1]))
+        ax_amp.set_xticks(time_ticks)
+        ax_amp.set_xticklabels(time_tick_labels)
+        ax_amp.set_ylim(
+            float(min(np.min(amplitude_theory), np.min(amplitude_fit)) - pad),
+            float(max(np.max(amplitude_theory), np.max(amplitude_fit)) + pad),
+        )
+        ax_amp.set_xlabel("t [s]", fontsize=8)
+        ax_amp.set_ylabel("a2", fontsize=8)
+        ax_amp.set_title("Shape amplitude", fontsize=8)
+        ax_amp.grid(True, alpha=0.25)
+        ax_amp.tick_params(labelsize=7)
+        ax_amp.legend(frameon=False, fontsize=7, loc="upper right")
+
+    fig.subplots_adjust(left=0.08, right=0.98, top=0.965, bottom=0.07)
+    animation = FuncAnimation(fig, draw, frames=len(frame_indices), interval=1000.0 / max(1, int(fps)))
+    out_dir.mkdir(parents=True, exist_ok=True)
+    path = out_dir / gif_name
+    animation.save(path, writer=PillowWriter(fps=max(1, int(fps))))
+    plt.close(fig)
+    return path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Render active-retopology runs with passive gas mesh overlay.")
+    parser.add_argument("--source-dir", type=Path, default=ROOT / "out" / "sphere_fheron_case11_12_active_retopology_full")
+    parser.add_argument("--out-dir", type=Path, default=ROOT / "out" / "sphere_fheron_case11_12_twophase_gasmesh_active_retopology")
+    parser.add_argument("--radius", type=float, default=1.0e-3)
+    parser.add_argument("--outer-scale", type=float, default=1.62)
+    parser.add_argument("--closure", choices=("both", "compressible", "incompressible"), default="both")
+    parser.add_argument("--max-frames", type=int, default=32)
+    parser.add_argument("--fps", type=int, default=12)
+    args = parser.parse_args()
+
+    closures = ("compressible", "incompressible") if args.closure == "both" else (args.closure,)
+    for closure in closures:
+        print(
+            render_case(
+                source_dir=args.source_dir,
+                out_dir=args.out_dir,
+                closure=closure,
+                radius=args.radius,
+                outer_scale=args.outer_scale,
+                max_frames=args.max_frames,
+                fps=args.fps,
+            )
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cases_dynamic/oscillating_droplet_p_ref/scripts/run_github_twophase_oscillating_preview.py
+++ b/cases_dynamic/oscillating_droplet_p_ref/scripts/run_github_twophase_oscillating_preview.py
@@ -1,0 +1,420 @@
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import sys
+import time
+import types
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parent
+GITHUB_REPO = Path("/private/tmp/ddgclib_latest_for_oscillating_droplet")
+if str(GITHUB_REPO) not in sys.path:
+    sys.path.insert(0, str(GITHUB_REPO))
+os.environ.setdefault("MPLCONFIGDIR", str(ROOT / ".mplconfig"))
+
+import matplotlib  # noqa: E402
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+from matplotlib.animation import FuncAnimation, PillowWriter  # noqa: E402
+from mpl_toolkits.mplot3d.art3d import Line3DCollection  # noqa: E402
+
+
+def _angular_sort_3d_compat(vertices):
+    verts = list(vertices)
+    if len(verts) < 3:
+        return verts
+    pts = np.asarray([v.x_a[:3] for v in verts], dtype=float)
+    center = np.mean(pts, axis=0)
+    shifted = pts - center[None, :]
+    try:
+        _u, _s, vh = np.linalg.svd(shifted, full_matrices=False)
+        normal = vh[-1]
+    except np.linalg.LinAlgError:
+        normal = np.array([0.0, 0.0, 1.0])
+    if np.linalg.norm(normal) <= 1.0e-30:
+        normal = np.array([0.0, 0.0, 1.0])
+    normal = normal / np.linalg.norm(normal)
+    ref = shifted[np.argmax(np.linalg.norm(shifted, axis=1))]
+    ref = ref - np.dot(ref, normal) * normal
+    if np.linalg.norm(ref) <= 1.0e-30:
+        ref = np.cross(normal, np.array([1.0, 0.0, 0.0]))
+        if np.linalg.norm(ref) <= 1.0e-30:
+            ref = np.cross(normal, np.array([0.0, 1.0, 0.0]))
+    ref = ref / np.linalg.norm(ref)
+    tangent = np.cross(normal, ref)
+    angles = np.arctan2(shifted @ tangent, shifted @ ref)
+    order = np.argsort(angles)
+    return [verts[int(i)] for i in order]
+
+
+dual_cell_module = types.ModuleType("hyperct.ddg._dual_cell")
+dual_cell_module._angular_sort_3d = _angular_sort_3d_compat
+sys.modules.setdefault("hyperct.ddg._dual_cell", dual_cell_module)
+
+try:
+    import hyperct.ddg as hyperct_ddg  # noqa: E402
+
+    _batch_e_star_original = hyperct_ddg.batch_e_star
+
+    def _orient_and_sum_edge_areas(edge_areas, HC):
+        vertices_by_id = {id(v): v for v in HC.V}
+        summed = {}
+        for vid, nb_map in edge_areas.items():
+            v = vertices_by_id.get(vid)
+            if v is None:
+                continue
+            summed[vid] = {}
+            for nbid, raw in nb_map.items():
+                nb = vertices_by_id.get(nbid)
+                arr = np.asarray(raw, dtype=float)
+                if arr.ndim == 1:
+                    summed[vid][nbid] = arr[:3]
+                    continue
+                if arr.size == 0:
+                    summed[vid][nbid] = np.zeros(3)
+                    continue
+                vec_to_i = None
+                if nb is not None:
+                    vc_12_pos = 0.5 * (nb.x_a - v.x_a) + v.x_a
+                    try:
+                        vc_12 = HC.Vd[tuple(vc_12_pos)]
+                        vec_to_i = v.x_a[:3] - vc_12.x_a[:3]
+                    except Exception:
+                        vec_to_i = v.x_a[:3] - 0.5 * (v.x_a[:3] + nb.x_a[:3])
+                A_ij = np.zeros(3)
+                for A_ijk in arr.reshape((-1, 3)):
+                    A = np.asarray(A_ijk, dtype=float).copy()
+                    if vec_to_i is not None and np.dot(A, vec_to_i) > 0:
+                        A = -A
+                    A_ij += A
+                summed[vid][nbid] = A_ij
+        return summed
+
+    def _batch_e_star_compat(vertices, HC, dim=3, backend=None, orient=None, compute_volumes=False):
+        result = _batch_e_star_original(
+            vertices,
+            HC,
+            dim=dim,
+            backend=backend,
+            compute_volumes=compute_volumes,
+        )
+        if not orient:
+            return result
+        if compute_volumes:
+            edge_areas, failed, vols = result
+            return _orient_and_sum_edge_areas(edge_areas, HC), failed, vols
+        edge_areas, failed = result
+        return _orient_and_sum_edge_areas(edge_areas, HC), failed
+
+    hyperct_ddg.batch_e_star = _batch_e_star_compat
+except Exception:
+    pass
+
+from cases_dynamic.oscillating_droplet.src._setup import setup_oscillating_droplet  # noqa: E402
+from cases_dynamic.oscillating_droplet.src._analytical import rayleigh_frequency  # noqa: E402
+from ddgclib.dynamic_integrators import symplectic_euler  # noqa: E402
+
+
+def vertex_phase(v) -> int:
+    return int(getattr(v, "phase", 0))
+
+
+def ordered_vertices(HC) -> list:
+    return list(HC.V)
+
+
+def snapshot_from_hc(HC, dim: int) -> dict[str, np.ndarray]:
+    verts = ordered_vertices(HC)
+    index = {v: i for i, v in enumerate(verts)}
+    points = np.asarray([v.x_a[:dim] for v in verts], dtype=float)
+    if dim == 2:
+        points = np.column_stack([points, np.zeros(points.shape[0])])
+    phases = np.asarray([vertex_phase(v) for v in verts], dtype=int)
+    is_interface = np.asarray([bool(getattr(v, "is_interface", False)) for v in verts], dtype=bool)
+    edges: set[tuple[int, int]] = set()
+    for v in verts:
+        i = index[v]
+        for nb in getattr(v, "nn", []):
+            j = index.get(nb)
+            if j is not None:
+                edges.add(tuple(sorted((i, j))))
+    return {
+        "points": points,
+        "phases": phases,
+        "is_interface": is_interface,
+        "edges": np.asarray(sorted(edges), dtype=int).reshape((-1, 2)),
+    }
+
+
+def fit_cos2_amplitude(points: np.ndarray, interface_mask: np.ndarray, radius: float) -> float:
+    interface = points[interface_mask]
+    if interface.size == 0:
+        return 0.0
+    r = np.linalg.norm(interface, axis=1)
+    theta = np.arctan2(
+        np.sqrt(interface[:, 0] * interface[:, 0] + interface[:, 1] * interface[:, 1]),
+        interface[:, 2],
+    )
+    basis = np.cos(2.0 * theta)
+    return float(np.dot((r / float(radius)) - 1.0, basis) / max(np.dot(basis, basis), 1.0e-300))
+
+
+def run_case(
+    *,
+    out_dir: Path,
+    closure_label: str,
+    R0: float,
+    epsilon: float,
+    gamma: float,
+    rho_d: float,
+    rho_o: float,
+    mu_d: float,
+    mu_o: float,
+    K_d: float,
+    K_o: float,
+    t_final: float,
+    dt: float,
+    refinement_outer: int,
+    refinement_droplet: int,
+    enable_retopology: bool,
+) -> tuple[list[dict[str, float]], list[dict[str, np.ndarray]], float]:
+    HC, bV, _mps, bc_set, dudt_fn, retopo_fn, _params = setup_oscillating_droplet(
+        dim=3,
+        R0=R0,
+        epsilon=epsilon,
+        l=2,
+        rho_d=rho_d,
+        rho_o=rho_o,
+        mu_d=mu_d,
+        mu_o=mu_o,
+        gamma=gamma,
+        K_d=K_d,
+        K_o=K_o,
+        L_domain=5.0 * R0,
+        refinement_outer=refinement_outer,
+        refinement_droplet=refinement_droplet,
+    )
+    omega = rayleigh_frequency(2, gamma, rho_d, R0, dim=3, rho_outer=rho_o)
+    n_steps = int(math.ceil(float(t_final) / float(dt)))
+    record_every = max(1, n_steps // 80)
+    rows: list[dict[str, float]] = []
+    snapshots: list[dict[str, np.ndarray]] = []
+    cpu_start = time.process_time()
+
+    def record(step: int, t: float) -> None:
+        snap = snapshot_from_hc(HC, 3)
+        a2 = fit_cos2_amplitude(snap["points"], snap["is_interface"], R0)
+        rows.append(
+            {
+                "step": float(step),
+                "t": float(t),
+                "closure": closure_label,
+                "shape_amplitude_fit": float(a2),
+                "shape_amplitude_theory": float(epsilon * math.cos(omega * t)),
+                "rayleigh_omega_rad_s": float(omega),
+                "cpu_time_s": float(time.process_time() - cpu_start),
+                "n_vertices": float(snap["points"].shape[0]),
+                "n_edges": float(snap["edges"].shape[0]),
+                "n_interface": float(np.sum(snap["is_interface"])),
+                "n_liquid": float(np.sum(snap["phases"] == 1)),
+                "n_gas": float(np.sum(snap["phases"] == 0)),
+                "retopology_active": float(bool(enable_retopology)),
+            }
+        )
+        snapshots.append(snap)
+
+    record(0, 0.0)
+
+    def callback(step, t, HC_cb, bV_cb=None, diagnostics=None):
+        if step % record_every == 0 or step == n_steps - 1:
+            record(step + 1, t)
+
+    symplectic_euler(
+        HC,
+        bV,
+        dudt_fn,
+        dt=float(dt),
+        n_steps=n_steps,
+        dim=3,
+        bc_set=bc_set,
+        callback=callback,
+        retopologize_fn=retopo_fn if enable_retopology else False,
+    )
+    return rows, snapshots, omega
+
+
+def write_github_preview_gif(
+    rows: list[dict[str, float]],
+    snapshots: list[dict[str, np.ndarray]],
+    out_dir: Path,
+    *,
+    closure_label: str,
+    fps: int,
+) -> Path:
+    t = np.asarray([row["t"] for row in rows], dtype=float)
+    a_fit = np.asarray([row["shape_amplitude_fit"] for row in rows], dtype=float)
+    a_theory = np.asarray([row["shape_amplitude_theory"] for row in rows], dtype=float)
+    cpu = np.asarray([row["cpu_time_s"] for row in rows], dtype=float)
+    retopo_active = bool(rows and rows[0].get("retopology_active", 0.0))
+    if closure_label == "compressible":
+        liquid_color = "#1f77b4"
+        gif_name = "github_twophase_compressible_preview.gif"
+        title = "#11 GitHub-style two-phase water-air mesh"
+    else:
+        liquid_color = "#ff7f0e"
+        gif_name = "github_twophase_incompressible_preview.gif"
+        title = "#12 GitHub-style two-phase mesh, projection comparison"
+
+    all_points = np.vstack([snap["points"] for snap in snapshots])
+    limit = 1.05 * float(np.max(np.linalg.norm(all_points, axis=1)))
+    frame_indices = np.arange(len(snapshots), dtype=int)
+    time_ticks = np.linspace(float(t[0]), float(t[-1]), 5)
+
+    fig = plt.figure(figsize=(5.2, 7.3))
+    grid = fig.add_gridspec(2, 1, height_ratios=(3.3, 1.0), hspace=0.16)
+    ax3d = fig.add_subplot(grid[0], projection="3d")
+    ax_amp = fig.add_subplot(grid[1])
+
+    def draw(frame_pos: int) -> None:
+        idx = int(frame_indices[frame_pos])
+        snap = snapshots[idx]
+        points = snap["points"]
+        phases = snap["phases"]
+        interface = snap["is_interface"]
+        edges = snap["edges"]
+
+        ax3d.cla()
+        ax_amp.cla()
+        gas_vertices = phases == 0
+        liquid_vertices = phases == 1
+        interface_vertices = interface
+        if edges.size:
+            edge_phase = np.maximum(phases[edges[:, 0]], phases[edges[:, 1]])
+            gas_edges = edges[edge_phase == 0]
+            liquid_edges = edges[edge_phase == 1]
+            interface_edges = edges[np.any(interface[edges], axis=1)]
+            if gas_edges.size:
+                ax3d.add_collection3d(Line3DCollection(points[gas_edges], colors=(0.25, 0.42, 0.65, 0.18), linewidths=0.28))
+            if liquid_edges.size:
+                ax3d.add_collection3d(Line3DCollection(points[liquid_edges], colors=(0.05, 0.05, 0.05, 0.22), linewidths=0.32))
+            if interface_edges.size:
+                ax3d.add_collection3d(Line3DCollection(points[interface_edges], colors=(0.85, 0.28, 0.10, 0.55), linewidths=0.55))
+
+        if gas_vertices.any():
+            ax3d.scatter(points[gas_vertices, 0], points[gas_vertices, 1], points[gas_vertices, 2], s=5, c="#8fb8de", alpha=0.34, edgecolors="none", depthshade=False)
+        if liquid_vertices.any():
+            ax3d.scatter(points[liquid_vertices, 0], points[liquid_vertices, 1], points[liquid_vertices, 2], s=7, c=liquid_color, alpha=0.58, edgecolors="none", depthshade=False)
+        if interface_vertices.any():
+            ax3d.scatter(points[interface_vertices, 0], points[interface_vertices, 1], points[interface_vertices, 2], s=13, c="#d62728", alpha=0.92, edgecolors="white", linewidths=0.2, depthshade=False)
+
+        ax3d.set_xlim(-limit, limit)
+        ax3d.set_ylim(-limit, limit)
+        ax3d.set_zlim(-limit, limit)
+        ax3d.set_box_aspect((1, 1, 1))
+        ax3d.set_xticks([])
+        ax3d.set_yticks([])
+        ax3d.set_zticks([])
+        ax3d.view_init(elev=20.0, azim=34.0 + 26.0 * float(t[idx]) / max(float(t[-1]), 1.0e-30))
+        ax3d.set_title(title, fontsize=8.8, pad=4)
+        ax3d.text2D(
+            0.02,
+            0.97,
+            (
+                f"t = {t[idx]:.5f} s\n"
+                f"phase 1 liquid verts = {int(rows[idx]['n_liquid'])}\n"
+                f"phase 0 gas verts = {int(rows[idx]['n_gas'])}\n"
+                f"interface verts = {int(rows[idx]['n_interface'])}\n"
+                f"retopology = {'active' if retopo_active else 'off'}\n"
+                f"CPU = {cpu[idx]:.1f}/{cpu[-1]:.1f} s"
+            ),
+            transform=ax3d.transAxes,
+            va="top",
+            ha="left",
+            fontsize=7.2,
+            family="monospace",
+        )
+
+        pad = max(0.1 * float(np.ptp(a_theory)), 0.004)
+        ax_amp.plot(t, a_theory, "k--", lw=1.3, label="Rayleigh theory")
+        ax_amp.plot(t, a_fit, color=liquid_color, lw=1.6, label="GitHub two-phase")
+        ax_amp.plot(t[idx], a_fit[idx], "o", color="#d62728", ms=4.0)
+        ax_amp.set_xlim(float(t[0]), float(t[-1]))
+        ax_amp.set_ylim(float(min(np.min(a_theory), np.min(a_fit)) - pad), float(max(np.max(a_theory), np.max(a_fit)) + pad))
+        ax_amp.set_xticks(time_ticks)
+        ax_amp.set_xlabel("t [s]", fontsize=8)
+        ax_amp.set_ylabel("a2", fontsize=8)
+        ax_amp.set_title("Shape amplitude", fontsize=8)
+        ax_amp.tick_params(labelsize=7)
+        ax_amp.grid(True, alpha=0.25)
+        ax_amp.legend(frameon=False, fontsize=7, loc="upper right")
+
+    fig.subplots_adjust(left=0.08, right=0.98, top=0.97, bottom=0.07)
+    animation = FuncAnimation(fig, draw, frames=len(frame_indices), interval=1000.0 / max(1, int(fps)))
+    path = out_dir / gif_name
+    animation.save(path, writer=PillowWriter(fps=max(1, int(fps))))
+    plt.close(fig)
+    return path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run latest GitHub two-phase oscillating droplet preview.")
+    parser.add_argument("--closure-label", choices=("compressible", "incompressible"), default="compressible")
+    parser.add_argument("--out-dir", type=Path, default=ROOT / "out" / "github_twophase_oscillating_preview")
+    parser.add_argument("--t-final", type=float, default=0.016)
+    parser.add_argument("--dt", type=float, default=1.0e-4)
+    parser.add_argument("--fps", type=int, default=12)
+    parser.add_argument("--refinement-outer", type=int, default=1)
+    parser.add_argument("--refinement-droplet", type=int, default=1)
+    parser.add_argument("--enable-retopology", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    R0 = 1.0e-3
+    gamma = 0.072
+    rho_d = 1000.0
+    rho_o = 1.225
+    epsilon = 0.05
+    c_s = 1.0
+    rows, snapshots, omega = run_case(
+        out_dir=args.out_dir,
+        closure_label=args.closure_label,
+        R0=R0,
+        epsilon=epsilon,
+        gamma=gamma,
+        rho_d=rho_d,
+        rho_o=rho_o,
+        mu_d=0.001,
+        mu_o=1.81e-5,
+        K_d=rho_d * c_s * c_s,
+        K_o=rho_o * c_s * c_s,
+        t_final=args.t_final,
+        dt=args.dt,
+        refinement_outer=args.refinement_outer,
+        refinement_droplet=args.refinement_droplet,
+        enable_retopology=args.enable_retopology,
+    )
+    (args.out_dir / f"{args.closure_label}_rows.json").write_text(json.dumps(rows, indent=2))
+    np.savez_compressed(
+        args.out_dir / f"{args.closure_label}_snapshots.npz",
+        points=np.asarray([snap["points"] for snap in snapshots], dtype=object),
+        phases=np.asarray([snap["phases"] for snap in snapshots], dtype=object),
+        interface=np.asarray([snap["is_interface"] for snap in snapshots], dtype=object),
+        edges=np.asarray([snap["edges"] for snap in snapshots], dtype=object),
+    )
+    gif = write_github_preview_gif(rows, snapshots, args.out_dir, closure_label=args.closure_label, fps=args.fps)
+    print(f"omega={omega:.6g}")
+    print(gif)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cases_dynamic/oscillating_droplet_p_ref/scripts/sphere_fheron_dynamic_integrator_p_ref.py
+++ b/cases_dynamic/oscillating_droplet_p_ref/scripts/sphere_fheron_dynamic_integrator_p_ref.py
@@ -2,7 +2,7 @@
 
 This runner validates the Stefan/Mädler pressure-reference implementation:
 
-* the state/cache object is ``ddgclib.operators.stress.VolumeGradientPressureState``;
+* the state/cache object is ``pr33_operators.VolumeGradientPressureState``;
 * the acceleration is the dynamic-integrator ``dudt_fn``
   ``volume_gradient_pressure_acceleration(v, state=...)``;
 * ``symplectic_euler`` advances the vertices with ``du/dt=Ftot/m`` and
@@ -32,8 +32,8 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from ddgclib.dynamic_integrators import symplectic_euler
-from ddgclib.operators import multiphase_stress as ddg_multiphase
-from ddgclib.operators import stress as ddg_stress
+import pr33_operators as ddg_multiphase
+import pr33_operators as ddg_stress
 
 import sphere_fheron_eos_projection_benchmark as base
 import sphere_fheron_twophase_gasmesh_benchmark as twophase

--- a/cases_dynamic/oscillating_droplet_p_ref/scripts/sphere_fheron_dynamic_integrator_p_ref.py
+++ b/cases_dynamic/oscillating_droplet_p_ref/scripts/sphere_fheron_dynamic_integrator_p_ref.py
@@ -1,0 +1,616 @@
+"""Built-in dynamic-integrator validation for the pressure-reference droplet.
+
+This runner validates the Stefan/Mädler pressure-reference implementation:
+
+* the state/cache object is ``ddgclib.operators.stress.VolumeGradientPressureState``;
+* the acceleration is the dynamic-integrator ``dudt_fn``
+  ``volume_gradient_pressure_acceleration(v, state=...)``;
+* ``symplectic_euler`` advances the vertices with ``du/dt=Ftot/m`` and
+  ``dx/dt=u``;
+* active-retopology cases rebuild the tet-volume pressure operator through the
+  integrator ``retopologize_fn`` callback before each step.
+
+References in the operator comments: Chorin (1968), Hirt et al. (1974),
+Toro (2009), and the ddgclib/HyperCT HC Heron curvature construction.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+from pathlib import Path
+import sys
+import time
+import warnings
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from ddgclib.dynamic_integrators import symplectic_euler
+from ddgclib.operators import multiphase_stress as ddg_multiphase
+from ddgclib.operators import stress as ddg_stress
+
+import sphere_fheron_eos_projection_benchmark as base
+import sphere_fheron_twophase_gasmesh_benchmark as twophase
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+LIQUID = 1
+GAS = 0
+
+
+def build_vertex_complex(
+    points: np.ndarray,
+    velocities: np.ndarray,
+    masses: np.ndarray,
+    vertex_phases: np.ndarray | None = None,
+):
+    """Build a minimal HC vertex complex for the built-in ODE integrator."""
+    from hyperct import Complex
+
+    HC = Complex(3, domain=None)
+    vertices = []
+    for index, point in enumerate(np.asarray(points, dtype=float)):
+        vertex = HC.V[tuple(float(x) for x in point)]
+        vertex.u = np.asarray(velocities[index], dtype=float).copy()
+        vertex.m = float(masses[index])
+        vertex.p = 0.0
+        vertex.phase = int(vertex_phases[index]) if vertex_phases is not None else 1
+        vertex.boundary = False
+        setattr(vertex, ddg_stress.VolumeGradientPressureState.vertex_index_attr, int(index))
+        vertices.append(vertex)
+    return HC, vertices
+
+
+def write_rows(rows: list[dict[str, float]], out_dir: Path, stem: str) -> tuple[Path, Path]:
+    csv_path = out_dir / f"{stem}.csv"
+    json_path = out_dir / f"{stem}.json"
+    with csv_path.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+    json_path.write_text(json.dumps(rows, indent=2))
+    return csv_path, json_path
+
+
+def run_case(
+    *,
+    case_id: int,
+    closure: str,
+    subdivisions: int,
+    radius: float,
+    gamma: float,
+    rho: float,
+    bulk_modulus: float,
+    amplitude: float,
+    n_steps: int,
+    t_final: float,
+    substeps_per_sample: int,
+    damping_ratio: float,
+    inertia_scale: float,
+    mass_flux_coupling: float,
+    momentum_flux_coupling: float,
+    density_change_limit: float | None,
+    face_flux_mode: str,
+    active_retopology: bool,
+    rayleigh_mode: int,
+    rayleigh_frequency_hz: float,
+    rayleigh_omega_rad_s: float,
+) -> tuple[list[dict[str, float]], np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    reference_points, tets, surface_indices, surface_faces, _surface_faces_global, _unit_points = base.build_ball_tet_mesh(
+        subdivisions,
+        radius,
+    )
+    points = base.deform_l2_volume_points(
+        reference_points,
+        tets,
+        radius=radius,
+        amplitude=amplitude,
+        target_volume=float(np.sum(ddg_stress.tet_cell_volumes(reference_points, tets))),
+    )
+    reference_tet_volumes, _matrix0 = ddg_stress.tet_volume_matrix(points, tets)
+    tet_masses = float(rho) * reference_tet_volumes
+    nodal_masses = ddg_stress.tet_volume_lumped_nodal_values(points.shape[0], tets, tet_masses)
+    velocities = np.zeros_like(points)
+
+    _forces0, _areas0, reference_pressure, _volume0 = ddg_stress.heron_forces_for_points(
+        reference_points[surface_indices],
+        surface_faces,
+        gamma,
+    )
+    dt = float(t_final) / float((int(n_steps) - 1) * int(substeps_per_sample))
+    damping_rate = 2.0 * float(damping_ratio) * float(rayleigh_omega_rad_s)
+    sound_speed = math.sqrt(float(bulk_modulus) / float(rho))
+
+    HC, _vertices = build_vertex_complex(points, velocities, np.maximum(nodal_masses, 1.0e-18))
+    bV: set = set()
+    state = ddg_stress.VolumeGradientPressureState(
+        tets=tets,
+        surface_indices=surface_indices,
+        surface_faces=surface_faces,
+        gamma=gamma,
+        density=rho,
+        bulk_modulus=bulk_modulus,
+        closure=closure,
+        reference_tet_volumes=reference_tet_volumes,
+        tet_masses=tet_masses,
+        base_tet_pressures=reference_pressure,
+        dt=dt,
+        inertia_scale=inertia_scale,
+        inertial_mass_addition=np.zeros(points.shape[0], dtype=float),
+        damping_rate=damping_rate,
+        active_retopology=active_retopology,
+        mass_flux_coupling=mass_flux_coupling,
+        momentum_flux_coupling=momentum_flux_coupling,
+        density_change_limit=density_change_limit,
+        face_flux_mode=face_flux_mode,
+        sound_speed=sound_speed,
+        incompressible_target_mode="reference",
+    )
+    state.HC = HC
+
+    rows: list[dict[str, float]] = []
+    snapshots: list[np.ndarray] = []
+    display_tets: list[np.ndarray] = []
+    cpu_start = time.process_time()
+    wall_start = time.perf_counter()
+
+    def collect(sample: int, time_value: float) -> None:
+        current_points, current_velocities = state.read_hc_state(HC)
+        stats = state.diagnostics(HC)
+        surface_points = current_points[surface_indices]
+        fitted_amplitude = base.fit_l2_shape_amplitude(surface_points, surface_faces)
+        theory_amplitude = float(amplitude) * math.cos(float(rayleigh_omega_rad_s) * float(time_value))
+        cpu_elapsed = time.process_time() - cpu_start
+        wall_elapsed = time.perf_counter() - wall_start
+        substeps_done = int(sample) * int(substeps_per_sample)
+        rows.append(
+            {
+                "case_id": float(case_id),
+                "sample": float(sample),
+                "t": float(time_value),
+                "closure": closure,
+                "integrator": "symplectic_euler",
+                "shape_amplitude_theory": float(theory_amplitude),
+                "shape_amplitude_fit": float(fitted_amplitude),
+                "shape_amplitude_abs_error": float(abs(fitted_amplitude - theory_amplitude)),
+                "rayleigh_frequency_hz": float(rayleigh_frequency_hz),
+                "rayleigh_omega_rad_s": float(rayleigh_omega_rad_s),
+                "reference_pressure_pa": float(reference_pressure),
+                "closure_pressure_pa": float(stats["closure_pressure_pa"]),
+                "fheron_pressure_pa": float(stats["fheron_pressure_pa"]),
+                "vol_rel": float(stats["vol_rel"]),
+                "local_volume_rel_max_abs": float(stats["local_volume_rel_max_abs"]),
+                "nodal_density_rel_min": float(stats["nodal_density_rel_min"]),
+                "nodal_density_rel_max": float(stats["nodal_density_rel_max"]),
+                "total_mass_kg": float(stats["total_mass_kg"]),
+                "mass_flux_l1_kg_s": float(stats["mass_flux_l1_kg_s"]),
+                "momentum_flux_l1_n": float(stats["momentum_flux_l1_n"]),
+                "flux_limiter_scale": float(stats["flux_limiter_scale"]),
+                "mass_flux_coupling": float(mass_flux_coupling),
+                "momentum_flux_coupling": float(momentum_flux_coupling),
+                "face_flux_lagrangian": 1.0 if face_flux_mode == "lagrangian" else 0.0,
+                "density_change_limit": float(density_change_limit) if density_change_limit is not None else 0.0,
+                "inertia_scale": float(inertia_scale),
+                "active_retopology": 1.0 if active_retopology else 0.0,
+                "solver_tet_count": float(state.tets.shape[0]),
+                "display_tet_count": float(stats["display_tet_count"]),
+                "display_changed_tets": float(stats["display_changed_tets"]),
+                "display_changed_fraction": float(stats["display_changed_fraction"]),
+                "cpu_time_s": float(cpu_elapsed),
+                "wall_time_s": float(wall_elapsed),
+                "cpu_ms_per_substep": float(1.0e3 * cpu_elapsed / float(substeps_done)) if substeps_done else 0.0,
+                "wall_ms_per_substep": float(1.0e3 * wall_elapsed / float(substeps_done)) if substeps_done else 0.0,
+                "max_speed_m_s": float(np.max(np.linalg.norm(current_velocities, axis=1))),
+            }
+        )
+        snapshots.append(current_points.copy())
+        display_tets.append(np.asarray(state.tets, dtype=int).copy())
+
+    state.prepare(HC)
+    collect(0, 0.0)
+
+    total_substeps = (int(n_steps) - 1) * int(substeps_per_sample)
+
+    def callback(step, t, HC_obj, bV_obj, _diagnostics) -> None:
+        state.remove_rigid_translation(HC_obj, bV_obj)
+        if (int(step) + 1) % int(substeps_per_sample) == 0:
+            sample = (int(step) + 1) // int(substeps_per_sample)
+            collect(sample, float(t))
+
+    symplectic_euler(
+        HC,
+        bV,
+        ddg_stress.volume_gradient_pressure_acceleration,
+        dt,
+        total_substeps,
+        dim=3,
+        callback=callback,
+        retopologize_fn=state.retopologize_callback,
+        state=state,
+        mu=0.0,
+    )
+    return rows, np.asarray(snapshots, dtype=float), surface_faces, surface_indices, np.asarray(display_tets, dtype=object)
+
+
+def run_twophase_case(
+    *,
+    case_id: int,
+    closure: str,
+    subdivisions: int,
+    radius: float,
+    outer_radius_scale: float,
+    gamma: float,
+    rho_liquid: float,
+    rho_gas: float,
+    bulk_liquid: float,
+    bulk_gas: float,
+    amplitude: float,
+    n_steps: int,
+    t_final: float,
+    substeps_per_sample: int,
+    inertia_scale: float,
+    rayleigh_mode: int,
+    rayleigh_frequency_hz: float,
+    rayleigh_omega_rad_s: float,
+) -> tuple[list[dict[str, float]], np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    reference_points, tets, phases, interface_indices, outer_indices, surface_faces, _unit, liquid_vertex_indices = (
+        twophase.build_liquid_gas_mesh(subdivisions, radius, outer_radius_scale)
+    )
+    points = twophase.deform_initial_interface(
+        reference_points,
+        tets,
+        phases,
+        liquid_vertex_indices,
+        radius,
+        amplitude,
+    )
+    liquid_tets = np.asarray(tets[phases == LIQUID], dtype=int)
+    gas_tets = np.asarray(tets[phases == GAS], dtype=int)
+    gas_tets_current = gas_tets.copy()
+    reference_liquid_volumes, _matrix0 = ddg_stress.tet_volume_matrix(points, liquid_tets)
+    reference_gas_volumes = ddg_stress.tet_cell_volumes(points, gas_tets)
+    tet_masses = float(rho_liquid) * reference_liquid_volumes
+    gas_tet_masses = float(rho_gas) * reference_gas_volumes
+    nodal_masses = ddg_stress.tet_volume_lumped_nodal_values(points.shape[0], liquid_tets, tet_masses)
+    velocities = np.zeros_like(points)
+    vertex_phases = np.full(points.shape[0], GAS, dtype=int)
+    vertex_phases[np.asarray(liquid_vertex_indices, dtype=int)] = LIQUID
+
+    inertial_mass_addition = np.zeros(points.shape[0], dtype=float)
+
+    _forces0, _areas0, reference_pressure, _volume0 = ddg_stress.heron_forces_for_points(
+        reference_points[interface_indices],
+        surface_faces,
+        gamma,
+    )
+    dt = float(t_final) / float((int(n_steps) - 1) * int(substeps_per_sample))
+
+    HC, _vertices = build_vertex_complex(points, velocities, np.maximum(nodal_masses, 1.0e-18), vertex_phases)
+    bV: set = set()
+    state = ddg_multiphase.MultiphaseVolumeGradientPressureState(
+        tets=liquid_tets,
+        surface_indices=interface_indices,
+        surface_faces=surface_faces,
+        gamma=gamma,
+        density=rho_liquid,
+        bulk_modulus=bulk_liquid,
+        closure=closure,
+        reference_tet_volumes=reference_liquid_volumes,
+        tet_masses=tet_masses,
+        base_tet_pressures=reference_pressure,
+        dt=dt,
+        inertia_scale=inertia_scale,
+        inertial_mass_addition=inertial_mass_addition,
+        damping_rate=0.0,
+        fixed_indices=outer_indices,
+        phase_ids=np.full(liquid_tets.shape[0], LIQUID, dtype=int),
+        phase_densities={LIQUID: float(rho_liquid), GAS: float(rho_gas)},
+        phase_bulk_moduli={LIQUID: float(bulk_liquid), GAS: float(bulk_gas)},
+        phase_base_pressures={LIQUID: float(reference_pressure), GAS: 0.0},
+        active_retopology=False,
+        mass_flux_coupling=1.0,
+        momentum_flux_coupling=1.0,
+        density_change_limit=None,
+        face_flux_mode="lagrangian",
+        sound_speed=math.sqrt(float(bulk_liquid) / float(rho_liquid)),
+        incompressible_target_mode="reference",
+    )
+    state.HC = HC
+
+    rows: list[dict[str, float]] = []
+    snapshots: list[np.ndarray] = []
+    display_tets: list[np.ndarray] = []
+    phases_snapshots: list[np.ndarray] = []
+    cpu_start = time.process_time()
+    wall_start = time.perf_counter()
+    reference_liquid_volume = float(np.sum(reference_liquid_volumes))
+    reference_gas_volume = float(np.sum(reference_gas_volumes))
+    liquid_vertex_indices = np.asarray(liquid_vertex_indices, dtype=int)
+    reference_combined_tet_set = {tuple(sorted(int(v) for v in tet)) for tet in np.asarray(tets, dtype=int)}
+    state.reference_display_tet_set = set(reference_combined_tet_set)
+
+    def twophase_retopology_callback(HC_obj, _bV, _dim, **_kwargs) -> None:
+        """Rebuild the two-phase Delaunay tet list and refresh liquid pressure.
+
+        The full liquid+gas vertex cloud is retriangulated.  New tetrahedra are
+        phase-labelled by the persistent Lagrangian vertex phase: a tet is
+        liquid only when all four vertices belong to the liquid vertex set;
+        every tet touching a gas/outer vertex is gas.  The pressure-reference
+        operator is then rebuilt only on the liquid tets, with tet masses and
+        target volumes remapped from the new tet volumes.  This is the
+        retopology workaround for the HC-dual-volume density/pressure jump
+        observed in the original oscillating-droplet case.
+        """
+        nonlocal gas_tets_current
+        current_points, _current_velocities = state.read_hc_state(HC_obj)
+        combined_old_tets = np.vstack([np.asarray(state.tets, dtype=int), np.asarray(gas_tets_current, dtype=int)])
+        new_all_tets = ddg_stress.delaunay_retriangulate_points(current_points, combined_old_tets)
+        new_all_tets = np.asarray(new_all_tets, dtype=int)
+        new_tet_phases = np.where(
+            np.all(vertex_phases[new_all_tets] == LIQUID, axis=1),
+            LIQUID,
+            GAS,
+        )
+        new_liquid_tets = np.asarray(new_all_tets[new_tet_phases == LIQUID], dtype=int)
+        new_gas_tets = np.asarray(new_all_tets[new_tet_phases == GAS], dtype=int)
+        if new_liquid_tets.size == 0 or new_gas_tets.size == 0:
+            new_liquid_tets = np.asarray(state.tets, dtype=int)
+            new_gas_tets = np.asarray(gas_tets_current, dtype=int)
+        new_liquid_volumes = ddg_stress.tet_cell_volumes(current_points, new_liquid_tets)
+        current_liquid_volume = float(np.sum(new_liquid_volumes))
+        if current_liquid_volume <= 1.0e-300:
+            new_liquid_tets = np.asarray(state.tets, dtype=int)
+            new_liquid_volumes = ddg_stress.tet_cell_volumes(current_points, new_liquid_tets)
+            current_liquid_volume = max(float(np.sum(new_liquid_volumes)), 1.0e-300)
+        # The pressure target is remapped from the new liquid tet volumes.
+        # Without this step, a Delaunay connectivity flip changes local volume
+        # bookkeeping and the EOS/projection interprets that as a physical
+        # density jump.
+        mass_density = float(state.reference_total_mass) / current_liquid_volume
+        volume_scale = float(state.reference_total_volume) / current_liquid_volume
+        state.tets = np.asarray(new_liquid_tets, dtype=int)
+        state.reference_tet_volumes = volume_scale * np.asarray(new_liquid_volumes, dtype=float)
+        state.tet_masses = mass_density * np.asarray(new_liquid_volumes, dtype=float)
+        state.reference_tet_masses = state.tet_masses.copy()
+        state.phase_ids = np.full(state.tets.shape[0], LIQUID, dtype=int)
+        state.face_pairs = ddg_stress.tet_face_pairs(state.tets)
+        gas_tets_current = np.asarray(new_gas_tets, dtype=int)
+        current_combined = np.vstack([state.tets, gas_tets_current])
+        current_set = {tuple(sorted(int(v) for v in tet)) for tet in current_combined}
+        changed = reference_combined_tet_set ^ current_set
+        state.last_retopology_stats = {
+            "retriangulation_active": 1.0,
+            "display_tet_count": float(current_combined.shape[0]),
+            "display_internal_face_count": float(len(ddg_stress.tet_face_pairs(current_combined))),
+            "display_changed_tets": float(len(changed)),
+            "display_changed_fraction": float(len(changed)) / max(float(len(reference_combined_tet_set | current_set)), 1.0),
+        }
+        state.mark_dirty()
+
+    def combined_display() -> tuple[np.ndarray, np.ndarray]:
+        combined_tets = np.vstack([np.asarray(state.tets, dtype=int), np.asarray(gas_tets_current, dtype=int)])
+        combined_phases = np.concatenate(
+            [
+                np.full(state.tets.shape[0], LIQUID, dtype=int),
+                np.full(gas_tets_current.shape[0], GAS, dtype=int),
+            ]
+        )
+        return combined_tets, combined_phases
+
+    def collect(sample: int, time_value: float) -> None:
+        current_points, current_velocities = state.read_hc_state(HC)
+        stats = state.diagnostics(HC)
+        combined_tets, current_phases = combined_display()
+        liquid_volumes, _matrix = ddg_stress.tet_volume_matrix(current_points, state.tets)
+        gas_volumes = ddg_stress.tet_cell_volumes(current_points, gas_tets_current)
+        interface_points = current_points[interface_indices]
+        fitted_amplitude = base.fit_l2_shape_amplitude(interface_points, surface_faces)
+        theory_amplitude = float(amplitude) * math.cos(float(rayleigh_omega_rad_s) * float(time_value))
+        cpu_elapsed = time.process_time() - cpu_start
+        wall_elapsed = time.perf_counter() - wall_start
+        substeps_done = int(sample) * int(substeps_per_sample)
+        liquid_mask = current_phases == LIQUID
+        gas_mask = current_phases == GAS
+        liquid_vol = float(np.sum(liquid_volumes))
+        gas_vol = float(np.sum(gas_volumes))
+        rows.append(
+            {
+                "case_id": float(case_id),
+                "sample": float(sample),
+                "t": float(time_value),
+                "closure": closure,
+                "integrator": "symplectic_euler",
+                "mesh_phases": 2.0,
+                "n_liquid_tets": float(np.sum(liquid_mask)),
+                "n_gas_tets": float(np.sum(gas_mask)),
+                "n_interface_vertices": float(interface_indices.shape[0]),
+                "n_outer_gas_vertices": float(outer_indices.shape[0]),
+                "shape_amplitude_theory": float(theory_amplitude),
+                "shape_amplitude_fit": float(fitted_amplitude),
+                "shape_amplitude_abs_error": float(abs(fitted_amplitude - theory_amplitude)),
+                "rayleigh_frequency_hz": float(rayleigh_frequency_hz),
+                "rayleigh_omega_rad_s": float(rayleigh_omega_rad_s),
+                "reference_pressure_pa": float(reference_pressure),
+                "closure_pressure_pa": float(stats["closure_pressure_pa"]),
+                "fheron_pressure_pa": float(stats["fheron_pressure_pa"]),
+                "liquid_vol_rel": float(liquid_vol / max(reference_liquid_volume, 1.0e-300)),
+                "gas_vol_rel": float(gas_vol / max(reference_gas_volume, 1.0e-300)),
+                "local_volume_rel_max_abs": float(stats["local_volume_rel_max_abs"]),
+                "nodal_density_rel_min": float(stats["nodal_density_rel_min"]),
+                "nodal_density_rel_max": float(stats["nodal_density_rel_max"]),
+                "total_mass_kg": float(stats["total_mass_kg"] + np.sum(gas_tet_masses)),
+                "mass_flux_l1_kg_s": float(stats["mass_flux_l1_kg_s"]),
+                "momentum_flux_l1_n": float(stats["momentum_flux_l1_n"]),
+                "flux_limiter_scale": float(stats["flux_limiter_scale"]),
+                "face_flux_lagrangian": 1.0,
+                "inertia_scale": float(inertia_scale),
+                "active_retopology": 1.0,
+                "solver_tet_count": float(state.tets.shape[0]),
+                "display_tet_count": float(combined_tets.shape[0]),
+                "display_changed_tets": float(state.last_retopology_stats["display_changed_tets"]),
+                "display_changed_fraction": float(state.last_retopology_stats["display_changed_fraction"]),
+                "cpu_time_s": float(cpu_elapsed),
+                "wall_time_s": float(wall_elapsed),
+                "cpu_ms_per_substep": float(1.0e3 * cpu_elapsed / float(substeps_done)) if substeps_done else 0.0,
+                "wall_ms_per_substep": float(1.0e3 * wall_elapsed / float(substeps_done)) if substeps_done else 0.0,
+                "max_speed_m_s": float(np.max(np.linalg.norm(current_velocities, axis=1))),
+            }
+        )
+        snapshots.append(current_points.copy())
+        display_tets.append(np.asarray(combined_tets, dtype=int).copy())
+        phases_snapshots.append(np.asarray(current_phases, dtype=int).copy())
+
+    state.prepare(HC)
+    collect(0, 0.0)
+    total_substeps = (int(n_steps) - 1) * int(substeps_per_sample)
+
+    def callback(step, t, HC_obj, bV_obj, _diagnostics) -> None:
+        state.mark_dirty()
+        if (int(step) + 1) % int(substeps_per_sample) == 0:
+            sample = (int(step) + 1) // int(substeps_per_sample)
+            collect(sample, float(t))
+
+    symplectic_euler(
+        HC,
+        bV,
+        ddg_multiphase.multiphase_volume_gradient_pressure_acceleration,
+        dt,
+        total_substeps,
+        dim=3,
+        callback=callback,
+        retopologize_fn=twophase_retopology_callback,
+        state=state,
+        mu=0.0,
+    )
+    return (
+        rows,
+        np.asarray(snapshots, dtype=float),
+        surface_faces,
+        interface_indices,
+        outer_indices,
+        np.asarray(display_tets, dtype=object),
+        np.asarray(phases_snapshots, dtype=object),
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate volume-gradient pressure through ddgclib dynamic integrators.")
+    parser.add_argument("--case-id", type=int, choices=(5, 6, 11, 12), required=True)
+    parser.add_argument("--radius", type=float, default=1.0e-3)
+    parser.add_argument("--outer-radius-scale", type=float, default=1.60)
+    parser.add_argument("--gamma", type=float, default=0.072)
+    parser.add_argument("--rho", type=float, default=1000.0)
+    parser.add_argument("--rho-gas", type=float, default=1.2)
+    parser.add_argument("--bulk-modulus", type=float, default=2.2e9)
+    parser.add_argument("--bulk-gas", type=float, default=1.42e5)
+    parser.add_argument("--rayleigh-mode", type=int, default=2)
+    parser.add_argument("--shape-mode-ar", type=float, default=1.05)
+    parser.add_argument("--t-final", type=float, default=0.016)
+    parser.add_argument("--subdivision", type=int, default=1)
+    parser.add_argument("--steps", type=int, default=81)
+    parser.add_argument("--substeps-per-sample", type=int, default=None)
+    parser.add_argument("--damping-ratio", type=float, default=0.0)
+    parser.add_argument("--inertia-scale", type=float, default=1.08)
+    parser.add_argument("--mass-flux-coupling", type=float, default=1.0)
+    parser.add_argument("--momentum-flux-coupling", type=float, default=1.0)
+    parser.add_argument("--density-change-limit", type=float, default=0.0)
+    parser.add_argument("--face-flux-mode", choices=("lagrangian", "cell-average"), default="lagrangian")
+    parser.add_argument("--out-dir", type=Path, default=SCRIPT_DIR / "out" / "dynamic_integrator_p_ref")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    closure = "compressible" if int(args.case_id) in (5, 11) else "incompressible"
+    active_retopology = int(args.case_id) in (11, 12)
+    default_substeps = 5 if active_retopology else 20
+    substeps_per_sample = int(args.substeps_per_sample or default_substeps)
+    omega, frequency, _period = base.rayleigh_lamb_frequency(args.rayleigh_mode, args.gamma, args.rho, args.radius)
+    amplitude = base.shape_amplitude_from_aspect_ratio(args.shape_mode_ar)
+    density_limit = None if args.density_change_limit is None or float(args.density_change_limit) <= 0.0 else float(args.density_change_limit)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        if int(args.case_id) in (11, 12):
+            rows, snapshots, faces, surface_indices, outer_indices, display_tets, phases_snapshots = run_twophase_case(
+                case_id=args.case_id,
+                closure=closure,
+                subdivisions=args.subdivision,
+                radius=args.radius,
+                outer_radius_scale=args.outer_radius_scale,
+                gamma=args.gamma,
+                rho_liquid=args.rho,
+                rho_gas=args.rho_gas,
+                bulk_liquid=args.bulk_modulus,
+                bulk_gas=args.bulk_gas,
+                amplitude=amplitude,
+                n_steps=args.steps,
+                t_final=args.t_final,
+                substeps_per_sample=substeps_per_sample,
+                inertia_scale=args.inertia_scale,
+                rayleigh_mode=args.rayleigh_mode,
+                rayleigh_frequency_hz=frequency,
+                rayleigh_omega_rad_s=omega,
+            )
+            stem = f"case{int(args.case_id)}_dynamic_integrator_twophase_{closure}"
+        else:
+            rows, snapshots, faces, surface_indices, display_tets = run_case(
+                case_id=args.case_id,
+                closure=closure,
+                subdivisions=args.subdivision,
+                radius=args.radius,
+                gamma=args.gamma,
+                rho=args.rho,
+                bulk_modulus=args.bulk_modulus,
+                amplitude=amplitude,
+                n_steps=args.steps,
+                t_final=args.t_final,
+                substeps_per_sample=substeps_per_sample,
+                damping_ratio=args.damping_ratio,
+                inertia_scale=args.inertia_scale,
+                mass_flux_coupling=args.mass_flux_coupling,
+                momentum_flux_coupling=args.momentum_flux_coupling,
+                density_change_limit=density_limit,
+                face_flux_mode=args.face_flux_mode,
+                active_retopology=active_retopology,
+                rayleigh_mode=args.rayleigh_mode,
+                rayleigh_frequency_hz=frequency,
+                rayleigh_omega_rad_s=omega,
+            )
+            outer_indices = np.asarray([], dtype=int)
+            phases_snapshots = np.asarray([], dtype=object)
+            stem = f"case{int(args.case_id)}_dynamic_integrator_{closure}"
+    csv_path, json_path = write_rows(rows, args.out_dir, stem)
+    npz_path = args.out_dir / f"{stem}_snapshots.npz"
+    np.savez_compressed(
+        npz_path,
+        points=snapshots,
+        faces=faces,
+        surface_indices=surface_indices,
+        outer_indices=outer_indices,
+        display_tets=display_tets,
+        phases=phases_snapshots,
+    )
+    final = rows[-1]
+    print(
+        f"#{int(args.case_id)} {closure}: "
+        f"a2={final['shape_amplitude_fit']:.8f}, "
+        f"theory={final['shape_amplitude_theory']:.8f}, "
+        f"|err|={final['shape_amplitude_abs_error']:.3e}, "
+        f"local={final['local_volume_rel_max_abs']:.3e}, "
+        f"changed_tets={final['display_changed_tets']:.0f}, "
+        f"CPU={final['cpu_time_s']:.2f}s"
+    )
+    print(f"rows: {json_path}")
+    print(f"snapshots: {npz_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cases_dynamic/oscillating_droplet_p_ref/scripts/sphere_fheron_eos_projection_benchmark.py
+++ b/cases_dynamic/oscillating_droplet_p_ref/scripts/sphere_fheron_eos_projection_benchmark.py
@@ -1,0 +1,2460 @@
+"""Minimal HC benchmark for Heron surface force vs pressure closures.
+
+The case is deliberately static and small:
+
+* build closed spherical surface meshes as ``hyperct.Complex`` objects,
+* compute the ddgclib Heron curvature force ``F_Heron = -gamma HN dA``,
+* compare it with the analytical Young-Laplace pressure
+  ``Delta p = 2 gamma / R``,
+* compare two pressure closures against the same force balance:
+  a weak-compressible linear EOS scalar and an incompressible projection
+  scalar.
+
+This is not a full acoustic or moving-interface run.  It isolates the part
+discussed in the meeting: whether the pressure closure balances the HC/Heron
+surface force, and how much time is spent in the Heron kernel versus the
+pressure closure.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import os
+from pathlib import Path
+import sys
+import time
+
+import numpy as np
+
+sys.dont_write_bytecode = True
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = next(
+    candidate
+    for candidate in (SCRIPT_DIR, *SCRIPT_DIR.parents)
+    if (candidate / "ddgclib").is_dir()
+)
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+os.environ.setdefault("MPLCONFIGDIR", str(SCRIPT_DIR / ".mplconfig"))
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from matplotlib.animation import FuncAnimation, PillowWriter
+from matplotlib.ticker import ScalarFormatter
+from mpl_toolkits.mplot3d.art3d import Line3DCollection, Poly3DCollection
+from scipy.spatial import Delaunay
+
+from hyperct import Complex
+from ddgclib._curvatures_heron import hndA_i
+
+
+BASE_ICOSAHEDRON_VERTICES = np.asarray(
+    [
+        (-1.0, (1.0 + math.sqrt(5.0)) / 2.0, 0.0),
+        (1.0, (1.0 + math.sqrt(5.0)) / 2.0, 0.0),
+        (-1.0, -(1.0 + math.sqrt(5.0)) / 2.0, 0.0),
+        (1.0, -(1.0 + math.sqrt(5.0)) / 2.0, 0.0),
+        (0.0, -1.0, (1.0 + math.sqrt(5.0)) / 2.0),
+        (0.0, 1.0, (1.0 + math.sqrt(5.0)) / 2.0),
+        (0.0, -1.0, -(1.0 + math.sqrt(5.0)) / 2.0),
+        (0.0, 1.0, -(1.0 + math.sqrt(5.0)) / 2.0),
+        ((1.0 + math.sqrt(5.0)) / 2.0, 0.0, -1.0),
+        ((1.0 + math.sqrt(5.0)) / 2.0, 0.0, 1.0),
+        (-(1.0 + math.sqrt(5.0)) / 2.0, 0.0, -1.0),
+        (-(1.0 + math.sqrt(5.0)) / 2.0, 0.0, 1.0),
+    ],
+    dtype=float,
+)
+
+BASE_ICOSAHEDRON_FACES = np.asarray(
+    [
+        (0, 11, 5),
+        (0, 5, 1),
+        (0, 1, 7),
+        (0, 7, 10),
+        (0, 10, 11),
+        (1, 5, 9),
+        (5, 11, 4),
+        (11, 10, 2),
+        (10, 7, 6),
+        (7, 1, 8),
+        (3, 9, 4),
+        (3, 4, 2),
+        (3, 2, 6),
+        (3, 6, 8),
+        (3, 8, 9),
+        (4, 9, 5),
+        (2, 4, 11),
+        (6, 2, 10),
+        (8, 6, 7),
+        (9, 8, 1),
+    ],
+    dtype=int,
+)
+
+
+def _normalize_to_radius(points: np.ndarray, radius: float) -> np.ndarray:
+    norms = np.linalg.norm(points, axis=1)
+    if np.any(norms <= 0.0):
+        raise ValueError("Cannot normalize a zero-length icosphere point")
+    return radius * points / norms[:, None]
+
+
+def icosphere(subdivisions: int, radius: float) -> tuple[np.ndarray, np.ndarray]:
+    """Return vertices and triangular faces for a radius-R icosphere."""
+    vertices = _normalize_to_radius(BASE_ICOSAHEDRON_VERTICES.copy(), radius)
+    faces = BASE_ICOSAHEDRON_FACES.copy()
+
+    for _ in range(int(subdivisions)):
+        midpoint_cache: dict[tuple[int, int], int] = {}
+        vertex_list = [vertices[i].copy() for i in range(vertices.shape[0])]
+        new_faces = []
+
+        def midpoint_index(i: int, j: int) -> int:
+            key = (min(i, j), max(i, j))
+            cached = midpoint_cache.get(key)
+            if cached is not None:
+                return cached
+            midpoint = 0.5 * (vertices[i] + vertices[j])
+            midpoint = radius * midpoint / np.linalg.norm(midpoint)
+            vertex_list.append(midpoint)
+            idx = len(vertex_list) - 1
+            midpoint_cache[key] = idx
+            return idx
+
+        for a, b, c in faces:
+            ab = midpoint_index(int(a), int(b))
+            bc = midpoint_index(int(b), int(c))
+            ca = midpoint_index(int(c), int(a))
+            new_faces.extend(
+                [
+                    (int(a), ab, ca),
+                    (int(b), bc, ab),
+                    (int(c), ca, bc),
+                    (ab, bc, ca),
+                ]
+            )
+
+        vertices = np.asarray(vertex_list, dtype=float)
+        faces = np.asarray(new_faces, dtype=int)
+
+    return vertices, faces
+
+
+def build_surface_hc(points: np.ndarray, faces: np.ndarray) -> tuple[Complex, list]:
+    """Build an HC surface graph from triangle connectivity."""
+    HC = Complex(3, domain=None)
+    vertices = [HC.V[tuple(float(x) for x in point)] for point in points]
+
+    for a, b, c in faces:
+        va, vb, vc = vertices[int(a)], vertices[int(b)], vertices[int(c)]
+        va.connect(vb)
+        vb.connect(vc)
+        vc.connect(va)
+
+    for vertex in vertices:
+        vertex.u = np.zeros(3, dtype=float)
+        vertex.p = 0.0
+        vertex.m = 1.0
+        vertex.phase = 0
+        vertex.boundary = False
+        vertex.is_interface = True
+
+    return HC, vertices
+
+
+def heron_force_area(vertices: list, gamma: float) -> tuple[np.ndarray, np.ndarray]:
+    """Compute ddgclib Heron force and Heron dual area in one kernel pass."""
+    forces = np.zeros((len(vertices), 3), dtype=float)
+    areas = np.zeros(len(vertices), dtype=float)
+    for i, vertex in enumerate(vertices):
+        hnda_i, area_i = hndA_i(vertex)
+        forces[i] = -float(gamma) * hnda_i[:3]
+        areas[i] = float(area_i)
+    return forces, areas
+
+
+def linear_eos_pressure(volume: float, reference_volume: float, bulk_modulus: float) -> float:
+    """Weak-compressible pressure, positive for compressed volume."""
+    return float(bulk_modulus) * (float(reference_volume) / float(volume) - 1.0)
+
+
+def projection_pressure(forces: np.ndarray, pressure_area_vectors: np.ndarray) -> float:
+    """One-scalar incompressibility projection for the static sphere balance."""
+    denom = float(np.sum(pressure_area_vectors * pressure_area_vectors))
+    if denom <= 0.0:
+        return 0.0
+    return -float(np.sum(pressure_area_vectors * forces)) / denom
+
+
+def residual_metrics(forces: np.ndarray, pressure_area_vectors: np.ndarray, pressure: float) -> dict[str, float]:
+    residual = forces + float(pressure) * pressure_area_vectors
+    force_norm = np.linalg.norm(forces, axis=1)
+    residual_norm = np.linalg.norm(residual, axis=1)
+    rms_force = math.sqrt(float(np.mean(force_norm * force_norm)))
+    rms_residual = math.sqrt(float(np.mean(residual_norm * residual_norm)))
+    rel_rms = rms_residual / max(rms_force, 1.0e-300)
+    max_rel = float(np.max(residual_norm) / max(float(np.max(force_norm)), 1.0e-300))
+    return {
+        "residual_rms_n": rms_residual,
+        "residual_rel_rms": rel_rms,
+        "residual_rel_max": max_rel,
+    }
+
+
+def time_repeated(count: int, callback):
+    """Return ``(last_result, seconds_per_call)`` for a repeated callback."""
+    start = time.perf_counter()
+    result = None
+    for _ in range(max(1, int(count))):
+        result = callback()
+    elapsed = time.perf_counter() - start
+    return result, elapsed / max(1, int(count))
+
+
+def run_one(
+    subdivisions: int,
+    radius: float,
+    gamma: float,
+    bulk_modulus: float,
+    fheron_repeats: int,
+    closure_repeats: int,
+) -> dict[str, float]:
+    build_start = time.perf_counter()
+    points, faces = icosphere(subdivisions, radius)
+    _HC, vertices = build_surface_hc(points, faces)
+    build_s = time.perf_counter() - build_start
+
+    (forces, areas), fheron_s = time_repeated(
+        fheron_repeats,
+        lambda: heron_force_area(vertices, gamma),
+    )
+
+    normals = points / np.linalg.norm(points, axis=1)[:, None]
+    pressure_area_vectors = areas[:, None] * normals
+    theory_pressure = 2.0 * float(gamma) / float(radius)
+    theory_forces = -theory_pressure * pressure_area_vectors
+    heron_error = forces - theory_forces
+    heron_rms = math.sqrt(float(np.mean(np.sum(heron_error * heron_error, axis=1))))
+    theory_rms = math.sqrt(float(np.mean(np.sum(theory_forces * theory_forces, axis=1))))
+
+    reference_volume = 4.0 * math.pi * float(radius) ** 3 / 3.0
+    compressed_volume = reference_volume / (1.0 + theory_pressure / float(bulk_modulus))
+    eos_pressure, eos_s = time_repeated(
+        closure_repeats,
+        lambda: linear_eos_pressure(compressed_volume, reference_volume, bulk_modulus),
+    )
+    proj_pressure, projection_s = time_repeated(
+        closure_repeats,
+        lambda: projection_pressure(forces, pressure_area_vectors),
+    )
+
+    theory_residual = residual_metrics(forces, pressure_area_vectors, theory_pressure)
+    eos_residual = residual_metrics(forces, pressure_area_vectors, eos_pressure)
+    projection_residual = residual_metrics(forces, pressure_area_vectors, proj_pressure)
+
+    edges = {
+        tuple(sorted((int(i), int(j))))
+        for tri in faces
+        for i, j in ((tri[0], tri[1]), (tri[1], tri[2]), (tri[2], tri[0]))
+    }
+    mean_edge = float(np.mean([np.linalg.norm(points[i] - points[j]) for i, j in edges]))
+    net_force = np.sum(forces, axis=0)
+
+    return {
+        "subdivisions": int(subdivisions),
+        "vertices": int(len(vertices)),
+        "faces": int(len(faces)),
+        "mean_edge_m": mean_edge,
+        "build_ms": 1.0e3 * build_s,
+        "fheron_ms": 1.0e3 * fheron_s,
+        "eos_us": 1.0e6 * eos_s,
+        "projection_us": 1.0e6 * projection_s,
+        "theory_pressure_pa": theory_pressure,
+        "eos_pressure_pa": float(eos_pressure),
+        "projection_pressure_pa": float(proj_pressure),
+        "eos_volume_strain": (reference_volume - compressed_volume) / reference_volume,
+        "heron_vs_theory_rel_rms": heron_rms / max(theory_rms, 1.0e-300),
+        "theory_residual_rel_rms": theory_residual["residual_rel_rms"],
+        "eos_residual_rel_rms": eos_residual["residual_rel_rms"],
+        "projection_residual_rel_rms": projection_residual["residual_rel_rms"],
+        "projection_residual_rel_max": projection_residual["residual_rel_max"],
+        "net_fheron_force_n": float(np.linalg.norm(net_force)),
+    }
+
+
+def sphere_volume(radius: float) -> float:
+    return 4.0 * math.pi * float(radius) ** 3 / 3.0
+
+
+def radius_from_volume(volume: float) -> float:
+    return (3.0 * float(volume) / (4.0 * math.pi)) ** (1.0 / 3.0)
+
+
+def mesh_volume(points: np.ndarray, faces: np.ndarray) -> float:
+    tetra_volumes = [
+        abs(float(np.dot(points[int(a)], np.cross(points[int(b)], points[int(c)])))) / 6.0
+        for a, b, c in faces
+    ]
+    return float(np.sum(tetra_volumes))
+
+
+def shape_amplitude_from_aspect_ratio(aspect_ratio: float) -> float:
+    """Return l=2 mode amplitude giving polar/equatorial AR."""
+    ar = float(aspect_ratio)
+    if ar <= 1.0:
+        raise ValueError("aspect_ratio must be greater than 1")
+    return (ar - 1.0) / (1.0 + 0.5 * ar)
+
+
+def rayleigh_lamb_frequency(l_mode: int, gamma: float, rho: float, radius: float) -> tuple[float, float, float]:
+    """Return angular frequency, frequency, and period for Rayleigh-Lamb mode l."""
+    l_val = int(l_mode)
+    if l_val < 2:
+        raise ValueError("Rayleigh-Lamb shape modes require l >= 2")
+    omega = math.sqrt(l_val * (l_val - 1) * (l_val + 2) * float(gamma) / (float(rho) * float(radius) ** 3))
+    frequency = omega / (2.0 * math.pi)
+    period = 1.0 / frequency
+    return omega, frequency, period
+
+
+def volumetric_star_tet_segments(points: np.ndarray, faces: np.ndarray, *, max_segments: int = 420) -> np.ndarray:
+    """Wireframe segments for the center-to-surface tetrahedral star mesh."""
+    center = np.mean(points, axis=0)
+    edge_keys = {
+        tuple(sorted((int(i), int(j))))
+        for tri in faces
+        for i, j in ((tri[0], tri[1]), (tri[1], tri[2]), (tri[2], tri[0]))
+    }
+    surface_edges = [(points[i], points[j]) for i, j in sorted(edge_keys)]
+    radial_step = max(1, int(math.ceil(points.shape[0] / max(1, max_segments // 3))))
+    radial_edges = [(center, points[i]) for i in range(0, points.shape[0], radial_step)]
+    segments = np.asarray(surface_edges + radial_edges, dtype=float)
+    if segments.shape[0] > max_segments:
+        keep = np.linspace(0, segments.shape[0] - 1, max_segments, dtype=int)
+        segments = segments[keep]
+    return segments
+
+
+def tet_edge_indices(tets: np.ndarray, *, max_edges: int = 360) -> np.ndarray:
+    """Representative unique edge index pairs from a tetrahedral volume mesh."""
+    edge_keys: set[tuple[int, int]] = set()
+    for tet in np.asarray(tets, dtype=int):
+        a, b, c, d = [int(index) for index in tet]
+        edge_keys.update(
+            tuple(sorted(edge))
+            for edge in ((a, b), (a, c), (a, d), (b, c), (b, d), (c, d))
+        )
+    edges = sorted(edge_keys)
+    if len(edges) > max_edges:
+        keep = np.linspace(0, len(edges) - 1, max_edges, dtype=int)
+        edges = [edges[int(index)] for index in keep]
+    return np.asarray(edges, dtype=int).reshape((-1, 2))
+
+
+def tet_edge_segments(points: np.ndarray, tets: np.ndarray, *, max_segments: int = 360) -> np.ndarray:
+    """Representative unique edge segments from a tetrahedral volume mesh."""
+    edges = tet_edge_indices(tets, max_edges=max_segments)
+    if edges.size == 0:
+        return np.empty((0, 2, 3), dtype=float)
+    return np.asarray(points[edges], dtype=float)
+
+
+def fheron_pressure_for_radius(subdivisions: int, radius: float, gamma: float) -> tuple[float, float]:
+    points, faces = icosphere(subdivisions, radius)
+    _HC, vertices = build_surface_hc(points, faces)
+    forces, areas = heron_force_area(vertices, gamma)
+    normals = points / np.linalg.norm(points, axis=1)[:, None]
+    pressure_area_vectors = areas[:, None] * normals
+    return projection_pressure(forces, pressure_area_vectors), mesh_volume(points, faces)
+
+
+def vertex_area_vectors(points: np.ndarray, faces: np.ndarray) -> np.ndarray:
+    area_vectors = np.zeros_like(points, dtype=float)
+    for a, b, c in faces:
+        a_i, b_i, c_i = int(a), int(b), int(c)
+        pa, pb, pc = points[a_i], points[b_i], points[c_i]
+        area_vec = 0.5 * np.cross(pb - pa, pc - pa)
+        centroid = (pa + pb + pc) / 3.0
+        if float(np.dot(area_vec, centroid)) < 0.0:
+            area_vec = -area_vec
+        share = area_vec / 3.0
+        area_vectors[a_i] += share
+        area_vectors[b_i] += share
+        area_vectors[c_i] += share
+    return area_vectors
+
+
+def vertex_scalar_areas(points: np.ndarray, faces: np.ndarray) -> np.ndarray:
+    areas = np.zeros(points.shape[0], dtype=float)
+    for a, b, c in faces:
+        a_i, b_i, c_i = int(a), int(b), int(c)
+        tri_area = 0.5 * float(np.linalg.norm(np.cross(points[b_i] - points[a_i], points[c_i] - points[a_i])))
+        share = tri_area / 3.0
+        areas[a_i] += share
+        areas[b_i] += share
+        areas[c_i] += share
+    return areas
+
+
+def vertex_star_tet_masses(points: np.ndarray, faces: np.ndarray, rho: float) -> np.ndarray:
+    """Lump closed star-tet volume mass to surface vertices."""
+    masses = np.zeros(points.shape[0], dtype=float)
+    center = np.mean(points, axis=0)
+    shifted = points - center[None, :]
+    for a, b, c in faces:
+        a_i, b_i, c_i = int(a), int(b), int(c)
+        tet_volume = abs(float(np.dot(shifted[a_i], np.cross(shifted[b_i], shifted[c_i])))) / 6.0
+        share = float(rho) * tet_volume / 3.0
+        masses[a_i] += share
+        masses[b_i] += share
+        masses[c_i] += share
+    return masses
+
+
+def fheron_pressure_for_points(points: np.ndarray, faces: np.ndarray, gamma: float) -> tuple[float, float]:
+    _HC, vertices = build_surface_hc(points, faces)
+    forces, _areas = heron_force_area(vertices, gamma)
+    return projection_pressure(forces, vertex_area_vectors(points, faces)), mesh_volume(points, faces)
+
+
+def fheron_forces_for_points(points: np.ndarray, faces: np.ndarray, gamma: float) -> tuple[np.ndarray, np.ndarray, float, float]:
+    _HC, vertices = build_surface_hc(points, faces)
+    forces, _areas = heron_force_area(vertices, gamma)
+    area_vectors = vertex_area_vectors(points, faces)
+    pressure_equivalent = projection_pressure(forces, area_vectors)
+    return forces, area_vectors, pressure_equivalent, mesh_volume(points, faces)
+
+
+def local_tet_volume_gradients(points: np.ndarray, faces: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Return star-tet volumes and dV_tet/dx_i for each surface face."""
+    volumes = np.zeros(faces.shape[0], dtype=float)
+    gradients = np.zeros((faces.shape[0], 3, 3), dtype=float)
+    for tet_idx, (a, b, c) in enumerate(faces):
+        a_i, b_i, c_i = int(a), int(b), int(c)
+        pa, pb, pc = points[a_i], points[b_i], points[c_i]
+        triple = float(np.dot(pa, np.cross(pb, pc)))
+        sign = 1.0 if triple >= 0.0 else -1.0
+        volumes[tet_idx] = abs(triple) / 6.0
+        gradients[tet_idx, 0] = sign * np.cross(pb, pc) / 6.0
+        gradients[tet_idx, 1] = sign * np.cross(pc, pa) / 6.0
+        gradients[tet_idx, 2] = sign * np.cross(pa, pb) / 6.0
+    return volumes, gradients
+
+
+def local_volume_matrix(points: np.ndarray, faces: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    volumes, gradients = local_tet_volume_gradients(points, faces)
+    matrix = np.zeros((faces.shape[0], points.shape[0] * 3), dtype=float)
+    for tet_idx, face in enumerate(faces):
+        for local_idx, vertex_idx in enumerate(face):
+            start = 3 * int(vertex_idx)
+            matrix[tet_idx, start:start + 3] += gradients[tet_idx, local_idx]
+    return volumes, matrix
+
+
+def local_pressure_forces(points: np.ndarray, faces: np.ndarray, pressures: np.ndarray) -> np.ndarray:
+    _volumes, matrix = local_volume_matrix(points, faces)
+    return np.asarray(matrix.T @ np.asarray(pressures, dtype=float), dtype=float).reshape(points.shape)
+
+
+def _solve_regularized(system: np.ndarray, rhs: np.ndarray) -> np.ndarray:
+    scale = max(float(np.mean(np.abs(np.diag(system)))) if system.size else 0.0, 1.0e-30)
+    regularized = system + (1.0e-12 * scale) * np.eye(system.shape[0])
+    try:
+        return np.linalg.solve(regularized, rhs)
+    except np.linalg.LinAlgError:
+        return np.linalg.lstsq(regularized, rhs, rcond=1.0e-12)[0]
+
+
+def _mass_inverse_dof(masses: np.ndarray) -> np.ndarray:
+    return np.repeat(1.0 / np.maximum(masses, 1.0e-300), 3)
+
+
+def _local_volume_stiffness(matrix: np.ndarray, masses: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    inv_mass_dof = _mass_inverse_dof(masses)
+    stiffness = (matrix * inv_mass_dof[None, :]) @ matrix.T
+    return stiffness, inv_mass_dof
+
+
+def build_ball_tet_mesh(
+    subdivisions: int,
+    radius: float,
+    *,
+    shell_radii: tuple[float, ...] = (0.45, 0.75),
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Connected tetrahedral ball mesh with active interior and surface vertices."""
+    unit_points, surface_faces = icosphere(subdivisions, 1.0)
+    points = [np.zeros((1, 3), dtype=float)]
+    for shell_radius in (*shell_radii, 1.0):
+        points.append(unit_points * (float(shell_radius) * float(radius)))
+    volume_points = np.vstack(points)
+    n_surface = unit_points.shape[0]
+    surface_offset = 1 + len(shell_radii) * n_surface
+    surface_indices = np.arange(surface_offset, surface_offset + n_surface, dtype=int)
+    surface_faces_global = surface_faces + surface_offset
+
+    triangulation = Delaunay(volume_points, qhull_options="Qbb Qc")
+    raw_tets = np.asarray(triangulation.simplices, dtype=int)
+    valid = np.all(raw_tets < volume_points.shape[0], axis=1)
+    raw_tets = raw_tets[valid]
+    volumes = tet_cell_volumes(volume_points, raw_tets)
+    positive = volumes[volumes > 0.0]
+    min_volume = 0.1 * float(np.median(positive)) if positive.size else 0.0
+    tets = raw_tets[volumes > min_volume]
+    return volume_points, tets, surface_indices, surface_faces, surface_faces_global, unit_points
+
+
+def tet_cell_volumes(points: np.ndarray, tets: np.ndarray) -> np.ndarray:
+    p0 = points[tets[:, 0]]
+    p1 = points[tets[:, 1]]
+    p2 = points[tets[:, 2]]
+    p3 = points[tets[:, 3]]
+    triple = np.einsum("ij,ij->i", p1 - p0, np.cross(p2 - p0, p3 - p0))
+    return np.abs(triple) / 6.0
+
+
+def tet_volume_matrix(points: np.ndarray, tets: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    volumes = np.zeros(tets.shape[0], dtype=float)
+    matrix = np.zeros((tets.shape[0], points.shape[0] * 3), dtype=float)
+    for tet_idx, tet in enumerate(tets):
+        i0, i1, i2, i3 = [int(i) for i in tet]
+        p0, p1, p2, p3 = points[i0], points[i1], points[i2], points[i3]
+        triple = float(np.dot(p1 - p0, np.cross(p2 - p0, p3 - p0)))
+        sign = 1.0 if triple >= 0.0 else -1.0
+        volumes[tet_idx] = abs(triple) / 6.0
+        g1 = sign * np.cross(p2 - p0, p3 - p0) / 6.0
+        g2 = sign * np.cross(p3 - p0, p1 - p0) / 6.0
+        g3 = sign * np.cross(p1 - p0, p2 - p0) / 6.0
+        g0 = -(g1 + g2 + g3)
+        for vertex_idx, gradient in ((i0, g0), (i1, g1), (i2, g2), (i3, g3)):
+            start = 3 * vertex_idx
+            matrix[tet_idx, start:start + 3] += gradient
+    return volumes, matrix
+
+
+def tet_pressure_forces(points: np.ndarray, tets: np.ndarray, pressures: np.ndarray) -> np.ndarray:
+    _volumes, matrix = tet_volume_matrix(points, tets)
+    return np.asarray(matrix.T @ np.asarray(pressures, dtype=float), dtype=float).reshape(points.shape)
+
+
+def lump_tet_masses(n_vertices: int, tets: np.ndarray, volumes: np.ndarray, rho: float) -> np.ndarray:
+    masses = np.zeros(n_vertices, dtype=float)
+    for tet, volume in zip(tets, volumes):
+        share = float(rho) * float(volume) / 4.0
+        for vertex_idx in tet:
+            masses[int(vertex_idx)] += share
+    return np.maximum(masses, 1.0e-18)
+
+
+def deform_l2_volume_points(
+    points: np.ndarray,
+    tets: np.ndarray,
+    *,
+    radius: float,
+    amplitude: float,
+    target_volume: float,
+) -> np.ndarray:
+    deformed = points.copy()
+    radii = np.linalg.norm(points, axis=1)
+    moving = radii > 1.0e-30
+    dirs = np.zeros_like(points)
+    dirs[moving] = points[moving] / radii[moving, None]
+    mu = dirs[:, 2]
+    p2 = 0.5 * (3.0 * mu * mu - 1.0)
+    scale = 1.0 + float(amplitude) * p2
+    if np.any(scale[moving] <= 0.0):
+        raise ValueError("shape-mode amplitude creates non-positive radius")
+    deformed[moving] = dirs[moving] * (radii[moving] * scale[moving])[:, None]
+    current_volume = float(np.sum(tet_cell_volumes(deformed, tets)))
+    if current_volume > 0.0:
+        deformed *= (float(target_volume) / current_volume) ** (1.0 / 3.0)
+    return deformed
+
+
+def projected_l2_shape_points(
+    unit_points: np.ndarray,
+    faces: np.ndarray,
+    *,
+    radius: float,
+    amplitude: float,
+    target_volume: float,
+) -> tuple[np.ndarray, float]:
+    mu = unit_points[:, 2]
+    p2 = 0.5 * (3.0 * mu * mu - 1.0)
+    raw_radius = float(radius) * (1.0 + float(amplitude) * p2)
+    if np.any(raw_radius <= 0.0):
+        raise ValueError("shape-mode amplitude creates non-positive radius")
+    points = unit_points * raw_radius[:, None]
+    current_volume = mesh_volume(points, faces)
+    scale = (float(target_volume) / max(current_volume, 1.0e-300)) ** (1.0 / 3.0)
+    points *= scale
+    return points, mesh_volume(points, faces)
+
+
+def compressible_l2_shape_points(
+    unit_points: np.ndarray,
+    faces: np.ndarray,
+    *,
+    radius: float,
+    amplitude: float,
+    target_shape_volume: float,
+    isotropic_radius_scale: float,
+) -> tuple[np.ndarray, float]:
+    """Shape-mode points with EOS isotropic volume scale.
+
+    The l=2 shape itself is first projected to preserve the reference shape
+    volume.  The compressible EOS response is then applied as a uniform scale.
+    This keeps the requested aspect ratio independent from the EOS breathing.
+    """
+    points, _shape_volume = projected_l2_shape_points(
+        unit_points,
+        faces,
+        radius=radius,
+        amplitude=amplitude,
+        target_volume=target_shape_volume,
+    )
+    points *= float(isotropic_radius_scale)
+    return points, mesh_volume(points, faces)
+
+
+def eos_radius_scale_from_pressure(pressure: float, bulk_modulus: float) -> float:
+    """Linear EOS radius scale for fixed mass under a scalar pressure."""
+    volume_denominator = 1.0 + float(pressure) / float(bulk_modulus)
+    if volume_denominator <= 0.0:
+        raise ValueError("EOS pressure would create non-positive volume")
+    return float(volume_denominator ** (-1.0 / 3.0))
+
+
+def fit_l2_shape_amplitude(points: np.ndarray, faces: np.ndarray) -> float:
+    """Fit the l=2 P2(cos theta) amplitude from a generated surface mesh."""
+    radii = np.linalg.norm(points, axis=1)
+    valid = radii > 1.0e-30
+    if not np.any(valid):
+        return 0.0
+    dirs = points[valid] / radii[valid, None]
+    mu = dirs[:, 2]
+    p2 = 0.5 * (3.0 * mu * mu - 1.0)
+    equivalent_radius = radius_from_volume(mesh_volume(points, faces))
+    y = radii[valid] / max(equivalent_radius, 1.0e-300) - 1.0
+    design = np.column_stack([np.ones_like(p2), p2])
+    _offset, amplitude = np.linalg.lstsq(design, y, rcond=None)[0]
+    return float(amplitude)
+
+
+def run_timeseries(
+    *,
+    subdivisions: int,
+    radius: float,
+    gamma: float,
+    bulk_modulus: float,
+    pressure_drive_fraction: float,
+    n_steps: int,
+    t_final: float,
+) -> list[dict[str, float]]:
+    """Two-path sphere run: weak-compressible EOS vs incompressible projection.
+
+    The physical default uses only the capillary pressure p = 2 gamma / R as
+    the EOS pressure.  ``pressure_drive_fraction`` is retained as an optional
+    diagnostic perturbation, but its default is zero.
+    """
+    if n_steps < 2:
+        raise ValueError("n_steps must be at least 2")
+    if not 0.0 <= pressure_drive_fraction < 0.95:
+        raise ValueError("pressure_drive_fraction must be in [0, 0.95)")
+
+    volume0 = sphere_volume(radius)
+    points0, faces0 = icosphere(subdivisions, radius)
+    mesh_volume0 = mesh_volume(points0, faces0)
+    pressure0 = 2.0 * float(gamma) / float(radius)
+    times = np.linspace(0.0, float(t_final), int(n_steps))
+    rows = []
+
+    for t in times:
+        phase = math.sin(2.0 * math.pi * float(t) / float(t_final))
+        extra_pressure_drive = float(pressure_drive_fraction) * float(bulk_modulus) * phase
+        radius_com = float(radius)
+        capillary_pressure = pressure0
+        eos_pressure = pressure0 + extra_pressure_drive
+        for _iteration in range(16):
+            capillary_pressure = 2.0 * float(gamma) / radius_com
+            eos_pressure = capillary_pressure + extra_pressure_drive
+            next_radius = float(radius) * eos_radius_scale_from_pressure(eos_pressure, bulk_modulus)
+            if abs(next_radius - radius_com) <= 1.0e-14 * float(radius):
+                radius_com = next_radius
+                break
+            radius_com = next_radius
+        capillary_pressure = 2.0 * float(gamma) / radius_com
+        eos_pressure = capillary_pressure + extra_pressure_drive
+        volume_com = volume0 * (radius_com / float(radius)) ** 3
+        radius_incom = float(radius)
+
+        fheron_com, mesh_volume_com = fheron_pressure_for_radius(subdivisions, radius_com, gamma)
+        fheron_incom, mesh_volume_incom = fheron_pressure_for_radius(subdivisions, radius_incom, gamma)
+        fheron_analytical_com = 2.0 * float(gamma) / radius_com
+        fheron_analytical_incom = 2.0 * float(gamma) / float(radius)
+        volume_analytical_com = mesh_volume0 * (radius_com / float(radius)) ** 3
+        volume_analytical_incom = mesh_volume0
+
+        rows.append(
+            {
+                "t": float(t),
+                "capillary_pressure_pa": float(capillary_pressure),
+                "extra_pressure_drive_pa": float(extra_pressure_drive),
+                "eos_pressure_pa": float(eos_pressure),
+                "pressure_drive_pa": float(extra_pressure_drive),
+                "radius_com_m": float(radius_com),
+                "radius_incom_m": float(radius_incom),
+                "fheron_com_pa": float(fheron_com),
+                "fheron_incom_pa": float(fheron_incom),
+                "fheron_analytical_pa": float(fheron_analytical_com),
+                "fheron_analytical_com_pa": float(fheron_analytical_com),
+                "fheron_analytical_incom_pa": float(fheron_analytical_incom),
+                "vol_com_m3": float(mesh_volume_com),
+                "vol_incom_m3": float(mesh_volume_incom),
+                "vol_analytical_m3": float(volume_analytical_com),
+                "vol_analytical_com_m3": float(volume_analytical_com),
+                "vol_analytical_incom_m3": float(volume_analytical_incom),
+                "vol_com_exact_m3": float(volume_com),
+                "vol0_m3": float(volume0),
+                "vol0_mesh_m3": float(mesh_volume0),
+            }
+        )
+
+    return rows
+
+
+def run_compressible_shape_timeseries(
+    *,
+    subdivisions: int,
+    radius: float,
+    gamma: float,
+    bulk_modulus: float,
+    pressure_drive_fraction: float,
+    amplitude: float,
+    n_steps: int,
+    t_final: float,
+    rayleigh_frequency_hz: float,
+    rayleigh_omega_rad_s: float,
+) -> list[dict[str, float]]:
+    """Compressible shape-mode run with EOS volume from the FHeron pressure."""
+    if n_steps < 2:
+        raise ValueError("n_steps must be at least 2")
+    if not 0.0 <= pressure_drive_fraction < 0.95:
+        raise ValueError("pressure_drive_fraction must be in [0, 0.95)")
+
+    unit_points, faces = icosphere(subdivisions, 1.0)
+    reference_points = unit_points * float(radius)
+    mesh_volume0 = mesh_volume(reference_points, faces)
+    times = np.linspace(0.0, float(t_final), int(n_steps))
+    rows = []
+
+    for t in times:
+        phase = math.sin(2.0 * math.pi * float(t) / float(t_final))
+        mode_amplitude = float(amplitude) * math.cos(2.0 * math.pi * float(t) / float(t_final))
+        extra_pressure_drive = float(pressure_drive_fraction) * float(bulk_modulus) * phase
+        isotropic_scale = 1.0
+        fheron_equiv = 0.0
+        eos_pressure = extra_pressure_drive
+
+        for _iteration in range(16):
+            trial_points, _trial_volume = compressible_l2_shape_points(
+                unit_points,
+                faces,
+                radius=radius,
+                amplitude=mode_amplitude,
+                target_shape_volume=mesh_volume0,
+                isotropic_radius_scale=isotropic_scale,
+            )
+            fheron_equiv, _volume_check = fheron_pressure_for_points(trial_points, faces, gamma)
+            eos_pressure = fheron_equiv + extra_pressure_drive
+            next_scale = eos_radius_scale_from_pressure(eos_pressure, bulk_modulus)
+            if abs(next_scale - isotropic_scale) <= 1.0e-14:
+                isotropic_scale = next_scale
+                break
+            isotropic_scale = next_scale
+
+        points, volume = compressible_l2_shape_points(
+            unit_points,
+            faces,
+            radius=radius,
+            amplitude=mode_amplitude,
+            target_shape_volume=mesh_volume0,
+            isotropic_radius_scale=isotropic_scale,
+        )
+        fheron_equiv, _volume_check = fheron_pressure_for_points(points, faces, gamma)
+        eos_pressure = fheron_equiv + extra_pressure_drive
+        eos_scale_target = eos_radius_scale_from_pressure(eos_pressure, bulk_modulus)
+        fitted_amplitude = fit_l2_shape_amplitude(points, faces)
+        radial_ratio = np.linalg.norm(points, axis=1) / float(radius)
+        rows.append(
+            {
+                "t": float(t),
+                "capillary_pressure_pa": float(fheron_equiv),
+                "extra_pressure_drive_pa": float(extra_pressure_drive),
+                "eos_pressure_pa": float(eos_pressure),
+                "pressure_drive_pa": float(extra_pressure_drive),
+                "shape_amplitude": float(mode_amplitude),
+                "shape_amplitude_fit": float(fitted_amplitude),
+                "rayleigh_frequency_hz": float(rayleigh_frequency_hz),
+                "rayleigh_omega_rad_s": float(rayleigh_omega_rad_s),
+                "eos_radius_scale": float(isotropic_scale),
+                "eos_radius_scale_target": float(eos_scale_target),
+                "eos_radius_scale_residual": float(isotropic_scale - eos_scale_target),
+                "fheron_compressible_shape_pa": float(fheron_equiv),
+                "vol_compressible_shape_m3": float(volume),
+                "vol0_mesh_m3": float(mesh_volume0),
+                "radial_ratio_min": float(np.min(radial_ratio)),
+                "radial_ratio_max": float(np.max(radial_ratio)),
+            }
+        )
+
+    return rows
+
+
+def run_local_projection_timeseries(
+    *,
+    subdivisions: int,
+    radius: float,
+    gamma: float,
+    amplitude: float,
+    n_steps: int,
+    t_final: float,
+    rayleigh_frequency_hz: float,
+    rayleigh_omega_rad_s: float,
+) -> list[dict[str, float]]:
+    """Incompressible shape-mode run with finite-amplitude volume projection."""
+    if n_steps < 2:
+        raise ValueError("n_steps must be at least 2")
+    if abs(float(amplitude)) >= 0.8:
+        raise ValueError("shape-mode amplitude is too large for this simple mesh test")
+
+    unit_points, faces = icosphere(subdivisions, 1.0)
+    reference_points = unit_points * float(radius)
+    target_volume = mesh_volume(reference_points, faces)
+    times = np.linspace(0.0, float(t_final), int(n_steps))
+    rows = []
+
+    for t in times:
+        mode_amplitude = float(amplitude) * math.cos(2.0 * math.pi * float(t) / float(t_final))
+        points, volume = projected_l2_shape_points(
+            unit_points,
+            faces,
+            radius=radius,
+            amplitude=mode_amplitude,
+            target_volume=target_volume,
+        )
+        fheron_equiv, _volume_check = fheron_pressure_for_points(points, faces, gamma)
+        fitted_amplitude = fit_l2_shape_amplitude(points, faces)
+        radial_ratio = np.linalg.norm(points, axis=1) / float(radius)
+        rows.append(
+            {
+                "t": float(t),
+                "shape_amplitude": float(mode_amplitude),
+                "shape_amplitude_fit": float(fitted_amplitude),
+                "rayleigh_frequency_hz": float(rayleigh_frequency_hz),
+                "rayleigh_omega_rad_s": float(rayleigh_omega_rad_s),
+                "fheron_local_projection_pa": float(fheron_equiv),
+                "vol_local_projection_m3": float(volume),
+                "vol0_mesh_m3": float(target_volume),
+                "radial_ratio_min": float(np.min(radial_ratio)),
+                "radial_ratio_max": float(np.max(radial_ratio)),
+            }
+        )
+
+    return rows
+
+
+def _remove_rigid_translation(points: np.ndarray, velocities: np.ndarray, masses: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    mass_sum = max(float(np.sum(masses)), 1.0e-300)
+    center = np.sum(points * masses[:, None], axis=0) / mass_sum
+    mean_velocity = np.sum(velocities * masses[:, None], axis=0) / mass_sum
+    return points - center[None, :], velocities - mean_velocity[None, :]
+
+
+def _project_volume_velocity(velocities: np.ndarray, area_vectors: np.ndarray, masses: np.ndarray) -> np.ndarray:
+    inv_masses = 1.0 / np.maximum(masses, 1.0e-300)
+    denom = float(np.sum(np.sum(area_vectors * area_vectors, axis=1) * inv_masses))
+    if denom <= 0.0:
+        return velocities
+    volume_rate = float(np.sum(area_vectors * velocities))
+    correction = (volume_rate / denom) * area_vectors * inv_masses[:, None]
+    return velocities - correction
+
+
+def _project_local_volume_velocity(
+    velocities: np.ndarray,
+    matrix: np.ndarray,
+    masses: np.ndarray,
+    target_rates: np.ndarray,
+) -> np.ndarray:
+    velocity_vec = velocities.reshape(-1)
+    stiffness, inv_mass_dof = _local_volume_stiffness(matrix, masses)
+    rhs = matrix @ velocity_vec - np.asarray(target_rates, dtype=float)
+    multipliers = _solve_regularized(stiffness, rhs)
+    projected_vec = velocity_vec - inv_mass_dof * (matrix.T @ multipliers)
+    return projected_vec.reshape(velocities.shape)
+
+
+def _incompressible_pressure(
+    nonpressure_forces: np.ndarray,
+    area_vectors: np.ndarray,
+    masses: np.ndarray,
+) -> float:
+    inv_masses = 1.0 / np.maximum(masses, 1.0e-300)
+    denom = float(np.sum(np.sum(area_vectors * area_vectors, axis=1) * inv_masses))
+    if denom <= 0.0:
+        return 0.0
+    numer = float(np.sum(np.sum(area_vectors * nonpressure_forces, axis=1) * inv_masses))
+    return -numer / denom
+
+
+def _local_incompressible_pressures(
+    velocities: np.ndarray,
+    nonpressure_forces: np.ndarray,
+    matrix: np.ndarray,
+    masses: np.ndarray,
+    volumes: np.ndarray,
+    reference_volumes: np.ndarray,
+    dt: float,
+) -> np.ndarray:
+    stiffness, inv_mass_dof = _local_volume_stiffness(matrix, masses)
+    target_rates = -(volumes - reference_volumes) / float(dt)
+    velocity_vec = velocities.reshape(-1)
+    force_vec = nonpressure_forces.reshape(-1)
+    rhs = (target_rates - matrix @ velocity_vec) / float(dt) - matrix @ (inv_mass_dof * force_vec)
+    return _solve_regularized(stiffness, rhs)
+
+
+def run_force_dynamic_timeseries(
+    *,
+    closure: str,
+    subdivisions: int,
+    radius: float,
+    gamma: float,
+    rho: float,
+    bulk_modulus: float,
+    amplitude: float,
+    n_steps: int,
+    t_final: float,
+    substeps_per_sample: int,
+    damping_ratio: float,
+    mass_model: str,
+    rayleigh_frequency_hz: float,
+    rayleigh_omega_rad_s: float,
+    rayleigh_mode: int,
+) -> tuple[list[dict[str, float]], np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Force-driven surface run: Ftot updates velocity and vertex positions."""
+    if closure not in {"compressible", "incompressible"}:
+        raise ValueError("closure must be 'compressible' or 'incompressible'")
+    if n_steps < 2:
+        raise ValueError("n_steps must be at least 2")
+    if substeps_per_sample < 1:
+        raise ValueError("substeps_per_sample must be at least 1")
+
+    reference_points, volume_tets, surface_indices, surface_faces, _surface_faces_global, _unit_points = build_ball_tet_mesh(
+        subdivisions,
+        radius,
+    )
+    reference_surface_points = reference_points[surface_indices]
+    target_volume = float(np.sum(tet_cell_volumes(reference_points, volume_tets)))
+    points = deform_l2_volume_points(
+        reference_points,
+        volume_tets,
+        radius=radius,
+        amplitude=amplitude,
+        target_volume=target_volume,
+    )
+    reference_tet_volumes, _reference_volume_matrix = tet_volume_matrix(points, volume_tets)
+    velocities = np.zeros_like(points)
+
+    _reference_forces, _reference_area_vectors, reference_pressure, _ = fheron_forces_for_points(
+        reference_surface_points,
+        surface_faces,
+        gamma,
+    )
+    if mass_model == "star-volume":
+        masses = lump_tet_masses(points.shape[0], volume_tets, reference_tet_volumes, rho)
+        mass_model_label = "bulk-tet lumped mass"
+    elif mass_model == "rayleigh-added":
+        masses = lump_tet_masses(points.shape[0], volume_tets, reference_tet_volumes, rho)
+        reference_scalar_areas = vertex_scalar_areas(reference_surface_points, surface_faces)
+        surface_added_mass = float(rho) * float(radius) / float(rayleigh_mode)
+        masses[surface_indices] += surface_added_mass * reference_scalar_areas
+        mass_model_label = "bulk plus Rayleigh surface mass"
+    else:
+        raise ValueError("mass_model must be 'star-volume' or 'rayleigh-added'")
+    masses = np.maximum(masses, 1.0e-18)
+    points, velocities = _remove_rigid_translation(points, velocities, masses)
+
+    dt = float(t_final) / float((int(n_steps) - 1) * int(substeps_per_sample))
+    damping_rate = 2.0 * float(damping_ratio) * float(rayleigh_omega_rad_s)
+    rows: list[dict[str, float]] = []
+    snapshots: list[np.ndarray] = []
+    cpu_start = time.process_time()
+    wall_start = time.perf_counter()
+
+    def collect(sample_index: int, time_value: float) -> None:
+        substeps_done = int(sample_index) * int(substeps_per_sample)
+        cpu_elapsed = time.process_time() - cpu_start
+        wall_elapsed = time.perf_counter() - wall_start
+        cpu_ms_per_substep = 1.0e3 * cpu_elapsed / float(substeps_done) if substeps_done else 0.0
+        wall_ms_per_substep = 1.0e3 * wall_elapsed / float(substeps_done) if substeps_done else 0.0
+        surface_points = points[surface_indices]
+        surface_forces, _surface_area_vectors, fheron_equiv, _surface_volume = fheron_forces_for_points(
+            surface_points,
+            surface_faces,
+            gamma,
+        )
+        forces = np.zeros_like(points)
+        forces[surface_indices] += surface_forces
+        tet_volumes, local_matrix = tet_volume_matrix(points, volume_tets)
+        volume = float(np.sum(tet_volumes))
+        local_volume_rel = tet_volumes / np.maximum(reference_tet_volumes, 1.0e-300)
+        if closure == "compressible":
+            pressure_values = float(reference_pressure) + float(bulk_modulus) * (
+                np.asarray(reference_tet_volumes, dtype=float) / np.maximum(tet_volumes, 1.0e-300) - 1.0
+            )
+            velocity_projected = 0.0
+        else:
+            damping_forces = -damping_rate * masses[:, None] * velocities
+            pressure_values = _local_incompressible_pressures(
+                velocities,
+                forces + damping_forces,
+                local_matrix,
+                masses,
+                tet_volumes,
+                reference_tet_volumes,
+                dt,
+            )
+            velocity_projected = float(np.linalg.norm(local_matrix @ velocities.reshape(-1)))
+        pressure = float(np.mean(pressure_values))
+        fitted_amplitude = fit_l2_shape_amplitude(surface_points, surface_faces)
+        radial_ratio = np.linalg.norm(surface_points, axis=1) / float(radius)
+        theory_amplitude = float(amplitude) * math.cos(float(rayleigh_omega_rad_s) * float(time_value))
+        rows.append(
+            {
+                "sample": float(sample_index),
+                "t": float(time_value),
+                "closure_pressure_pa": float(pressure),
+                "closure_pressure_min_pa": float(np.min(pressure_values)),
+                "closure_pressure_max_pa": float(np.max(pressure_values)),
+                "reference_pressure_pa": float(reference_pressure),
+                "mass_model": mass_model_label,
+                "total_mass_kg": float(np.sum(masses)),
+                "shape_amplitude_theory": float(theory_amplitude),
+                "shape_amplitude_fit": float(fitted_amplitude),
+                "rayleigh_frequency_hz": float(rayleigh_frequency_hz),
+                "rayleigh_omega_rad_s": float(rayleigh_omega_rad_s),
+                "fheron_pressure_pa": float(fheron_equiv),
+                "vol_m3": float(volume),
+                "vol0_mesh_m3": float(target_volume),
+                "vol_rel": float(volume / target_volume),
+                "local_volume_rel_rms": float(math.sqrt(float(np.mean((local_volume_rel - 1.0) ** 2)))),
+                "local_volume_rel_max_abs": float(np.max(np.abs(local_volume_rel - 1.0))),
+                "vol_rate_m3_s": float(np.sum(local_matrix @ velocities.reshape(-1))),
+                "constraint_volume_rate_m3_s": float(velocity_projected),
+                "kinetic_energy_j": float(0.5 * np.sum(masses * np.sum(velocities * velocities, axis=1))),
+                "max_speed_m_s": float(np.max(np.linalg.norm(velocities, axis=1))),
+                "cpu_time_s": float(cpu_elapsed),
+                "wall_time_s": float(wall_elapsed),
+                "cpu_ms_per_substep": float(cpu_ms_per_substep),
+                "wall_ms_per_substep": float(wall_ms_per_substep),
+                "radial_ratio_min": float(np.min(radial_ratio)),
+                "radial_ratio_max": float(np.max(radial_ratio)),
+            }
+        )
+        snapshots.append(points.copy())
+
+    collect(0, 0.0)
+    sample_index = 1
+    total_substeps = (int(n_steps) - 1) * int(substeps_per_sample)
+    for substep in range(1, total_substeps + 1):
+        surface_points = points[surface_indices]
+        surface_forces, _surface_area_vectors, _fheron_equiv, _surface_volume = fheron_forces_for_points(
+            surface_points,
+            surface_faces,
+            gamma,
+        )
+        forces = np.zeros_like(points)
+        forces[surface_indices] += surface_forces
+        tet_volumes, local_matrix = tet_volume_matrix(points, volume_tets)
+        damping_forces = -damping_rate * masses[:, None] * velocities
+
+        if closure == "compressible":
+            base_pressure = float(reference_pressure)
+            base_pressures = np.full(volume_tets.shape[0], base_pressure, dtype=float)
+            nonpressure_forces = forces + tet_pressure_forces(points, volume_tets, base_pressures) + damping_forces
+            u_star = velocities + dt * nonpressure_forces / masses[:, None]
+            stiffness, inv_mass_dof = _local_volume_stiffness(local_matrix, masses)
+            compressibility = float(bulk_modulus) / np.maximum(reference_tet_volumes, 1.0e-300)
+            linear_volume_error = tet_volumes - reference_tet_volumes + dt * (local_matrix @ u_star.reshape(-1))
+            system = np.eye(volume_tets.shape[0]) + (compressibility[:, None] * dt * dt) * stiffness
+            rhs = -compressibility * linear_volume_error
+            pressure_delta = _solve_regularized(system, rhs)
+            velocities = (u_star.reshape(-1) + dt * inv_mass_dof * (local_matrix.T @ pressure_delta)).reshape(velocities.shape)
+            pressure = float(np.mean(base_pressures + pressure_delta))
+        else:
+            pressure_values = _local_incompressible_pressures(
+                velocities,
+                forces + damping_forces,
+                local_matrix,
+                masses,
+                tet_volumes,
+                reference_tet_volumes,
+                dt,
+            )
+            pressure = float(np.mean(pressure_values))
+            total_forces = forces + tet_pressure_forces(points, volume_tets, pressure_values) + damping_forces
+            accelerations = total_forces / masses[:, None]
+            velocities = velocities + dt * accelerations
+            target_rates = -(tet_volumes - reference_tet_volumes) / float(dt)
+            velocities = _project_local_volume_velocity(velocities, local_matrix, masses, target_rates)
+
+        points = points + dt * velocities
+        points, velocities = _remove_rigid_translation(points, velocities, masses)
+
+        if not np.all(np.isfinite(points)) or not np.all(np.isfinite(velocities)):
+            raise FloatingPointError(f"{closure} dynamic run became non-finite at substep {substep}")
+        if np.min(np.linalg.norm(points[surface_indices], axis=1)) <= 0.15 * float(radius):
+            raise FloatingPointError(f"{closure} dynamic run collapsed at substep {substep}")
+
+        if substep % int(substeps_per_sample) == 0:
+            collect(sample_index, sample_index * float(t_final) / float(int(n_steps) - 1))
+            sample_index += 1
+
+    return rows, np.asarray(snapshots, dtype=float), surface_faces, volume_tets, surface_indices
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Compare HC Heron surface force with EOS and incompressible pressure closures on a sphere."
+    )
+    parser.add_argument("--max-subdivision", type=int, default=3)
+    parser.add_argument("--radius", type=float, default=1.0e-3, help="Sphere radius [m].")
+    parser.add_argument("--gamma", type=float, default=0.072, help="Surface tension [N/m].")
+    parser.add_argument("--bulk-modulus", type=float, default=2.2e9, help="EOS bulk modulus [Pa].")
+    parser.add_argument("--rho", type=float, default=1000.0, help="Liquid density [kg/m^3] for Rayleigh-Lamb frequency.")
+    parser.add_argument("--rayleigh-mode", type=int, default=2, help="Rayleigh-Lamb shape mode used for GIF timing.")
+    parser.add_argument(
+        "--use-rayleigh-frequency",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Use Rayleigh-Lamb period for shape-mode GIFs.",
+    )
+    parser.add_argument("--fheron-repeats", type=int, default=3)
+    parser.add_argument("--closure-repeats", type=int, default=2000)
+    parser.add_argument("--timeseries-subdivision", type=int, default=2)
+    parser.add_argument("--timeseries-steps", type=int, default=121)
+    parser.add_argument(
+        "--dynamic-subdivision",
+        type=int,
+        default=1,
+        help="Icosphere subdivision used for force-driven GIFs.",
+    )
+    parser.add_argument(
+        "--dynamic-substeps-per-sample",
+        type=int,
+        default=80,
+        help="Explicit Ftot integration substeps between saved dynamic samples.",
+    )
+    parser.add_argument(
+        "--dynamic-damping-ratio",
+        type=float,
+        default=0.003,
+        help="Small modal damping ratio used only to control discrete mesh noise in Ftot GIFs.",
+    )
+    parser.add_argument(
+        "--dynamic-mass-model",
+        choices=("star-volume", "rayleigh-added"),
+        default="star-volume",
+        help="Mass used for Ftot integration. star-volume is untuned; rayleigh-added reproduces Rayleigh inertia.",
+    )
+    parser.add_argument(
+        "--timeseries-final-time",
+        type=float,
+        default=None,
+        help="Override final time [s]. Defaults to one Rayleigh-Lamb period when enabled.",
+    )
+    parser.add_argument("--animation-max-frames", type=int, default=80)
+    parser.add_argument("--animation-fps", type=int, default=18)
+    parser.add_argument(
+        "--shape-mode-amplitude",
+        type=float,
+        default=None,
+        help="Finite-amplitude l=2 shape mode. Overrides --shape-mode-ar when set.",
+    )
+    parser.add_argument(
+        "--shape-mode-ar",
+        type=float,
+        default=1.05,
+        help="Maximum aspect ratio for the local incompressible projection GIF.",
+    )
+    parser.add_argument(
+        "--pressure-drive-fraction",
+        type=float,
+        default=0.0,
+        help=(
+            "Optional nonphysical sinusoidal pressure perturbation as a fraction of the EOS bulk modulus. "
+            "Default 0 keeps the compressible case driven only by FHeron/capillary pressure."
+        ),
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=SCRIPT_DIR / "out" / "sphere_fheron_eos_projection",
+    )
+    return parser.parse_args()
+
+
+def write_outputs(rows: list[dict[str, float]], out_dir: Path) -> tuple[Path, Path]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = out_dir / "sphere_fheron_eos_projection_benchmark.csv"
+    json_path = out_dir / "sphere_fheron_eos_projection_benchmark.json"
+    fieldnames = list(rows[0].keys())
+    with csv_path.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+    json_path.write_text(json.dumps(rows, indent=2))
+    return csv_path, json_path
+
+
+def write_timeseries_outputs(rows: list[dict[str, float]], out_dir: Path) -> tuple[Path, Path]:
+    csv_path = out_dir / "sphere_fheron_eos_projection_timeseries.csv"
+    json_path = out_dir / "sphere_fheron_eos_projection_timeseries.json"
+    fieldnames = list(rows[0].keys())
+    with csv_path.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+    json_path.write_text(json.dumps(rows, indent=2))
+    return csv_path, json_path
+
+
+def write_local_projection_outputs(rows: list[dict[str, float]], out_dir: Path) -> tuple[Path, Path]:
+    csv_path = out_dir / "sphere_fheron_incompressible_local_projection_timeseries.csv"
+    json_path = out_dir / "sphere_fheron_incompressible_local_projection_timeseries.json"
+    fieldnames = list(rows[0].keys())
+    with csv_path.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+    json_path.write_text(json.dumps(rows, indent=2))
+    return csv_path, json_path
+
+
+def write_compressible_shape_outputs(rows: list[dict[str, float]], out_dir: Path) -> tuple[Path, Path]:
+    csv_path = out_dir / "sphere_fheron_compressible_shape_timeseries.csv"
+    json_path = out_dir / "sphere_fheron_compressible_shape_timeseries.json"
+    fieldnames = list(rows[0].keys())
+    with csv_path.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+    json_path.write_text(json.dumps(rows, indent=2))
+    return csv_path, json_path
+
+
+def write_named_rows_outputs(rows: list[dict[str, float]], out_dir: Path, stem: str) -> tuple[Path, Path]:
+    csv_path = out_dir / f"{stem}.csv"
+    json_path = out_dir / f"{stem}.json"
+    fieldnames = list(rows[0].keys())
+    with csv_path.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+    json_path.write_text(json.dumps(rows, indent=2))
+    return csv_path, json_path
+
+
+def write_dynamic_snapshots(
+    snapshots: np.ndarray,
+    faces: np.ndarray,
+    out_dir: Path,
+    stem: str,
+    *,
+    tets: np.ndarray | None = None,
+    surface_indices: np.ndarray | None = None,
+) -> Path:
+    path = out_dir / f"{stem}.npz"
+    payload = {"points": snapshots, "faces": faces}
+    if tets is not None:
+        payload["tets"] = tets
+    if surface_indices is not None:
+        payload["surface_indices"] = surface_indices
+    np.savez_compressed(path, **payload)
+    return path
+
+
+def _row_array(rows: list[dict[str, float]], key: str) -> np.ndarray:
+    return np.asarray([float(row[key]) for row in rows], dtype=float)
+
+
+def _finish_plot(fig, path: Path) -> Path:
+    fig.tight_layout()
+    fig.savefig(path, dpi=180)
+    plt.close(fig)
+    return path
+
+
+def write_timing_plot(rows: list[dict[str, float]], out_dir: Path) -> Path:
+    vertices = _row_array(rows, "vertices")
+    fig, ax = plt.subplots(figsize=(7.0, 4.6))
+    ax.loglog(vertices, _row_array(rows, "fheron_ms"), "o-", lw=2.0, label="FHeron kernel")
+    ax.loglog(vertices, 1.0e-3 * _row_array(rows, "eos_us"), "s-", lw=2.0, label="EOS scalar")
+    ax.loglog(vertices, 1.0e-3 * _row_array(rows, "projection_us"), "^-", lw=2.0, label="Incompressible projection scalar")
+    ax.set_xlabel("HC surface vertices")
+    ax.set_ylabel("time per evaluation [ms]")
+    ax.set_title("Compute time: FHeron vs pressure closures")
+    ax.grid(True, which="both", alpha=0.28)
+    ax.legend(frameon=False)
+    return _finish_plot(fig, out_dir / "compute_time_fheron_eos_projection.png")
+
+
+def write_pressure_plot(rows: list[dict[str, float]], out_dir: Path) -> Path:
+    vertices = _row_array(rows, "vertices")
+    theory = _row_array(rows, "theory_pressure_pa")
+    eos = _row_array(rows, "eos_pressure_pa")
+    projection = _row_array(rows, "projection_pressure_pa")
+
+    fig, (ax0, ax1) = plt.subplots(2, 1, figsize=(7.0, 6.2), sharex=True)
+    ax0.semilogx(vertices, theory, "k--", lw=2.0, label="Young-Laplace theory")
+    ax0.semilogx(vertices, eos, "o-", lw=1.9, label="EOS")
+    ax0.semilogx(vertices, projection, "^-", lw=1.9, label="Incompressible projection")
+    ax0.set_ylabel("pressure [Pa]")
+    ax0.set_title("Pressure closures against theory")
+    pressure_formatter = ScalarFormatter(useOffset=False)
+    pressure_formatter.set_scientific(False)
+    ax0.yaxis.set_major_formatter(pressure_formatter)
+    p_ref = float(np.mean(theory))
+    p_pad = max(0.005 * abs(p_ref), 20.0 * float(np.max(np.abs(eos - theory))), 1.0e-9)
+    ax0.set_ylim(p_ref - p_pad, p_ref + p_pad)
+    ax0.grid(True, which="both", alpha=0.28)
+    ax0.legend(frameon=False)
+
+    denom = np.maximum(np.abs(theory), 1.0e-300)
+    ax1.loglog(vertices, np.maximum(np.abs(eos - theory) / denom, 1.0e-18), "o-", lw=1.9, label="EOS pressure error")
+    ax1.loglog(
+        vertices,
+        np.maximum(np.abs(projection - theory) / denom, 1.0e-18),
+        "^-",
+        lw=1.9,
+        label="Projection pressure error",
+    )
+    ax1.set_xlabel("HC surface vertices")
+    ax1.set_ylabel("relative pressure error")
+    ax1.grid(True, which="both", alpha=0.28)
+    ax1.legend(frameon=False)
+    return _finish_plot(fig, out_dir / "pressure_vs_young_laplace_theory.png")
+
+
+def write_residual_plot(rows: list[dict[str, float]], out_dir: Path) -> Path:
+    vertices = _row_array(rows, "vertices")
+    fig, ax = plt.subplots(figsize=(7.0, 4.8))
+    ax.loglog(vertices, np.maximum(_row_array(rows, "heron_vs_theory_rel_rms"), 1.0e-18), "o-", lw=2.0, label="FHeron vs theory force")
+    ax.loglog(vertices, np.maximum(_row_array(rows, "eos_residual_rel_rms"), 1.0e-18), "s-", lw=2.0, label="EOS residual")
+    ax.loglog(
+        vertices,
+        np.maximum(_row_array(rows, "projection_residual_rel_rms"), 1.0e-18),
+        "^-",
+        lw=2.0,
+        label="Projection residual",
+    )
+    ax.set_xlabel("HC surface vertices")
+    ax.set_ylabel("relative RMS")
+    ax.set_title("Force-balance residual: FHeron + pressure area")
+    ax.grid(True, which="both", alpha=0.28)
+    ax.legend(frameon=False)
+    return _finish_plot(fig, out_dir / "fheron_theory_residuals.png")
+
+
+def write_fheron_sphere_plot(
+    out_dir: Path,
+    *,
+    subdivisions: int,
+    radius: float,
+    gamma: float,
+) -> Path:
+    points, faces = icosphere(subdivisions, radius)
+    _HC, vertices = build_surface_hc(points, faces)
+    forces, areas = heron_force_area(vertices, gamma)
+    normals = points / np.linalg.norm(points, axis=1)[:, None]
+
+    sample_step = max(1, int(math.ceil(len(vertices) / 56)))
+    sample = np.arange(0, len(vertices), sample_step)
+    f_norm = np.linalg.norm(forces[sample], axis=1)
+    f_dirs = np.zeros((sample.size, 3), dtype=float)
+    valid = f_norm > 0.0
+    f_dirs[valid] = forces[sample][valid] / f_norm[valid, None]
+
+    fig = plt.figure(figsize=(7.2, 6.2))
+    ax = fig.add_subplot(111, projection="3d")
+    triangles = points[faces]
+    surface = Poly3DCollection(
+        triangles,
+        facecolor="#d9ecff",
+        edgecolor="#7aa6c8",
+        linewidth=0.25,
+        alpha=0.45,
+    )
+    ax.add_collection3d(surface)
+    arrow_len = 0.22 * float(radius)
+    ax.quiver(
+        points[sample, 0],
+        points[sample, 1],
+        points[sample, 2],
+        f_dirs[:, 0],
+        f_dirs[:, 1],
+        f_dirs[:, 2],
+        length=arrow_len,
+        normalize=True,
+        color="#d62728",
+        linewidth=1.2,
+        label="FHeron",
+    )
+    ax.quiver(
+        points[sample, 0],
+        points[sample, 1],
+        points[sample, 2],
+        normals[sample, 0],
+        normals[sample, 1],
+        normals[sample, 2],
+        length=0.72 * arrow_len,
+        normalize=True,
+        color="#1f77b4",
+        linewidth=0.9,
+        alpha=0.85,
+        label="pressure balance",
+    )
+
+    limit = 1.35 * float(radius)
+    ax.set_xlim(-limit, limit)
+    ax.set_ylim(-limit, limit)
+    ax.set_zlim(-limit, limit)
+    ax.set_box_aspect((1.0, 1.0, 1.0))
+    ax.set_xlabel("x [m]")
+    ax.set_ylabel("y [m]")
+    ax.set_zlabel("z [m]")
+    ax.set_title("HC sphere: inward FHeron balanced by pressure")
+    ax.view_init(elev=22, azim=35)
+    ax.legend(loc="upper left", frameon=False)
+
+    mean_area = float(np.mean(areas))
+    ax.text2D(
+        0.58,
+        0.83,
+        f"Delta p = 2 gamma / R = {2.0 * gamma / radius:.3g} Pa\n"
+        f"mean Heron dual area = {mean_area:.3e} m^2",
+        transform=ax.transAxes,
+        bbox={"facecolor": "white", "edgecolor": "none", "alpha": 0.82, "pad": 4.0},
+    )
+    return _finish_plot(fig, out_dir / "fheron_sphere_force_balance.png")
+
+
+def write_plots(
+    rows: list[dict[str, float]],
+    out_dir: Path,
+    *,
+    radius: float,
+    gamma: float,
+) -> list[Path]:
+    plot_paths = [
+        write_timing_plot(rows, out_dir),
+        write_pressure_plot(rows, out_dir),
+        write_residual_plot(rows, out_dir),
+    ]
+    finest_subdivision = int(max(row["subdivisions"] for row in rows))
+    plot_paths.append(
+        write_fheron_sphere_plot(
+            out_dir,
+            subdivisions=finest_subdivision,
+            radius=radius,
+            gamma=gamma,
+        )
+    )
+    return plot_paths
+
+
+def write_timeseries_plots(rows: list[dict[str, float]], out_dir: Path) -> list[Path]:
+    t = _row_array(rows, "t")
+    vol0 = float(rows[0]["vol0_mesh_m3"])
+
+    fig, ax = plt.subplots(figsize=(7.2, 4.8))
+    ax.plot(t, _row_array(rows, "fheron_com_pa"), lw=2.0, label="FHeron_com")
+    ax.plot(t, _row_array(rows, "fheron_analytical_com_pa"), "k--", lw=2.0, label="FHeron_com analytical")
+    ax.plot(t, _row_array(rows, "fheron_incom_pa"), lw=2.0, label="FHeron_incom")
+    ax.plot(
+        t,
+        _row_array(rows, "fheron_analytical_incom_pa"),
+        ":",
+        color="0.20",
+        lw=2.4,
+        label="FHeron_incom analytical",
+    )
+    ax.set_xlabel("t [s]")
+    ax.set_ylabel("FHeron pressure equivalent [Pa]")
+    ax.set_title("FHeron vs t: each path against its own analytical reference")
+    fheron_formatter = ScalarFormatter(useOffset=False)
+    fheron_formatter.set_scientific(False)
+    ax.yaxis.set_major_formatter(fheron_formatter)
+    ax.grid(True, alpha=0.28)
+    ax.legend(frameon=False)
+    fheron_path = _finish_plot(fig, out_dir / "timeseries_fheron_com_incom_analytical_vs_t.png")
+
+    fig, ax = plt.subplots(figsize=(7.2, 4.8))
+    ax.plot(t, _row_array(rows, "vol_com_m3") / vol0, lw=2.0, label="Vol_com")
+    ax.plot(t, _row_array(rows, "vol_analytical_com_m3") / vol0, "k--", lw=2.0, label="Vol_com analytical")
+    ax.plot(t, _row_array(rows, "vol_incom_m3") / vol0, lw=2.0, label="Vol_incom")
+    ax.plot(
+        t,
+        _row_array(rows, "vol_analytical_incom_m3") / vol0,
+        ":",
+        color="0.20",
+        lw=2.4,
+        label="Vol_incom analytical",
+    )
+    ax.set_xlabel("t [s]")
+    ax.set_ylabel("V / V0")
+    ax.set_title("Volume vs t: each path against its own analytical reference")
+    volume_formatter = ScalarFormatter(useOffset=False)
+    volume_formatter.set_scientific(False)
+    ax.yaxis.set_major_formatter(volume_formatter)
+    ax.grid(True, alpha=0.28)
+    ax.legend(frameon=False)
+    volume_path = _finish_plot(fig, out_dir / "timeseries_volume_com_incom_analytical_vs_t.png")
+
+    return [fheron_path, volume_path]
+
+
+def write_sphere_animation(
+    rows: list[dict[str, float]],
+    out_dir: Path,
+    *,
+    subdivisions: int,
+    radius: float,
+    radius_key: str,
+    volume_key: str,
+    fheron_key: str,
+    sphere_title: str,
+    volume_title: str,
+    suptitle_prefix: str,
+    gif_name: str,
+    facecolor: str,
+    edgecolor: str,
+    max_frames: int,
+    fps: int,
+) -> Path:
+    t = _row_array(rows, "t")
+    radius_values = _row_array(rows, radius_key)
+    volume = _row_array(rows, volume_key)
+    volume0 = float(rows[0]["vol0_mesh_m3"])
+    fheron = _row_array(rows, fheron_key)
+    unit_points, faces = icosphere(subdivisions, 1.0)
+    reference_points = unit_points * float(radius)
+
+    frame_count = min(len(rows), max(2, int(max_frames)))
+    frame_indices = np.unique(np.linspace(0, len(rows) - 1, frame_count, dtype=int))
+
+    fig = plt.figure(figsize=(9.2, 5.2))
+    grid = fig.add_gridspec(2, 2, width_ratios=(1.3, 1.0), wspace=0.22, hspace=0.34)
+    ax3d = fig.add_subplot(grid[:, 0], projection="3d")
+    ax_vol = fig.add_subplot(grid[0, 1])
+    ax_force = fig.add_subplot(grid[1, 1])
+
+    r_min = float(np.min(radius_values) / float(radius))
+    r_max = float(np.max(radius_values) / float(radius))
+    limit = 1.10 * max(float(radius), float(np.max(radius_values)))
+
+    def draw_frame(frame_pos: int):
+        row_idx = int(frame_indices[frame_pos])
+        current_radius = float(radius_values[row_idx])
+        current_points = unit_points * current_radius
+
+        ax3d.cla()
+        ax_vol.cla()
+        ax_force.cla()
+
+        reference = Poly3DCollection(
+            reference_points[faces],
+            facecolor=(0.0, 0.0, 0.0, 0.025),
+            edgecolor=(0.25, 0.25, 0.25, 0.28),
+            linewidth=0.25,
+        )
+        current = Poly3DCollection(
+            current_points[faces],
+            facecolor=facecolor,
+            edgecolor=edgecolor,
+            linewidth=0.28,
+            alpha=0.70,
+        )
+        ax3d.add_collection3d(reference)
+        ax3d.add_collection3d(current)
+        ax3d.set_xlim(-limit, limit)
+        ax3d.set_ylim(-limit, limit)
+        ax3d.set_zlim(-limit, limit)
+        ax3d.set_box_aspect((1.0, 1.0, 1.0))
+        ax3d.set_xticks([])
+        ax3d.set_yticks([])
+        ax3d.set_zticks([])
+        ax3d.set_title(sphere_title)
+        ax3d.view_init(elev=20.0, azim=32.0 + 20.0 * float(t[row_idx]) / max(float(t[-1]), 1.0e-30))
+        ax3d.text2D(
+            0.02,
+            0.02,
+            f"t = {t[row_idx]:.5f} s\n"
+            f"R/R0 = {current_radius / float(radius):.5f}\n"
+            f"V/V0 = {volume[row_idx] / volume0:.5f}\n"
+            f"FHeron = {fheron[row_idx]:.3f} Pa",
+            transform=ax3d.transAxes,
+            bbox={"facecolor": "white", "edgecolor": "none", "alpha": 0.82, "pad": 4.0},
+        )
+
+        ax_vol.plot(t, volume / volume0, color=edgecolor, lw=1.8)
+        ax_vol.plot(t[row_idx], volume[row_idx] / volume0, "o", color="#d62728", ms=5.5)
+        ax_vol.axhline(1.0, color="0.25", ls=":", lw=1.4)
+        ax_vol.set_xlim(float(t[0]), float(t[-1]))
+        vol_rel = volume / volume0
+        if float(np.ptp(vol_rel)) < 1.0e-12:
+            ax_vol.set_ylim(0.98, 1.02)
+        else:
+            ax_vol.set_ylim(0.98 * min(float(np.min(vol_rel)), 1.0), 1.02 * max(float(np.max(vol_rel)), 1.0))
+        ax_vol.set_ylabel("V / V0")
+        ax_vol.set_title(volume_title)
+        ax_vol.grid(True, alpha=0.25)
+
+        ax_force.plot(t, fheron, color=edgecolor, lw=1.8)
+        ax_force.plot(t[row_idx], fheron[row_idx], "o", color="#d62728", ms=5.5)
+        ax_force.set_xlim(float(t[0]), float(t[-1]))
+        force_formatter = ScalarFormatter(useOffset=False)
+        force_formatter.set_scientific(False)
+        ax_force.yaxis.set_major_formatter(force_formatter)
+        if float(np.ptp(fheron)) < 1.0e-10:
+            pad = max(0.005 * abs(float(np.mean(fheron))), 0.5)
+        else:
+            pad = max(0.03 * float(np.ptp(fheron)), 1.0e-9)
+        ax_force.set_ylim(float(np.min(fheron) - pad), float(np.max(fheron) + pad))
+        ax_force.set_xlabel("t [s]")
+        ax_force.set_ylabel("FHeron [Pa]")
+        ax_force.set_title("Surface-force pressure equivalent")
+        ax_force.grid(True, alpha=0.25)
+
+        fig.suptitle(
+            f"{suptitle_prefix}, R/R0 range {r_min:.5f}-{r_max:.5f}",
+            y=0.98,
+        )
+
+    animation = FuncAnimation(fig, draw_frame, frames=len(frame_indices), interval=1000.0 / max(1, int(fps)))
+    gif_path = out_dir / gif_name
+    animation.save(gif_path, writer=PillowWriter(fps=max(1, int(fps))))
+    plt.close(fig)
+    return gif_path
+
+
+def write_compressible_animation(
+    rows: list[dict[str, float]],
+    out_dir: Path,
+    *,
+    subdivisions: int,
+    radius: float,
+    max_frames: int,
+    fps: int,
+) -> Path:
+    return write_sphere_animation(
+        rows,
+        out_dir,
+        subdivisions=subdivisions,
+        radius=radius,
+        radius_key="radius_com_m",
+        volume_key="vol_com_m3",
+        fheron_key="fheron_com_pa",
+        sphere_title="Compressible EOS sphere",
+        volume_title="EOS volume response",
+        suptitle_prefix="Compressible sphere oscillation",
+        gif_name="compressible_sphere_oscillation.gif",
+        facecolor="#9ecae1",
+        edgecolor="#1f77b4",
+        max_frames=max_frames,
+        fps=fps,
+    )
+
+
+def write_incompressible_animation(
+    rows: list[dict[str, float]],
+    out_dir: Path,
+    *,
+    subdivisions: int,
+    radius: float,
+    max_frames: int,
+    fps: int,
+) -> Path:
+    return write_sphere_animation(
+        rows,
+        out_dir,
+        subdivisions=subdivisions,
+        radius=radius,
+        radius_key="radius_incom_m",
+        volume_key="vol_incom_m3",
+        fheron_key="fheron_incom_pa",
+        sphere_title="Incompressible projected sphere",
+        volume_title="Projected constant volume",
+        suptitle_prefix="Incompressible projection",
+        gif_name="incompressible_sphere_projection.gif",
+        facecolor="#fdd0a2",
+        edgecolor="#ff7f0e",
+        max_frames=max_frames,
+        fps=fps,
+    )
+
+
+def write_compressible_shape_animation(
+    rows: list[dict[str, float]],
+    out_dir: Path,
+    *,
+    subdivisions: int,
+    radius: float,
+    max_frames: int,
+    fps: int,
+) -> Path:
+    t = _row_array(rows, "t")
+    amplitude = _row_array(rows, "shape_amplitude")
+    amplitude_fit = _row_array(rows, "shape_amplitude_fit")
+    radius_scale = _row_array(rows, "eos_radius_scale")
+    volume = _row_array(rows, "vol_compressible_shape_m3")
+    volume0 = float(rows[0]["vol0_mesh_m3"])
+    fheron = _row_array(rows, "fheron_compressible_shape_pa")
+    capillary_pressure = _row_array(rows, "capillary_pressure_pa")
+    extra_pressure_drive = _row_array(rows, "extra_pressure_drive_pa")
+    eos_pressure = _row_array(rows, "eos_pressure_pa")
+    rayleigh_frequency = float(rows[0].get("rayleigh_frequency_hz", 1.0 / max(float(t[-1] - t[0]), 1.0e-30)))
+    unit_points, faces = icosphere(subdivisions, 1.0)
+    reference_points = unit_points * float(radius)
+
+    frame_count = min(len(rows), max(2, int(max_frames)))
+    frame_indices = np.unique(np.linspace(0, len(rows) - 1, frame_count, dtype=int))
+    radial_min = min(float(row["radial_ratio_min"]) for row in rows)
+    radial_max = max(float(row["radial_ratio_max"]) for row in rows)
+    limit = 1.12 * radial_max * float(radius)
+
+    fig = plt.figure(figsize=(10.2, 7.2))
+    grid = fig.add_gridspec(3, 2, width_ratios=(1.32, 1.0), wspace=0.25, hspace=0.48)
+    ax3d = fig.add_subplot(grid[:2, 0], projection="3d")
+    ax_info = fig.add_subplot(grid[2, 0])
+    ax_amp = fig.add_subplot(grid[0, 1])
+    ax_vol = fig.add_subplot(grid[1, 1])
+    ax_force = fig.add_subplot(grid[2, 1])
+
+    def draw_frame(frame_pos: int):
+        row_idx = int(frame_indices[frame_pos])
+        points, _volume_check = compressible_l2_shape_points(
+            unit_points,
+            faces,
+            radius=radius,
+            amplitude=float(amplitude[row_idx]),
+            target_shape_volume=volume0,
+            isotropic_radius_scale=float(radius_scale[row_idx]),
+        )
+
+        ax3d.cla()
+        ax_info.cla()
+        ax_amp.cla()
+        ax_vol.cla()
+        ax_force.cla()
+
+        reference = Poly3DCollection(
+            reference_points[faces],
+            facecolor=(0.0, 0.0, 0.0, 0.025),
+            edgecolor=(0.25, 0.25, 0.25, 0.28),
+            linewidth=0.25,
+        )
+        current = Poly3DCollection(
+            points[faces],
+            facecolor="#9ecae1",
+            edgecolor="#1f77b4",
+            linewidth=0.28,
+            alpha=0.76,
+        )
+        ax3d.add_collection3d(reference)
+        ax3d.add_collection3d(current)
+        tet_wire = Line3DCollection(
+            volumetric_star_tet_segments(points, faces),
+            colors=(0.12, 0.47, 0.71, 0.28),
+            linewidths=0.35,
+        )
+        ax3d.add_collection3d(tet_wire)
+        ax3d.set_xlim(-limit, limit)
+        ax3d.set_ylim(-limit, limit)
+        ax3d.set_zlim(-limit, limit)
+        ax3d.set_box_aspect((1.0, 1.0, 1.0))
+        ax3d.set_xticks([])
+        ax3d.set_yticks([])
+        ax3d.set_zticks([])
+        ax3d.set_title("Compressible volumetric star-tet mesh")
+        ax3d.view_init(elev=20.0, azim=32.0 + 24.0 * float(t[row_idx]) / max(float(t[-1]), 1.0e-30))
+        ax3d.text2D(
+            0.02,
+            0.02,
+            f"t = {t[row_idx]:.5f} s\n"
+            f"mode a2 = {amplitude[row_idx]:+.4f}\n"
+            f"fit a2 = {amplitude_fit[row_idx]:+.4f}\n"
+            f"AR = {float(rows[row_idx]['radial_ratio_max']) / float(rows[row_idx]['radial_ratio_min']):.4f}\n"
+            f"dV/V0 = {(volume[row_idx] / volume0 - 1.0) * 1.0e6:+.4f} ppm\n"
+            f"p_cap = {capillary_pressure[row_idx]:.3f} Pa\n"
+            f"p_extra = {extra_pressure_drive[row_idx]:+.3e} Pa\n"
+            f"p_EOS = {eos_pressure[row_idx]:.3f} Pa\n"
+            f"FHeron = {fheron[row_idx]:.3f} Pa",
+            transform=ax3d.transAxes,
+            bbox={"facecolor": "white", "edgecolor": "none", "alpha": 0.82, "pad": 4.0},
+        )
+
+        amp_pad = max(0.08 * float(np.ptp(amplitude)), 0.005)
+        ax_amp.plot(t, amplitude, "k--", lw=1.7, label="theory")
+        ax_amp.plot(t, amplitude_fit, color="#1f77b4", lw=1.8, label="fit from mesh")
+        ax_amp.plot(t[row_idx], amplitude_fit[row_idx], "o", color="#d62728", ms=5.0)
+        ax_amp.set_xlim(float(t[0]), float(t[-1]))
+        ax_amp.set_ylim(
+            float(min(np.min(amplitude), np.min(amplitude_fit)) - amp_pad),
+            float(max(np.max(amplitude), np.max(amplitude_fit)) + amp_pad),
+        )
+        ax_amp.set_ylabel("a2")
+        ax_amp.set_title("Shape amplitude")
+        ax_amp.grid(True, alpha=0.25)
+        ax_amp.legend(frameon=False, fontsize=8, loc="upper right")
+
+        vol_rel_ppm = (volume / volume0 - 1.0) * 1.0e6
+        ax_vol.plot(t, vol_rel_ppm, color="#1f77b4", lw=1.8)
+        ax_vol.plot(t[row_idx], vol_rel_ppm[row_idx], "o", color="#d62728", ms=5.5)
+        ax_vol.axhline(0.0, color="0.25", ls=":", lw=1.4)
+        ax_vol.set_xlim(float(t[0]), float(t[-1]))
+        vol_pad = max(0.12 * float(np.ptp(vol_rel_ppm)), 0.01)
+        ax_vol.set_ylim(float(np.min(vol_rel_ppm) - vol_pad), float(np.max(vol_rel_ppm) + vol_pad))
+        ax_vol.set_ylabel("Delta V / V0 [ppm]")
+        ax_vol.set_title("Physical EOS volume response")
+        ax_vol.grid(True, alpha=0.25)
+
+        ax_force.plot(t, fheron, color="#1f77b4", lw=1.8)
+        ax_force.plot(t[row_idx], fheron[row_idx], "o", color="#d62728", ms=5.5)
+        ax_force.set_xlim(float(t[0]), float(t[-1]))
+        force_formatter = ScalarFormatter(useOffset=False)
+        force_formatter.set_scientific(False)
+        ax_force.yaxis.set_major_formatter(force_formatter)
+        pad = max(0.04 * float(np.ptp(fheron)), 1.0e-9)
+        ax_force.set_ylim(float(np.min(fheron) - pad), float(np.max(fheron) + pad))
+        ax_force.set_xlabel("t [s]")
+        ax_force.set_ylabel("FHeron [Pa]")
+        ax_force.set_title("Shape plus EOS curvature response")
+        ax_force.grid(True, alpha=0.25)
+
+        fig.suptitle(
+            f"Compressible shape mode, Rayleigh f={rayleigh_frequency:.3f} Hz, radial range {radial_min:.4f}-{radial_max:.4f}",
+            y=0.98,
+        )
+
+    animation = FuncAnimation(fig, draw_frame, frames=len(frame_indices), interval=1000.0 / max(1, int(fps)))
+    gif_path = out_dir / "compressible_sphere_oscillation.gif"
+    animation.save(gif_path, writer=PillowWriter(fps=max(1, int(fps))))
+    plt.close(fig)
+    return gif_path
+
+
+def write_force_dynamic_animation(
+    rows: list[dict[str, float]],
+    snapshots: np.ndarray,
+    faces: np.ndarray,
+    out_dir: Path,
+    *,
+    radius: float,
+    subdivisions: int,
+    closure: str,
+    max_frames: int,
+    fps: int,
+    volume_tets: np.ndarray | None = None,
+    surface_indices: np.ndarray | None = None,
+) -> Path:
+    t = _row_array(rows, "t")
+    amplitude_theory = _row_array(rows, "shape_amplitude_theory")
+    amplitude_fit = _row_array(rows, "shape_amplitude_fit")
+    volume = _row_array(rows, "vol_m3")
+    volume0 = float(rows[0]["vol0_mesh_m3"])
+    local_volume_max_ppm = _row_array(rows, "local_volume_rel_max_abs") * 1.0e6
+    fheron = _row_array(rows, "fheron_pressure_pa")
+    closure_pressure = _row_array(rows, "closure_pressure_pa")
+    speed = _row_array(rows, "max_speed_m_s")
+    cpu_time = np.asarray([float(row.get("cpu_time_s", 0.0)) for row in rows], dtype=float)
+    cpu_ms_per_substep = np.asarray([float(row.get("cpu_ms_per_substep", 0.0)) for row in rows], dtype=float)
+    cpu_total = float(cpu_time[-1]) if cpu_time.size else 0.0
+    cpu_avg_ms = float(cpu_ms_per_substep[-1]) if cpu_ms_per_substep.size else 0.0
+    mass_model = str(rows[0].get("mass_model", "dynamic mass"))
+    rayleigh_frequency = float(rows[0].get("rayleigh_frequency_hz", 1.0 / max(float(t[-1] - t[0]), 1.0e-30)))
+    (
+        reference_volume_points,
+        reference_tets,
+        reference_surface_indices,
+        _reference_faces,
+        _reference_faces_global,
+        _reference_unit_points,
+    ) = build_ball_tet_mesh(subdivisions, float(radius))
+    if volume_tets is None:
+        volume_tets = reference_tets
+    if surface_indices is None:
+        surface_indices = reference_surface_indices
+    surface_indices = np.asarray(surface_indices, dtype=int)
+    volume_tets = np.asarray(volume_tets, dtype=int)
+    reference_surface_points = reference_volume_points[surface_indices]
+    reference_radii = np.linalg.norm(reference_volume_points, axis=1)
+    interior_indices = np.setdiff1d(np.arange(reference_volume_points.shape[0], dtype=int), surface_indices)
+    center_indices = interior_indices[reference_radii[interior_indices] <= 1.0e-12]
+    shell_indices = interior_indices[reference_radii[interior_indices] > 1.0e-12]
+    volume_edge_indices = tet_edge_indices(volume_tets, max_edges=360)
+
+    frame_count = min(len(rows), max(2, int(max_frames)))
+    frame_indices = np.unique(np.linspace(0, len(rows) - 1, frame_count, dtype=int))
+    radial_min = min(float(row["radial_ratio_min"]) for row in rows)
+    radial_max = max(float(row["radial_ratio_max"]) for row in rows)
+    limit = 1.14 * radial_max * float(radius)
+
+    if closure == "compressible":
+        facecolor = "#9ecae1"
+        edgecolor = "#1f77b4"
+        title = "Compressible EOS: Ftot-driven vertices"
+        gif_name = "compressible_sphere_oscillation.gif"
+        vol_title = "EOS volume response"
+    else:
+        facecolor = "#fdd0a2"
+        edgecolor = "#ff7f0e"
+        title = "Incompressible projection: Ftot-driven vertices"
+        gif_name = "incompressible_sphere_projection.gif"
+        vol_title = "Projected volume constraint"
+
+    fig = plt.figure(figsize=(10.2, 7.2))
+    grid = fig.add_gridspec(3, 2, width_ratios=(1.32, 1.0), wspace=0.25, hspace=0.48)
+    ax3d = fig.add_subplot(grid[:2, 0], projection="3d")
+    ax_info = fig.add_subplot(grid[2, 0])
+    ax_amp = fig.add_subplot(grid[0, 1])
+    ax_vol = fig.add_subplot(grid[1, 1])
+    ax_force = fig.add_subplot(grid[2, 1])
+
+    def draw_frame(frame_pos: int):
+        row_idx = int(frame_indices[frame_pos])
+        volume_points = snapshots[row_idx]
+        surface_points = volume_points[surface_indices]
+
+        ax3d.cla()
+        ax_info.cla()
+        ax_amp.cla()
+        ax_vol.cla()
+        ax_force.cla()
+
+        reference = Poly3DCollection(
+            reference_surface_points[faces],
+            facecolor=(0.0, 0.0, 0.0, 0.025),
+            edgecolor=(0.25, 0.25, 0.25, 0.28),
+            linewidth=0.25,
+        )
+        current = Poly3DCollection(
+            surface_points[faces],
+            facecolor=facecolor,
+            edgecolor=edgecolor,
+            linewidth=0.28,
+            alpha=0.48,
+        )
+        ax3d.add_collection3d(reference)
+        ax3d.add_collection3d(current)
+        edge_segments = (
+            np.asarray(volume_points[volume_edge_indices], dtype=float)
+            if volume_edge_indices.size
+            else np.empty((0, 2, 3), dtype=float)
+        )
+        tet_wire = Line3DCollection(
+            edge_segments,
+            colors=(0.12, 0.12, 0.12, 0.26),
+            linewidths=0.35,
+        )
+        ax3d.add_collection3d(tet_wire)
+        if shell_indices.size:
+            shell_points = volume_points[shell_indices]
+            ax3d.scatter(
+                shell_points[:, 0],
+                shell_points[:, 1],
+                shell_points[:, 2],
+                s=12.0,
+                c="#2ca02c",
+                edgecolors="none",
+                alpha=0.82,
+                depthshade=False,
+            )
+        if center_indices.size:
+            center_points = volume_points[center_indices]
+            ax3d.scatter(
+                center_points[:, 0],
+                center_points[:, 1],
+                center_points[:, 2],
+                s=22.0,
+                c="#111111",
+                edgecolors="white",
+                linewidths=0.35,
+                alpha=0.9,
+                depthshade=False,
+            )
+        ax3d.set_xlim(-limit, limit)
+        ax3d.set_ylim(-limit, limit)
+        ax3d.set_zlim(-limit, limit)
+        ax3d.set_box_aspect((1.0, 1.0, 1.0))
+        ax3d.set_xticks([])
+        ax3d.set_yticks([])
+        ax3d.set_zticks([])
+        ax3d.set_title(title)
+        ax3d.view_init(elev=20.0, azim=32.0 + 24.0 * float(t[row_idx]) / max(float(t[-1]), 1.0e-30))
+
+        ax_info.axis("off")
+        left_info = (
+            f"t = {t[row_idx]:.5f} s\n"
+            f"theory a2 = {amplitude_theory[row_idx]:+.4f}\n"
+            f"fit a2 = {amplitude_fit[row_idx]:+.4f}\n"
+            f"AR = {float(rows[row_idx]['radial_ratio_max']) / float(rows[row_idx]['radial_ratio_min']):.4f}\n"
+            f"dV/V0 = {(volume[row_idx] / volume0 - 1.0) * 1.0e6:+.3f} ppm\n"
+            f"max tet dV = {local_volume_max_ppm[row_idx]:.3f} ppm\n"
+            f"CPU now = {cpu_time[row_idx]:.2f} s\n"
+            f"CPU/step = {cpu_ms_per_substep[row_idx]:.2f} ms"
+        )
+        right_info = (
+            f"mesh = {volume_points.shape[0]} verts, {volume_tets.shape[0]} tets\n"
+            f"interior = {interior_indices.size} verts\n"
+            f"mass = {mass_model}\n"
+            f"p = {closure_pressure[row_idx]:.3f} Pa\n"
+            f"FHeron = {fheron[row_idx]:.3f} Pa\n"
+            f"max |u| = {speed[row_idx]:.3e} m/s\n"
+            f"CPU total = {cpu_total:.1f} s\n"
+            f"avg CPU/step = {cpu_avg_ms:.1f} ms"
+        )
+        ax_info.text(
+            0.02,
+            0.98,
+            left_info,
+            transform=ax_info.transAxes,
+            va="top",
+            ha="left",
+            family="monospace",
+            fontsize=8.2,
+        )
+        ax_info.text(
+            0.50,
+            0.98,
+            right_info,
+            transform=ax_info.transAxes,
+            va="top",
+            ha="left",
+            family="monospace",
+            fontsize=8.2,
+        )
+
+        amp_pad = max(0.1 * float(np.ptp(amplitude_theory)), 0.004)
+        ax_amp.plot(t, amplitude_theory, "k--", lw=1.7, label="Rayleigh theory")
+        ax_amp.plot(t, amplitude_fit, color=edgecolor, lw=1.8, label="Ftot simulation")
+        ax_amp.plot(t[row_idx], amplitude_fit[row_idx], "o", color="#d62728", ms=5.0)
+        ax_amp.set_xlim(float(t[0]), float(t[-1]))
+        ax_amp.set_ylim(
+            float(min(np.min(amplitude_theory), np.min(amplitude_fit)) - amp_pad),
+            float(max(np.max(amplitude_theory), np.max(amplitude_fit)) + amp_pad),
+        )
+        ax_amp.set_ylabel("a2")
+        ax_amp.set_title("Shape amplitude")
+        ax_amp.grid(True, alpha=0.25)
+        ax_amp.legend(frameon=False, fontsize=8, loc="upper right")
+
+        vol_pad = max(0.12 * float(np.ptp(local_volume_max_ppm)), 0.01)
+        ax_vol.plot(t, local_volume_max_ppm, color=edgecolor, lw=1.8)
+        ax_vol.plot(t[row_idx], local_volume_max_ppm[row_idx], "o", color="#d62728", ms=5.5)
+        ax_vol.axhline(0.0, color="0.25", ls=":", lw=1.4)
+        ax_vol.set_xlim(float(t[0]), float(t[-1]))
+        ax_vol.set_ylim(float(np.min(local_volume_max_ppm) - vol_pad), float(np.max(local_volume_max_ppm) + vol_pad))
+        ax_vol.set_ylabel("max tet |Delta V| [ppm]")
+        ax_vol.set_title(vol_title)
+        ax_vol.grid(True, alpha=0.25)
+
+        ax_force.plot(t, fheron, color=edgecolor, lw=1.8, label="FHeron")
+        ax_force.plot(t, closure_pressure, color="0.25", lw=1.2, ls=":", label="closure p")
+        ax_force.plot(t[row_idx], fheron[row_idx], "o", color="#d62728", ms=5.5)
+        ax_force.set_xlim(float(t[0]), float(t[-1]))
+        force_formatter = ScalarFormatter(useOffset=False)
+        force_formatter.set_scientific(False)
+        ax_force.yaxis.set_major_formatter(force_formatter)
+        force_min = min(float(np.min(fheron)), float(np.min(closure_pressure)))
+        force_max = max(float(np.max(fheron)), float(np.max(closure_pressure)))
+        force_pad = max(0.04 * (force_max - force_min), 1.0e-9)
+        ax_force.set_ylim(force_min - force_pad, force_max + force_pad)
+        ax_force.set_xlabel("t [s]")
+        ax_force.set_ylabel("pressure [Pa]")
+        ax_force.set_title("Forces used in Ftot")
+        ax_force.grid(True, alpha=0.25)
+        ax_force.legend(frameon=False, fontsize=8, loc="upper right")
+
+        fig.suptitle(
+            f"{closure.capitalize()} Ftot dynamic, {mass_model}, Rayleigh f={rayleigh_frequency:.3f} Hz, "
+            f"CPU {cpu_total:.1f} s ({cpu_avg_ms:.1f} ms/step)",
+            y=0.965,
+        )
+
+    animation = FuncAnimation(fig, draw_frame, frames=len(frame_indices), interval=1000.0 / max(1, int(fps)))
+    gif_path = out_dir / gif_name
+    animation.save(gif_path, writer=PillowWriter(fps=max(1, int(fps))))
+    plt.close(fig)
+    return gif_path
+
+
+def write_incompressible_local_projection_animation(
+    rows: list[dict[str, float]],
+    out_dir: Path,
+    *,
+    subdivisions: int,
+    radius: float,
+    max_frames: int,
+    fps: int,
+) -> Path:
+    t = _row_array(rows, "t")
+    amplitude = _row_array(rows, "shape_amplitude")
+    amplitude_fit = _row_array(rows, "shape_amplitude_fit")
+    volume = _row_array(rows, "vol_local_projection_m3")
+    volume0 = float(rows[0]["vol0_mesh_m3"])
+    fheron = _row_array(rows, "fheron_local_projection_pa")
+    rayleigh_frequency = float(rows[0].get("rayleigh_frequency_hz", 1.0 / max(float(t[-1] - t[0]), 1.0e-30)))
+    unit_points, faces = icosphere(subdivisions, 1.0)
+    reference_points = unit_points * float(radius)
+
+    frame_count = min(len(rows), max(2, int(max_frames)))
+    frame_indices = np.unique(np.linspace(0, len(rows) - 1, frame_count, dtype=int))
+    radial_min = min(float(row["radial_ratio_min"]) for row in rows)
+    radial_max = max(float(row["radial_ratio_max"]) for row in rows)
+    limit = 1.12 * radial_max * float(radius)
+
+    fig = plt.figure(figsize=(9.4, 6.8))
+    grid = fig.add_gridspec(3, 2, width_ratios=(1.35, 1.0), wspace=0.24, hspace=0.46)
+    ax3d = fig.add_subplot(grid[:, 0], projection="3d")
+    ax_amp = fig.add_subplot(grid[0, 1])
+    ax_vol = fig.add_subplot(grid[1, 1])
+    ax_force = fig.add_subplot(grid[2, 1])
+
+    def draw_frame(frame_pos: int):
+        row_idx = int(frame_indices[frame_pos])
+        points, _volume_check = projected_l2_shape_points(
+            unit_points,
+            faces,
+            radius=radius,
+            amplitude=float(amplitude[row_idx]),
+            target_volume=volume0,
+        )
+
+        ax3d.cla()
+        ax_amp.cla()
+        ax_vol.cla()
+        ax_force.cla()
+
+        reference = Poly3DCollection(
+            reference_points[faces],
+            facecolor=(0.0, 0.0, 0.0, 0.025),
+            edgecolor=(0.25, 0.25, 0.25, 0.28),
+            linewidth=0.25,
+        )
+        current = Poly3DCollection(
+            points[faces],
+            facecolor="#fdd0a2",
+            edgecolor="#ff7f0e",
+            linewidth=0.28,
+            alpha=0.76,
+        )
+        ax3d.add_collection3d(reference)
+        ax3d.add_collection3d(current)
+        tet_wire = Line3DCollection(
+            volumetric_star_tet_segments(points, faces),
+            colors=(1.0, 0.45, 0.0, 0.28),
+            linewidths=0.35,
+        )
+        ax3d.add_collection3d(tet_wire)
+        ax3d.set_xlim(-limit, limit)
+        ax3d.set_ylim(-limit, limit)
+        ax3d.set_zlim(-limit, limit)
+        ax3d.set_box_aspect((1.0, 1.0, 1.0))
+        ax3d.set_xticks([])
+        ax3d.set_yticks([])
+        ax3d.set_zticks([])
+        ax3d.set_title("Incompressible volumetric star-tet mesh")
+        ax3d.view_init(elev=20.0, azim=32.0 + 24.0 * float(t[row_idx]) / max(float(t[-1]), 1.0e-30))
+        ax3d.text2D(
+            0.02,
+            0.02,
+            f"t = {t[row_idx]:.5f} s\n"
+            f"mode a2 = {amplitude[row_idx]:+.4f}\n"
+            f"fit a2 = {amplitude_fit[row_idx]:+.4f}\n"
+            f"AR = {float(rows[row_idx]['radial_ratio_max']) / float(rows[row_idx]['radial_ratio_min']):.4f}\n"
+            f"V/V0 = {volume[row_idx] / volume0:.6f}\n"
+            f"FHeron = {fheron[row_idx]:.3f} Pa",
+            transform=ax3d.transAxes,
+            bbox={"facecolor": "white", "edgecolor": "none", "alpha": 0.82, "pad": 4.0},
+        )
+
+        amp_pad = max(0.08 * float(np.ptp(amplitude)), 0.005)
+        ax_amp.plot(t, amplitude, "k--", lw=1.7, label="theory")
+        ax_amp.plot(t, amplitude_fit, color="#ff7f0e", lw=1.8, label="fit from mesh")
+        ax_amp.plot(t[row_idx], amplitude_fit[row_idx], "o", color="#d62728", ms=5.0)
+        ax_amp.set_xlim(float(t[0]), float(t[-1]))
+        ax_amp.set_ylim(
+            float(min(np.min(amplitude), np.min(amplitude_fit)) - amp_pad),
+            float(max(np.max(amplitude), np.max(amplitude_fit)) + amp_pad),
+        )
+        ax_amp.set_ylabel("a2")
+        ax_amp.set_title("Shape amplitude")
+        ax_amp.grid(True, alpha=0.25)
+        ax_amp.legend(frameon=False, fontsize=8, loc="upper right")
+
+        ax_vol.plot(t, volume / volume0, color="#ff7f0e", lw=1.8)
+        ax_vol.plot(t[row_idx], volume[row_idx] / volume0, "o", color="#d62728", ms=5.5)
+        ax_vol.axhline(1.0, color="0.25", ls=":", lw=1.4)
+        ax_vol.set_xlim(float(t[0]), float(t[-1]))
+        ax_vol.set_ylim(0.98, 1.02)
+        ax_vol.set_ylabel("V / V0")
+        ax_vol.set_title("Projected constant volume")
+        ax_vol.grid(True, alpha=0.25)
+
+        ax_force.plot(t, fheron, color="#ff7f0e", lw=1.8)
+        ax_force.plot(t[row_idx], fheron[row_idx], "o", color="#d62728", ms=5.5)
+        ax_force.set_xlim(float(t[0]), float(t[-1]))
+        force_formatter = ScalarFormatter(useOffset=False)
+        force_formatter.set_scientific(False)
+        ax_force.yaxis.set_major_formatter(force_formatter)
+        pad = max(0.04 * float(np.ptp(fheron)), 1.0e-9)
+        ax_force.set_ylim(float(np.min(fheron) - pad), float(np.max(fheron) + pad))
+        ax_force.set_xlabel("t [s]")
+        ax_force.set_ylabel("FHeron [Pa]")
+        ax_force.set_title("Shape-curvature response")
+        ax_force.grid(True, alpha=0.25)
+
+        fig.suptitle(
+            f"Incompressible local projection, Rayleigh f={rayleigh_frequency:.3f} Hz, radial range {radial_min:.4f}-{radial_max:.4f}",
+            y=0.98,
+        )
+
+    animation = FuncAnimation(fig, draw_frame, frames=len(frame_indices), interval=1000.0 / max(1, int(fps)))
+    gif_path = out_dir / "incompressible_sphere_projection.gif"
+    animation.save(gif_path, writer=PillowWriter(fps=max(1, int(fps))))
+    plt.close(fig)
+    return gif_path
+
+
+def main() -> int:
+    args = parse_args()
+    rayleigh_omega, rayleigh_frequency, rayleigh_period = rayleigh_lamb_frequency(
+        args.rayleigh_mode,
+        args.gamma,
+        args.rho,
+        args.radius,
+    )
+    t_final = (
+        float(args.timeseries_final_time)
+        if args.timeseries_final_time is not None
+        else (float(rayleigh_period) if args.use_rayleigh_frequency else 1.0)
+    )
+    rows = [
+        run_one(
+            subdivisions=subdivision,
+            radius=args.radius,
+            gamma=args.gamma,
+            bulk_modulus=args.bulk_modulus,
+            fheron_repeats=args.fheron_repeats,
+            closure_repeats=args.closure_repeats,
+        )
+        for subdivision in range(args.max_subdivision + 1)
+    ]
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    csv_path, json_path = write_outputs(rows, args.out_dir)
+    plot_paths = write_plots(rows, args.out_dir, radius=args.radius, gamma=args.gamma)
+    timeseries_rows = run_timeseries(
+        subdivisions=args.timeseries_subdivision,
+        radius=args.radius,
+        gamma=args.gamma,
+        bulk_modulus=args.bulk_modulus,
+        pressure_drive_fraction=args.pressure_drive_fraction,
+        n_steps=args.timeseries_steps,
+        t_final=t_final,
+    )
+    timeseries_csv_path, timeseries_json_path = write_timeseries_outputs(timeseries_rows, args.out_dir)
+    timeseries_plot_paths = write_timeseries_plots(timeseries_rows, args.out_dir)
+    shape_mode_amplitude = (
+        float(args.shape_mode_amplitude)
+        if args.shape_mode_amplitude is not None
+        else shape_amplitude_from_aspect_ratio(args.shape_mode_ar)
+    )
+    compressible_shape_rows = run_compressible_shape_timeseries(
+        subdivisions=args.timeseries_subdivision,
+        radius=args.radius,
+        gamma=args.gamma,
+        bulk_modulus=args.bulk_modulus,
+        pressure_drive_fraction=args.pressure_drive_fraction,
+        amplitude=shape_mode_amplitude,
+        n_steps=args.timeseries_steps,
+        t_final=t_final,
+        rayleigh_frequency_hz=rayleigh_frequency,
+        rayleigh_omega_rad_s=rayleigh_omega,
+    )
+    compressible_shape_csv_path, compressible_shape_json_path = write_compressible_shape_outputs(
+        compressible_shape_rows,
+        args.out_dir,
+    )
+    local_projection_rows = run_local_projection_timeseries(
+        subdivisions=args.timeseries_subdivision,
+        radius=args.radius,
+        gamma=args.gamma,
+        amplitude=shape_mode_amplitude,
+        n_steps=args.timeseries_steps,
+        t_final=t_final,
+        rayleigh_frequency_hz=rayleigh_frequency,
+        rayleigh_omega_rad_s=rayleigh_omega,
+    )
+    local_csv_path, local_json_path = write_local_projection_outputs(local_projection_rows, args.out_dir)
+    (
+        compressible_dynamic_rows,
+        compressible_dynamic_snapshots,
+        dynamic_faces,
+        dynamic_tets,
+        dynamic_surface_indices,
+    ) = run_force_dynamic_timeseries(
+        closure="compressible",
+        subdivisions=args.dynamic_subdivision,
+        radius=args.radius,
+        gamma=args.gamma,
+        rho=args.rho,
+        bulk_modulus=args.bulk_modulus,
+        amplitude=shape_mode_amplitude,
+        n_steps=args.timeseries_steps,
+        t_final=t_final,
+        substeps_per_sample=args.dynamic_substeps_per_sample,
+        damping_ratio=args.dynamic_damping_ratio,
+        mass_model=args.dynamic_mass_model,
+        rayleigh_frequency_hz=rayleigh_frequency,
+        rayleigh_omega_rad_s=rayleigh_omega,
+        rayleigh_mode=args.rayleigh_mode,
+    )
+    (
+        incompressible_dynamic_rows,
+        incompressible_dynamic_snapshots,
+        _dynamic_faces,
+        _dynamic_tets,
+        _dynamic_surface_indices,
+    ) = run_force_dynamic_timeseries(
+        closure="incompressible",
+        subdivisions=args.dynamic_subdivision,
+        radius=args.radius,
+        gamma=args.gamma,
+        rho=args.rho,
+        bulk_modulus=args.bulk_modulus,
+        amplitude=shape_mode_amplitude,
+        n_steps=args.timeseries_steps,
+        t_final=t_final,
+        substeps_per_sample=args.dynamic_substeps_per_sample,
+        damping_ratio=args.dynamic_damping_ratio,
+        mass_model=args.dynamic_mass_model,
+        rayleigh_frequency_hz=rayleigh_frequency,
+        rayleigh_omega_rad_s=rayleigh_omega,
+        rayleigh_mode=args.rayleigh_mode,
+    )
+    compressible_dynamic_csv_path, compressible_dynamic_json_path = write_named_rows_outputs(
+        compressible_dynamic_rows,
+        args.out_dir,
+        "sphere_fheron_compressible_dynamic_timeseries",
+    )
+    incompressible_dynamic_csv_path, incompressible_dynamic_json_path = write_named_rows_outputs(
+        incompressible_dynamic_rows,
+        args.out_dir,
+        "sphere_fheron_incompressible_dynamic_timeseries",
+    )
+    compressible_dynamic_npz_path = write_dynamic_snapshots(
+        compressible_dynamic_snapshots,
+        dynamic_faces,
+        args.out_dir,
+        "sphere_fheron_compressible_dynamic_snapshots",
+        tets=dynamic_tets,
+        surface_indices=dynamic_surface_indices,
+    )
+    incompressible_dynamic_npz_path = write_dynamic_snapshots(
+        incompressible_dynamic_snapshots,
+        dynamic_faces,
+        args.out_dir,
+        "sphere_fheron_incompressible_dynamic_snapshots",
+        tets=dynamic_tets,
+        surface_indices=dynamic_surface_indices,
+    )
+    compressible_animation_path = write_force_dynamic_animation(
+        compressible_dynamic_rows,
+        compressible_dynamic_snapshots,
+        dynamic_faces,
+        args.out_dir,
+        radius=args.radius,
+        subdivisions=args.dynamic_subdivision,
+        closure="compressible",
+        max_frames=args.animation_max_frames,
+        fps=args.animation_fps,
+        volume_tets=dynamic_tets,
+        surface_indices=dynamic_surface_indices,
+    )
+    incompressible_animation_path = write_force_dynamic_animation(
+        incompressible_dynamic_rows,
+        incompressible_dynamic_snapshots,
+        dynamic_faces,
+        args.out_dir,
+        radius=args.radius,
+        subdivisions=args.dynamic_subdivision,
+        closure="incompressible",
+        max_frames=args.animation_max_frames,
+        fps=args.animation_fps,
+        volume_tets=dynamic_tets,
+        surface_indices=dynamic_surface_indices,
+    )
+
+    print(
+        "sub  verts  FHeron[ms]  EOS[us]  Proj[us]  pTheory[Pa]  pEOS[Pa]  pProj[Pa]  "
+        "HeronErr  ProjResidual"
+    )
+    for row in rows:
+        print(
+            f"{row['subdivisions']:>3d} "
+            f"{row['vertices']:>6d} "
+            f"{row['fheron_ms']:>11.4f} "
+            f"{row['eos_us']:>8.4f} "
+            f"{row['projection_us']:>9.4f} "
+            f"{row['theory_pressure_pa']:>11.4f} "
+            f"{row['eos_pressure_pa']:>9.4f} "
+            f"{row['projection_pressure_pa']:>9.4f} "
+            f"{row['heron_vs_theory_rel_rms']:>8.2e} "
+            f"{row['projection_residual_rel_rms']:>12.2e}"
+        )
+
+    print(f"CSV:  {csv_path}")
+    print(f"JSON: {json_path}")
+    print(f"Rayleigh-Lamb l={args.rayleigh_mode}: f={rayleigh_frequency:.6f} Hz, T={rayleigh_period:.6e} s")
+    print(f"CSV:  {timeseries_csv_path}")
+    print(f"JSON: {timeseries_json_path}")
+    print(f"CSV:  {compressible_shape_csv_path}")
+    print(f"JSON: {compressible_shape_json_path}")
+    print(f"CSV:  {local_csv_path}")
+    print(f"JSON: {local_json_path}")
+    print(f"CSV:  {compressible_dynamic_csv_path}")
+    print(f"JSON: {compressible_dynamic_json_path}")
+    print(f"NPZ:  {compressible_dynamic_npz_path}")
+    print(f"CSV:  {incompressible_dynamic_csv_path}")
+    print(f"JSON: {incompressible_dynamic_json_path}")
+    print(f"NPZ:  {incompressible_dynamic_npz_path}")
+    for plot_path in plot_paths:
+        print(f"PNG:  {plot_path}")
+    for plot_path in timeseries_plot_paths:
+        print(f"PNG:  {plot_path}")
+    print(f"GIF:  {compressible_animation_path}")
+    print(f"GIF:  {incompressible_animation_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cases_dynamic/oscillating_droplet_p_ref/scripts/sphere_fheron_flux_fv_benchmark.py
+++ b/cases_dynamic/oscillating_droplet_p_ref/scripts/sphere_fheron_flux_fv_benchmark.py
@@ -1,0 +1,1486 @@
+"""Flux-aware HC/FHeron droplet benchmark.
+
+This is a separate finite-volume/ALE-style diagnostic from
+``sphere_fheron_eos_projection_benchmark.py``.  It keeps the same HC Heron
+surface force, but updates nodal mass, nodal dual volume, nodal density, and
+boundary area vectors every step.  It also computes internal tet-face mass and
+momentum fluxes.
+
+The flux model here is deliberately compact for a benchmark GIF.  It is not a
+production CFD discretization.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+from pathlib import Path
+import time
+import warnings
+
+import numpy as np
+
+import sphere_fheron_eos_projection_benchmark as base
+
+plt = base.plt
+FuncAnimation = base.FuncAnimation
+PillowWriter = base.PillowWriter
+Line3DCollection = base.Line3DCollection
+Poly3DCollection = base.Poly3DCollection
+ScalarFormatter = base.ScalarFormatter
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+def tet_face_pairs(tets: np.ndarray) -> list[tuple[np.ndarray, int, int]]:
+    """Return internal faces as ``(face_vertices, left_tet, right_tet)``."""
+    face_map: dict[tuple[int, int, int], list[int]] = {}
+    for tet_idx, tet in enumerate(np.asarray(tets, dtype=int)):
+        a, b, c, d = [int(index) for index in tet]
+        for face in ((a, b, c), (a, b, d), (a, c, d), (b, c, d)):
+            face_map.setdefault(tuple(sorted(face)), []).append(tet_idx)
+    pairs: list[tuple[np.ndarray, int, int]] = []
+    for face, owners in face_map.items():
+        if len(owners) == 2:
+            pairs.append((np.asarray(face, dtype=int), int(owners[0]), int(owners[1])))
+    return pairs
+
+
+def canonical_tet_set(tets: np.ndarray) -> set[tuple[int, int, int, int]]:
+    return {tuple(sorted(int(index) for index in tet)) for tet in np.asarray(tets, dtype=int)}
+
+
+def delaunay_tets_for_points(points: np.ndarray, fallback_tets: np.ndarray) -> np.ndarray:
+    """Fresh Delaunay tets for diagnostics without changing material masses."""
+    try:
+        triangulation = base.Delaunay(np.asarray(points, dtype=float), qhull_options="Qbb Qc")
+        raw_tets = np.asarray(triangulation.simplices, dtype=int)
+        valid = np.all(raw_tets < points.shape[0], axis=1)
+        raw_tets = raw_tets[valid]
+        if raw_tets.size == 0:
+            return np.asarray(fallback_tets, dtype=int).copy()
+        volumes = base.tet_cell_volumes(points, raw_tets)
+        positive = volumes[volumes > 0.0]
+        min_volume = 0.1 * float(np.median(positive)) if positive.size else 0.0
+        filtered = raw_tets[volumes > min_volume]
+        if filtered.size == 0:
+            return np.asarray(fallback_tets, dtype=int).copy()
+        return np.asarray(filtered, dtype=int)
+    except Exception:
+        return np.asarray(fallback_tets, dtype=int).copy()
+
+
+def nodal_from_tets(n_vertices: int, tets: np.ndarray, tet_values: np.ndarray) -> np.ndarray:
+    nodal = np.zeros(n_vertices, dtype=float)
+    for tet, value in zip(np.asarray(tets, dtype=int), np.asarray(tet_values, dtype=float)):
+        share = 0.25 * float(value)
+        for vertex_idx in tet:
+            nodal[int(vertex_idx)] += share
+    return nodal
+
+
+def current_area_vectors(
+    points: np.ndarray,
+    surface_indices: np.ndarray,
+    surface_faces: np.ndarray,
+) -> np.ndarray:
+    area_vectors = np.zeros_like(points)
+    area_vectors[np.asarray(surface_indices, dtype=int)] = base.vertex_area_vectors(
+        points[np.asarray(surface_indices, dtype=int)],
+        surface_faces,
+    )
+    return area_vectors
+
+
+def compute_ale_fluxes(
+    points: np.ndarray,
+    velocities: np.ndarray,
+    tets: np.ndarray,
+    face_pairs: list[tuple[np.ndarray, int, int]],
+    tet_masses: np.ndarray,
+    reference_tet_masses: np.ndarray,
+    tet_volumes: np.ndarray,
+    dt: float,
+    *,
+    reference_density: float,
+    sound_speed: float,
+    mass_floor_fraction: float = 0.35,
+    mass_update_coupling: float = 0.02,
+    momentum_force_coupling: float = 0.0,
+    density_change_limit: float | None = None,
+    flux_cfl_limit: float = 0.25,
+    flux_scheme: str = "upwind",
+    face_flux_mode: str = "cell-average",
+) -> tuple[np.ndarray, np.ndarray, dict[str, float]]:
+    """Compute internal ALE face mass/momentum flux and update cell masses."""
+    if flux_scheme not in {"upwind", "rusanov"}:
+        raise ValueError("flux_scheme must be 'upwind' or 'rusanov'")
+    if face_flux_mode not in {"cell-average", "lagrangian"}:
+        raise ValueError("face_flux_mode must be 'cell-average' or 'lagrangian'")
+
+    n_tets = np.asarray(tets).shape[0]
+    cell_centers = np.mean(points[np.asarray(tets, dtype=int)], axis=1)
+    cell_velocities = np.mean(velocities[np.asarray(tets, dtype=int)], axis=1)
+    cell_density = np.asarray(tet_masses, dtype=float) / np.maximum(tet_volumes, 1.0e-300)
+
+    dm_dt = np.zeros(n_tets, dtype=float)
+    cell_force = np.zeros((n_tets, 3), dtype=float)
+    mass_flux_l1 = 0.0
+    max_abs_mass_flux = 0.0
+    momentum_flux_l1 = 0.0
+    volume_flux_l1 = 0.0
+
+    for face_vertices, left, right in face_pairs:
+        pa, pb, pc = points[face_vertices]
+        area_vec = 0.5 * np.cross(pb - pa, pc - pa)
+        center_delta = cell_centers[right] - cell_centers[left]
+        if float(np.dot(area_vec, center_delta)) < 0.0:
+            area_vec = -area_vec
+
+        area = float(np.linalg.norm(area_vec))
+        if area <= 0.0:
+            continue
+        normal = area_vec / area
+        mesh_face_velocity = np.mean(velocities[face_vertices], axis=0)
+        left_velocity = cell_velocities[left]
+        right_velocity = cell_velocities[right]
+        left_density = float(cell_density[left])
+        right_density = float(cell_density[right])
+
+        if face_flux_mode == "lagrangian":
+            # In a Lagrangian vertex mesh the material face velocity is the
+            # mesh-face velocity.  This preserves the ALE geometric conservation
+            # law and prevents artificial inter-tet flux from cell averaging.
+            relative_volume_flux = 0.0
+            mass_flux = 0.0
+            momentum_flux = np.zeros(3, dtype=float)
+
+        elif flux_scheme == "rusanov":
+            left_relative_normal = float(np.dot(left_velocity - mesh_face_velocity, normal))
+            right_relative_normal = float(np.dot(right_velocity - mesh_face_velocity, normal))
+            max_wave_speed = max(
+                abs(left_relative_normal) + float(sound_speed),
+                abs(right_relative_normal) + float(sound_speed),
+                1.0e-30,
+            )
+            mass_flux = area * (
+                0.5 * (left_density * left_relative_normal + right_density * right_relative_normal)
+                - 0.5 * max_wave_speed * (right_density - left_density)
+            )
+            momentum_flux = area * (
+                0.5 * (left_density * left_velocity * left_relative_normal + right_density * right_velocity * right_relative_normal)
+                - 0.5 * max_wave_speed * (right_density * right_velocity - left_density * left_velocity)
+            )
+            relative_volume_flux = mass_flux / max(0.5 * (left_density + right_density), 1.0e-300)
+        else:
+            fluid_face_velocity = 0.5 * (left_velocity + right_velocity)
+            relative_volume_flux = float(np.dot(fluid_face_velocity - mesh_face_velocity, area_vec))
+            if relative_volume_flux >= 0.0:
+                density = left_density
+                upwind_velocity = left_velocity
+            else:
+                density = right_density
+                upwind_velocity = right_velocity
+            mass_flux = density * relative_volume_flux
+            momentum_flux = mass_flux * upwind_velocity
+
+        dm_dt[left] -= mass_flux
+        dm_dt[right] += mass_flux
+        cell_force[left] -= momentum_flux
+        cell_force[right] += momentum_flux
+
+        abs_mass_flux = abs(float(mass_flux))
+        mass_flux_l1 += abs_mass_flux
+        max_abs_mass_flux = max(max_abs_mass_flux, abs_mass_flux)
+        momentum_flux_l1 += float(np.linalg.norm(momentum_flux))
+        volume_flux_l1 += abs(float(relative_volume_flux))
+
+    effective_dm_dt = float(mass_update_coupling) * dm_dt
+    effective_cell_force = float(momentum_force_coupling) * cell_force
+
+    scale = 1.0
+    mass_delta = float(dt) * effective_dm_dt
+    mass_abs_delta = np.abs(mass_delta)
+    if flux_cfl_limit > 0.0 and np.any(mass_abs_delta > 0.0):
+        cfl_scale = np.min(
+            float(flux_cfl_limit) * np.asarray(tet_masses, dtype=float)[mass_abs_delta > 0.0]
+            / mass_abs_delta[mass_abs_delta > 0.0]
+        )
+        scale = min(scale, max(0.0, float(cfl_scale)))
+
+    floors = float(mass_floor_fraction) * np.asarray(reference_tet_masses, dtype=float)
+    proposed = np.asarray(tet_masses, dtype=float) + mass_delta
+    floor_bad = proposed < floors
+    if np.any(floor_bad):
+        denom = -mass_delta[floor_bad]
+        valid = denom > 0.0
+        if np.any(valid):
+            floor_scale = np.min((tet_masses[floor_bad][valid] - floors[floor_bad][valid]) / denom[valid])
+            scale = min(scale, max(0.0, float(floor_scale)))
+
+    if density_change_limit is not None and density_change_limit > 0.0:
+        lower_masses = (1.0 - float(density_change_limit)) * float(reference_density) * np.maximum(
+            tet_volumes,
+            1.0e-300,
+        )
+        upper_masses = (1.0 + float(density_change_limit)) * float(reference_density) * np.maximum(
+            tet_volumes,
+            1.0e-300,
+        )
+        increasing_too_much = (mass_delta > 0.0) & (proposed > upper_masses)
+        if np.any(increasing_too_much):
+            density_scale = np.min(
+                (upper_masses[increasing_too_much] - tet_masses[increasing_too_much])
+                / mass_delta[increasing_too_much]
+            )
+            scale = min(scale, max(0.0, float(density_scale)))
+        decreasing_too_much = (mass_delta < 0.0) & (proposed < lower_masses)
+        if np.any(decreasing_too_much):
+            density_scale = np.min(
+                (lower_masses[decreasing_too_much] - tet_masses[decreasing_too_much])
+                / mass_delta[decreasing_too_much]
+            )
+            scale = min(scale, max(0.0, float(density_scale)))
+
+    effective_dm_dt *= scale
+    effective_cell_force *= scale
+
+    updated_masses = np.maximum(np.asarray(tet_masses, dtype=float) + float(dt) * effective_dm_dt, floors)
+    nodal_flux_force = np.zeros_like(points)
+    for tet, force in zip(np.asarray(tets, dtype=int), effective_cell_force):
+        for vertex_idx in tet:
+            nodal_flux_force[int(vertex_idx)] += 0.25 * force
+
+    stats = {
+        "mass_flux_l1_kg_s": float(mass_flux_l1),
+        "mass_flux_max_kg_s": float(max_abs_mass_flux),
+        "momentum_flux_l1_n": float(momentum_flux_l1),
+        "volume_flux_l1_m3_s": float(volume_flux_l1),
+        "flux_limiter_scale": float(scale),
+        "mass_update_coupling": float(mass_update_coupling),
+        "momentum_force_coupling": float(momentum_force_coupling),
+        "density_change_limit": float(density_change_limit) if density_change_limit is not None else 0.0,
+        "flux_cfl_limit": float(flux_cfl_limit),
+        "flux_scheme_rusanov": 1.0 if flux_scheme == "rusanov" else 0.0,
+        "face_flux_lagrangian": 1.0 if face_flux_mode == "lagrangian" else 0.0,
+    }
+    return updated_masses, nodal_flux_force, stats
+
+
+def linearized_mass_flux_matrix(
+    points: np.ndarray,
+    tets: np.ndarray,
+    face_pairs: list[tuple[np.ndarray, int, int]],
+    tet_masses: np.ndarray,
+    tet_volumes: np.ndarray,
+    *,
+    reference_density: float,
+    mass_update_coupling: float,
+) -> np.ndarray:
+    """Linearized ALE mass-flux operator ``dm_dt = G u`` for the pressure solve."""
+    n_tets = np.asarray(tets).shape[0]
+    n_dof = np.asarray(points).shape[0] * 3
+    matrix = np.zeros((n_tets, n_dof), dtype=float)
+    if not face_pairs or mass_update_coupling == 0.0:
+        return matrix
+
+    cell_centers = np.mean(points[np.asarray(tets, dtype=int)], axis=1)
+    cell_density = np.asarray(tet_masses, dtype=float) / np.maximum(tet_volumes, 1.0e-300)
+    for face_vertices, left, right in face_pairs:
+        pa, pb, pc = points[face_vertices]
+        area_vec = 0.5 * np.cross(pb - pa, pc - pa)
+        center_delta = cell_centers[right] - cell_centers[left]
+        if float(np.dot(area_vec, center_delta)) < 0.0:
+            area_vec = -area_vec
+        if float(np.linalg.norm(area_vec)) <= 0.0:
+            continue
+
+        rho_face = max(0.5 * (float(cell_density[left]) + float(cell_density[right])), 1.0e-12)
+        weights: dict[int, float] = {}
+        for vertex_idx in np.asarray(tets[left], dtype=int):
+            weights[int(vertex_idx)] = weights.get(int(vertex_idx), 0.0) + 0.125
+        for vertex_idx in np.asarray(tets[right], dtype=int):
+            weights[int(vertex_idx)] = weights.get(int(vertex_idx), 0.0) + 0.125
+        for vertex_idx in np.asarray(face_vertices, dtype=int):
+            weights[int(vertex_idx)] = weights.get(int(vertex_idx), 0.0) - 1.0 / 3.0
+
+        for vertex_idx, weight in weights.items():
+            for component in range(3):
+                coefficient = float(mass_update_coupling) * rho_face * float(weight) * float(area_vec[component])
+                dof = 3 * int(vertex_idx) + component
+                matrix[int(left), dof] -= coefficient
+                matrix[int(right), dof] += coefficient
+    return matrix
+
+
+def barycentric_edge_dual_areas(points: np.ndarray, tets: np.ndarray) -> dict[tuple[int, int], np.ndarray]:
+    """Barycentric dual-face area vectors ``A_ij`` for mesh vertex pairs.
+
+    The returned vector is oriented from the lower vertex index toward the
+    higher vertex index.  For vertex ``i`` the pairwise pressure force uses
+    ``A_ij`` outward from ``i``; the sign is flipped automatically when
+    ``i`` is the higher-index endpoint.
+    """
+    edge_areas: dict[tuple[int, int], np.ndarray] = {}
+    pts = np.asarray(points, dtype=float)
+    for tet in np.asarray(tets, dtype=int):
+        centroid = np.mean(pts[tet], axis=0)
+        for a_local in range(4):
+            for b_local in range(a_local + 1, 4):
+                i = int(tet[a_local])
+                j = int(tet[b_local])
+                other = [int(tet[k]) for k in range(4) if k not in (a_local, b_local)]
+                k, l = other
+                midpoint = 0.5 * (pts[i] + pts[j])
+                face_centroid_1 = (pts[i] + pts[j] + pts[k]) / 3.0
+                face_centroid_2 = (pts[i] + pts[j] + pts[l]) / 3.0
+                area_vec = (
+                    0.5 * np.cross(face_centroid_1 - midpoint, centroid - midpoint)
+                    + 0.5 * np.cross(centroid - midpoint, face_centroid_2 - midpoint)
+                )
+                if float(np.dot(area_vec, pts[j] - pts[i])) < 0.0:
+                    area_vec = -area_vec
+                if i < j:
+                    key = (i, j)
+                    oriented = area_vec
+                else:
+                    key = (j, i)
+                    oriented = -area_vec
+                edge_areas[key] = edge_areas.get(key, np.zeros(3, dtype=float)) + oriented
+    return edge_areas
+
+
+def tet_pressure_to_vertex_weights(n_vertices: int, tets: np.ndarray, tet_volumes: np.ndarray) -> np.ndarray:
+    """Volume-weighted map from tet pressure values to vertex pressure values."""
+    n_tets = int(np.asarray(tets).shape[0])
+    weights = np.zeros((int(n_vertices), n_tets), dtype=float)
+    incident = np.zeros(int(n_vertices), dtype=float)
+    for tet_idx, tet in enumerate(np.asarray(tets, dtype=int)):
+        volume = max(float(tet_volumes[int(tet_idx)]), 1.0e-300)
+        for vertex_idx in tet:
+            weights[int(vertex_idx), int(tet_idx)] += volume
+            incident[int(vertex_idx)] += volume
+    weights /= np.maximum(incident[:, None], 1.0e-300)
+    return weights
+
+
+def pairwise_pressure_force_matrix(
+    points: np.ndarray,
+    tets: np.ndarray,
+    tet_volumes: np.ndarray,
+) -> np.ndarray:
+    """Linear force matrix for ``F_i^p = sum_j -0.5(p_i+p_j) A_ij``."""
+    n_vertices = int(np.asarray(points).shape[0])
+    n_tets = int(np.asarray(tets).shape[0])
+    pressure_weights = tet_pressure_to_vertex_weights(n_vertices, tets, tet_volumes)
+    matrix = np.zeros((3 * n_vertices, n_tets), dtype=float)
+    for (i, j), area_vec in barycentric_edge_dual_areas(points, tets).items():
+        coefficient = -0.5 * (pressure_weights[int(i)] + pressure_weights[int(j)])
+        for component in range(3):
+            force_coeff = coefficient * float(area_vec[component])
+            matrix[3 * int(i) + component] += force_coeff
+            matrix[3 * int(j) + component] -= force_coeff
+    return matrix
+
+
+def pairwise_vertex_pressure_matrix(points: np.ndarray, tets: np.ndarray) -> np.ndarray:
+    """Force matrix for vertex pressures in ``-0.5(p_i+p_j) A_ij``."""
+    n_vertices = int(np.asarray(points).shape[0])
+    matrix = np.zeros((3 * n_vertices, n_vertices), dtype=float)
+    for (i, j), area_vec in barycentric_edge_dual_areas(points, tets).items():
+        for component in range(3):
+            coefficient = -0.5 * float(area_vec[component])
+            matrix[3 * int(i) + component, int(i)] += coefficient
+            matrix[3 * int(i) + component, int(j)] += coefficient
+            matrix[3 * int(j) + component, int(i)] -= coefficient
+            matrix[3 * int(j) + component, int(j)] -= coefficient
+    return matrix
+
+
+def tet_vertex_pressure_average_matrix(n_vertices: int, tets: np.ndarray) -> np.ndarray:
+    """Map vertex pressures to tet pressures by arithmetic vertex average."""
+    n_tets = int(np.asarray(tets).shape[0])
+    matrix = np.zeros((n_tets, int(n_vertices)), dtype=float)
+    for tet_idx, tet in enumerate(np.asarray(tets, dtype=int)):
+        for vertex_idx in tet:
+            matrix[int(tet_idx), int(vertex_idx)] += 0.25
+    return matrix
+
+
+def solve_regularized_lstsq(matrix: np.ndarray, rhs: np.ndarray, *, relative: float = 1.0e-12) -> np.ndarray:
+    """Least-squares solve with small Tikhonov regularization for rectangular systems."""
+    lhs = np.asarray(matrix, dtype=float)
+    rhs_array = np.asarray(rhs, dtype=float)
+    scale = max(float(np.mean(np.abs(lhs))) if lhs.size else 0.0, 1.0e-30)
+    damping = math.sqrt(float(relative) * scale)
+    augmented = np.vstack([lhs, damping * np.eye(lhs.shape[1])])
+    augmented_rhs = np.concatenate([rhs_array, np.zeros(lhs.shape[1], dtype=float)])
+    return np.linalg.lstsq(augmented, augmented_rhs, rcond=1.0e-12)[0]
+
+
+def pairwise_forcefit_pressure_matrix(
+    points: np.ndarray,
+    tets: np.ndarray,
+    local_matrix: np.ndarray,
+) -> np.ndarray:
+    """Map tet pressures to vertex-pair forces via fitted vertex pressures."""
+    vertex_matrix = pairwise_vertex_pressure_matrix(points, tets)
+    pressure_transfer = np.linalg.lstsq(vertex_matrix, np.asarray(local_matrix.T, dtype=float), rcond=1.0e-12)[0]
+    return vertex_matrix @ pressure_transfer
+
+
+def pressure_force_matrix_for_mode(
+    mode: str,
+    points: np.ndarray,
+    tets: np.ndarray,
+    tet_volumes: np.ndarray,
+    local_matrix: np.ndarray,
+) -> np.ndarray:
+    if mode == "volume-gradient":
+        return np.asarray(local_matrix.T, dtype=float)
+    if mode in {"pairwise-dual", "pairwise-dual-consistent"}:
+        return pairwise_pressure_force_matrix(points, tets, tet_volumes)
+    if mode == "pairwise-vertex-eos":
+        return pairwise_vertex_pressure_matrix(points, tets)
+    if mode == "pairwise-dual-scalar":
+        pairwise_matrix = pairwise_pressure_force_matrix(points, tets, tet_volumes)
+        uniform_force = pairwise_matrix @ np.ones(int(np.asarray(tets).shape[0]), dtype=float)
+        scalar_average = np.full(int(np.asarray(tets).shape[0]), 1.0 / float(np.asarray(tets).shape[0]))
+        return np.outer(uniform_force, scalar_average)
+    if mode == "pairwise-dual-forcefit":
+        return pairwise_forcefit_pressure_matrix(points, tets, local_matrix)
+    raise ValueError(
+        "pressure_force_mode must be volume-gradient, pairwise-dual, "
+        "pairwise-dual-scalar, pairwise-dual-forcefit, pairwise-dual-consistent, "
+        "or pairwise-vertex-eos"
+    )
+
+
+def pressure_solve_matrix_for_mode(
+    mode: str,
+    pressure_force_matrix: np.ndarray,
+    local_matrix: np.ndarray,
+) -> np.ndarray:
+    if mode in {"pairwise-dual-consistent", "pairwise-vertex-eos"}:
+        return pressure_force_matrix
+    return np.asarray(local_matrix.T, dtype=float)
+
+
+def project_local_volume_velocity_with_pressure_matrix(
+    velocities: np.ndarray,
+    volume_matrix: np.ndarray,
+    pressure_force_matrix: np.ndarray,
+    masses: np.ndarray,
+    target_rates: np.ndarray,
+) -> np.ndarray:
+    velocity_vec = velocities.reshape(-1)
+    inv_mass_dof = np.repeat(1.0 / np.maximum(masses, 1.0e-300), 3)
+    stiffness = (volume_matrix * inv_mass_dof[None, :]) @ pressure_force_matrix
+    rhs = volume_matrix @ velocity_vec - np.asarray(target_rates, dtype=float)
+    multipliers = base._solve_regularized(stiffness, rhs)
+    projected_vec = velocity_vec - inv_mass_dof * (pressure_force_matrix @ multipliers)
+    return projected_vec.reshape(velocities.shape)
+
+
+def row_array(rows: list[dict[str, float]], key: str) -> np.ndarray:
+    return np.asarray([float(row[key]) for row in rows], dtype=float)
+
+
+def write_rows(rows: list[dict[str, float]], out_dir: Path, stem: str) -> tuple[Path, Path]:
+    csv_path = out_dir / f"{stem}.csv"
+    json_path = out_dir / f"{stem}.json"
+    with csv_path.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+    json_path.write_text(json.dumps(rows, indent=2))
+    return csv_path, json_path
+
+
+def run_flux_dynamic(
+    *,
+    closure: str,
+    subdivisions: int,
+    radius: float,
+    gamma: float,
+    rho: float,
+    bulk_modulus: float,
+    amplitude: float,
+    n_steps: int,
+    t_final: float,
+    substeps_per_sample: int,
+    damping_ratio: float,
+    mass_model: str,
+    inertia_scale: float,
+    mass_flux_coupling: float,
+    momentum_flux_coupling: float,
+    density_change_limit: float | None,
+    flux_cfl_limit: float,
+    flux_scheme: str,
+    flux_timing: str,
+    face_flux_mode: str,
+    mass_floor_fraction: float,
+    coupled_flux_continuity: bool,
+    flux_continuity_sign: float,
+    incompressible_target_mode: str,
+    pressure_force_mode: str,
+    rayleigh_frequency_hz: float,
+    rayleigh_omega_rad_s: float,
+    rayleigh_mode: int,
+    ambient_pressure: float,
+    retriangulation_mode: str,
+) -> tuple[list[dict[str, float]], np.ndarray, np.ndarray, np.ndarray, np.ndarray, list[np.ndarray]]:
+    if closure not in {"compressible", "incompressible"}:
+        raise ValueError("closure must be compressible or incompressible")
+    if incompressible_target_mode not in {"reference", "mass"}:
+        raise ValueError("incompressible_target_mode must be reference or mass")
+    if flux_timing not in {"pre-pressure", "post-pressure"}:
+        raise ValueError("flux_timing must be pre-pressure or post-pressure")
+    if mass_model not in {"star-volume", "rayleigh-added"}:
+        raise ValueError("mass_model must be star-volume or rayleigh-added")
+    if pressure_force_mode not in {
+        "volume-gradient",
+        "pairwise-dual",
+        "pairwise-dual-scalar",
+        "pairwise-dual-forcefit",
+        "pairwise-dual-consistent",
+        "pairwise-vertex-eos",
+    }:
+        raise ValueError(
+            "pressure_force_mode must be volume-gradient, pairwise-dual, "
+            "pairwise-dual-scalar, pairwise-dual-forcefit, pairwise-dual-consistent, "
+            "or pairwise-vertex-eos"
+        )
+    if retriangulation_mode not in {"none", "diagnostic", "active"}:
+        raise ValueError("retriangulation_mode must be none, diagnostic, or active")
+
+    reference_points, tets, surface_indices, surface_faces, _surface_faces_global, _unit_points = base.build_ball_tet_mesh(
+        subdivisions,
+        radius,
+    )
+    points = base.deform_l2_volume_points(
+        reference_points,
+        tets,
+        radius=radius,
+        amplitude=amplitude,
+        target_volume=float(np.sum(base.tet_cell_volumes(reference_points, tets))),
+    )
+    reference_tet_volumes, _matrix0 = base.tet_volume_matrix(points, tets)
+    reference_total_volume = float(np.sum(reference_tet_volumes))
+    tet_masses = float(rho) * reference_tet_volumes
+    reference_tet_masses = tet_masses.copy()
+    reference_total_mass = float(np.sum(tet_masses))
+    reference_nodal_volumes = nodal_from_tets(points.shape[0], tets, reference_tet_volumes)
+    velocities = np.zeros_like(points)
+    face_pairs = tet_face_pairs(tets)
+    reference_display_tet_set = canonical_tet_set(tets)
+    inertial_mass_addition = np.zeros(points.shape[0], dtype=float)
+    if mass_model == "rayleigh-added":
+        reference_scalar_areas = base.vertex_scalar_areas(reference_points[surface_indices], surface_faces)
+        surface_added_mass = float(rho) * float(radius) / float(rayleigh_mode)
+        inertial_mass_addition[surface_indices] = surface_added_mass * reference_scalar_areas
+        mass_model_label = "bulk plus Rayleigh surface mass"
+    else:
+        mass_model_label = "bulk-tet lumped mass"
+
+    _forces0, _areas0, reference_pressure, _volume0 = base.fheron_forces_for_points(
+        reference_points[surface_indices],
+        surface_faces,
+        gamma,
+    )
+
+    dt = float(t_final) / float((int(n_steps) - 1) * int(substeps_per_sample))
+    damping_rate = 2.0 * float(damping_ratio) * float(rayleigh_omega_rad_s)
+    rows: list[dict[str, float]] = []
+    snapshots: list[np.ndarray] = []
+    display_tets_snapshots: list[np.ndarray] = []
+    cpu_start = time.process_time()
+    wall_start = time.perf_counter()
+    last_flux = {
+        "mass_flux_l1_kg_s": 0.0,
+        "mass_flux_max_kg_s": 0.0,
+        "momentum_flux_l1_n": 0.0,
+        "volume_flux_l1_m3_s": 0.0,
+        "flux_limiter_scale": 1.0,
+        "mass_update_coupling": float(mass_flux_coupling),
+        "momentum_force_coupling": float(momentum_flux_coupling),
+        "density_change_limit": float(density_change_limit) if density_change_limit is not None else 0.0,
+        "flux_cfl_limit": float(flux_cfl_limit),
+        "flux_scheme_rusanov": 1.0 if flux_scheme == "rusanov" else 0.0,
+        "face_flux_lagrangian": 1.0 if face_flux_mode == "lagrangian" else 0.0,
+        "flux_post_pressure": 1.0 if flux_timing == "post-pressure" else 0.0,
+        "mass_floor_fraction": float(mass_floor_fraction),
+        "coupled_flux_continuity": 1.0 if coupled_flux_continuity else 0.0,
+        "flux_continuity_sign": float(flux_continuity_sign),
+        "pressure_force_pairwise_dual": 1.0 if pressure_force_mode != "volume-gradient" else 0.0,
+        "pressure_force_scalar_pairwise": 1.0 if pressure_force_mode == "pairwise-dual-scalar" else 0.0,
+        "pressure_force_forcefit_pairwise": 1.0 if pressure_force_mode == "pairwise-dual-forcefit" else 0.0,
+        "pressure_solve_pairwise_dual": 1.0 if pressure_force_mode == "pairwise-dual-consistent" else 0.0,
+        "pressure_solve_pairwise_vertex": 1.0 if pressure_force_mode == "pairwise-vertex-eos" else 0.0,
+    }
+    sound_speed = math.sqrt(float(bulk_modulus) / float(rho))
+
+    def active_retriangulate() -> None:
+        nonlocal tets, reference_tet_volumes, tet_masses, reference_tet_masses
+        nonlocal reference_nodal_volumes, face_pairs
+
+        new_tets = delaunay_tets_for_points(points, tets)
+        new_volumes, _new_matrix = base.tet_volume_matrix(points, new_tets)
+        positive = new_volumes > 1.0e-30
+        if not np.any(positive):
+            return
+
+        new_tets = np.asarray(new_tets[positive], dtype=int)
+        new_volumes = np.asarray(new_volumes[positive], dtype=float)
+        current_volume = float(np.sum(new_volumes))
+        if current_volume <= 1.0e-300:
+            return
+
+        target_density = float(reference_total_mass) / current_volume
+        target_volume_scale = float(reference_total_volume) / current_volume
+        tets = new_tets
+        reference_tet_volumes = target_volume_scale * new_volumes
+        tet_masses = target_density * new_volumes
+        reference_tet_masses = tet_masses.copy()
+        reference_nodal_volumes = nodal_from_tets(points.shape[0], tets, reference_tet_volumes)
+        face_pairs = tet_face_pairs(tets)
+
+    def collect(sample_index: int, time_value: float) -> None:
+        tet_volumes, local_matrix = base.tet_volume_matrix(points, tets)
+        if retriangulation_mode == "diagnostic":
+            display_tets = delaunay_tets_for_points(points, tets)
+        else:
+            display_tets = tets
+        display_tet_set = canonical_tet_set(display_tets)
+        display_union = reference_display_tet_set | display_tet_set
+        display_changed = reference_display_tet_set ^ display_tet_set
+        display_change_fraction = float(len(display_changed)) / max(float(len(display_union)), 1.0)
+        display_face_pairs = tet_face_pairs(display_tets)
+        nodal_mass = nodal_from_tets(points.shape[0], tets, tet_masses)
+        inertial_nodal_mass = np.maximum(float(inertia_scale) * (nodal_mass + inertial_mass_addition), 1.0e-18)
+        nodal_volume = nodal_from_tets(points.shape[0], tets, tet_volumes)
+        nodal_density = nodal_mass / np.maximum(nodal_volume, 1.0e-300)
+        area_vectors = current_area_vectors(points, surface_indices, surface_faces)
+        surface_points = points[surface_indices]
+        _surface_forces, _surface_area_vectors, fheron_equiv, _surface_volume = base.fheron_forces_for_points(
+            surface_points,
+            surface_faces,
+            gamma,
+        )
+        fitted_amplitude = base.fit_l2_shape_amplitude(surface_points, surface_faces)
+        theory_amplitude = float(amplitude) * math.cos(float(rayleigh_omega_rad_s) * float(time_value))
+        radial_ratio = np.linalg.norm(surface_points, axis=1) / float(radius)
+        cpu_elapsed = time.process_time() - cpu_start
+        wall_elapsed = time.perf_counter() - wall_start
+        substeps_done = int(sample_index) * int(substeps_per_sample)
+        cpu_ms_per_substep = 1.0e3 * cpu_elapsed / float(substeps_done) if substeps_done else 0.0
+        wall_ms_per_substep = 1.0e3 * wall_elapsed / float(substeps_done) if substeps_done else 0.0
+        if closure == "compressible" or incompressible_target_mode == "mass":
+            target_volumes = tet_masses / float(rho)
+        else:
+            target_volumes = reference_tet_volumes
+        local_volume_rel = tet_volumes / np.maximum(target_volumes, 1.0e-300)
+        density_rel = nodal_density / float(rho)
+        nodal_volume_rel = nodal_volume / np.maximum(reference_nodal_volumes, 1.0e-300)
+        area_norm = np.linalg.norm(area_vectors[surface_indices], axis=1)
+
+        rows.append(
+            {
+                "sample": float(sample_index),
+                "t": float(time_value),
+                "closure": closure,
+                "shape_amplitude_theory": float(theory_amplitude),
+                "shape_amplitude_fit": float(fitted_amplitude),
+                "rayleigh_frequency_hz": float(rayleigh_frequency_hz),
+                "rayleigh_omega_rad_s": float(rayleigh_omega_rad_s),
+                "fheron_pressure_pa": float(fheron_equiv),
+                "reference_pressure_pa": float(reference_pressure),
+                "closure_pressure_pa": float(getattr(collect, "last_pressure", reference_pressure)),
+                "ambient_pressure_pa": float(ambient_pressure),
+                "liquid_pressure_absolute_pa": float(ambient_pressure + getattr(collect, "last_pressure", reference_pressure)),
+                "mass_model": mass_model_label,
+                "inertia_scale": float(inertia_scale),
+                "total_mass_kg": float(np.sum(tet_masses)),
+                "total_inertial_mass_kg": float(np.sum(inertial_nodal_mass)),
+                "mass_rel_error": float(np.sum(tet_masses) / reference_total_mass - 1.0),
+                "vol_m3": float(np.sum(tet_volumes)),
+                "vol0_mesh_m3": float(np.sum(reference_tet_volumes)),
+                "vol_rel": float(np.sum(tet_volumes) / np.sum(reference_tet_volumes)),
+                "local_volume_rel_rms": float(math.sqrt(float(np.mean((local_volume_rel - 1.0) ** 2)))),
+                "local_volume_rel_max_abs": float(np.max(np.abs(local_volume_rel - 1.0))),
+                "nodal_mass_min_kg": float(np.min(nodal_mass)),
+                "nodal_mass_max_kg": float(np.max(nodal_mass)),
+                "inertial_mass_min_kg": float(np.min(inertial_nodal_mass)),
+                "inertial_mass_max_kg": float(np.max(inertial_nodal_mass)),
+                "nodal_volume_rel_min": float(np.min(nodal_volume_rel[nodal_volume > 0.0])),
+                "nodal_volume_rel_max": float(np.max(nodal_volume_rel[nodal_volume > 0.0])),
+                "nodal_density_rel_min": float(np.min(density_rel[nodal_volume > 0.0])),
+                "nodal_density_rel_max": float(np.max(density_rel[nodal_volume > 0.0])),
+                "area_vector_mean_m2": float(np.mean(area_norm)),
+                "area_vector_max_m2": float(np.max(area_norm)),
+                "mass_flux_l1_kg_s": float(last_flux["mass_flux_l1_kg_s"]),
+                "mass_flux_max_kg_s": float(last_flux["mass_flux_max_kg_s"]),
+                "momentum_flux_l1_n": float(last_flux["momentum_flux_l1_n"]),
+                "volume_flux_l1_m3_s": float(last_flux["volume_flux_l1_m3_s"]),
+                "flux_limiter_scale": float(last_flux["flux_limiter_scale"]),
+                "mass_update_coupling": float(last_flux["mass_update_coupling"]),
+                "momentum_force_coupling": float(last_flux["momentum_force_coupling"]),
+                "density_change_limit": float(last_flux["density_change_limit"]),
+                "flux_cfl_limit": float(last_flux["flux_cfl_limit"]),
+                "flux_scheme_rusanov": float(last_flux["flux_scheme_rusanov"]),
+                "face_flux_lagrangian": float(last_flux["face_flux_lagrangian"]),
+                "flux_post_pressure": float(last_flux["flux_post_pressure"]),
+                "mass_floor_fraction": float(last_flux["mass_floor_fraction"]),
+                "coupled_flux_continuity": float(last_flux["coupled_flux_continuity"]),
+                "flux_continuity_sign": float(last_flux["flux_continuity_sign"]),
+                "pressure_force_pairwise_dual": float(last_flux["pressure_force_pairwise_dual"]),
+                "pressure_force_scalar_pairwise": float(last_flux["pressure_force_scalar_pairwise"]),
+                "pressure_force_forcefit_pairwise": float(last_flux["pressure_force_forcefit_pairwise"]),
+                "pressure_solve_pairwise_dual": float(last_flux["pressure_solve_pairwise_dual"]),
+                "pressure_solve_pairwise_vertex": float(last_flux["pressure_solve_pairwise_vertex"]),
+                "retriangulation_diagnostic": 1.0 if retriangulation_mode == "diagnostic" else 0.0,
+                "retriangulation_active": 1.0 if retriangulation_mode == "active" else 0.0,
+                "solver_tet_count": float(tets.shape[0]),
+                "display_tet_count": float(display_tets.shape[0]),
+                "display_internal_face_count": float(len(display_face_pairs)),
+                "display_changed_tets": float(len(display_changed)),
+                "display_changed_fraction": float(display_change_fraction),
+                "incompressible_target_from_mass": 1.0 if incompressible_target_mode == "mass" else 0.0,
+                "cpu_time_s": float(cpu_elapsed),
+                "wall_time_s": float(wall_elapsed),
+                "cpu_ms_per_substep": float(cpu_ms_per_substep),
+                "wall_ms_per_substep": float(wall_ms_per_substep),
+                "max_speed_m_s": float(np.max(np.linalg.norm(velocities, axis=1))),
+                "radial_ratio_min": float(np.min(radial_ratio)),
+                "radial_ratio_max": float(np.max(radial_ratio)),
+            }
+        )
+        snapshots.append(points.copy())
+        display_tets_snapshots.append(np.asarray(display_tets, dtype=int).copy())
+
+    collect.last_pressure = reference_pressure  # type: ignore[attr-defined]
+    collect(0, 0.0)
+
+    total_substeps = (int(n_steps) - 1) * int(substeps_per_sample)
+    sample_index = 1
+    for substep in range(1, total_substeps + 1):
+        if retriangulation_mode == "active":
+            active_retriangulate()
+        tet_volumes, local_matrix = base.tet_volume_matrix(points, tets)
+        if flux_timing == "pre-pressure":
+            tet_masses, flux_forces, last_flux = compute_ale_fluxes(
+                points,
+                velocities,
+                tets,
+                face_pairs,
+                tet_masses,
+                reference_tet_masses,
+                tet_volumes,
+                dt,
+                reference_density=rho,
+                sound_speed=sound_speed,
+                mass_floor_fraction=mass_floor_fraction,
+                mass_update_coupling=mass_flux_coupling,
+                momentum_force_coupling=momentum_flux_coupling,
+                density_change_limit=density_change_limit,
+                flux_cfl_limit=flux_cfl_limit,
+                flux_scheme=flux_scheme,
+                face_flux_mode=face_flux_mode,
+            )
+            last_flux["flux_post_pressure"] = 0.0
+            last_flux["mass_floor_fraction"] = float(mass_floor_fraction)
+            last_flux["coupled_flux_continuity"] = 1.0 if coupled_flux_continuity else 0.0
+            last_flux["flux_continuity_sign"] = float(flux_continuity_sign)
+            last_flux["pressure_force_pairwise_dual"] = 1.0 if pressure_force_mode != "volume-gradient" else 0.0
+            last_flux["pressure_force_scalar_pairwise"] = 1.0 if pressure_force_mode == "pairwise-dual-scalar" else 0.0
+            last_flux["pressure_force_forcefit_pairwise"] = 1.0 if pressure_force_mode == "pairwise-dual-forcefit" else 0.0
+            last_flux["pressure_solve_pairwise_dual"] = 1.0 if pressure_force_mode == "pairwise-dual-consistent" else 0.0
+            last_flux["pressure_solve_pairwise_vertex"] = 1.0 if pressure_force_mode == "pairwise-vertex-eos" else 0.0
+        else:
+            flux_forces = np.zeros_like(points)
+            last_flux = dict(last_flux)
+            last_flux["mass_flux_l1_kg_s"] = 0.0
+            last_flux["mass_flux_max_kg_s"] = 0.0
+            last_flux["momentum_flux_l1_n"] = 0.0
+            last_flux["volume_flux_l1_m3_s"] = 0.0
+            last_flux["flux_limiter_scale"] = 1.0
+            last_flux["flux_post_pressure"] = 1.0
+            last_flux["mass_floor_fraction"] = float(mass_floor_fraction)
+            last_flux["coupled_flux_continuity"] = 1.0 if coupled_flux_continuity else 0.0
+            last_flux["flux_continuity_sign"] = float(flux_continuity_sign)
+            last_flux["pressure_force_pairwise_dual"] = 1.0 if pressure_force_mode != "volume-gradient" else 0.0
+            last_flux["pressure_force_scalar_pairwise"] = 1.0 if pressure_force_mode == "pairwise-dual-scalar" else 0.0
+            last_flux["pressure_force_forcefit_pairwise"] = 1.0 if pressure_force_mode == "pairwise-dual-forcefit" else 0.0
+            last_flux["pressure_solve_pairwise_dual"] = 1.0 if pressure_force_mode == "pairwise-dual-consistent" else 0.0
+            last_flux["pressure_solve_pairwise_vertex"] = 1.0 if pressure_force_mode == "pairwise-vertex-eos" else 0.0
+        nodal_mass = nodal_from_tets(points.shape[0], tets, tet_masses)
+        inertial_nodal_mass = np.maximum(float(inertia_scale) * (nodal_mass + inertial_mass_addition), 1.0e-18)
+        surface_points = points[surface_indices]
+        surface_forces, _surface_area_vectors, _fheron_equiv, _surface_volume = base.fheron_forces_for_points(
+            surface_points,
+            surface_faces,
+            gamma,
+        )
+        forces = np.zeros_like(points)
+        forces[surface_indices] += surface_forces
+        damping_forces = -damping_rate * inertial_nodal_mass[:, None] * velocities
+        if closure == "compressible" or incompressible_target_mode == "mass":
+            target_tet_volumes = tet_masses / float(rho)
+        else:
+            target_tet_volumes = reference_tet_volumes
+        pressure_matrix = pressure_force_matrix_for_mode(
+            pressure_force_mode,
+            points,
+            tets,
+            tet_volumes,
+            local_matrix,
+        )
+        pressure_solve_matrix = pressure_solve_matrix_for_mode(
+            pressure_force_mode,
+            pressure_matrix,
+            local_matrix,
+        )
+
+        if closure == "compressible":
+            if pressure_force_mode == "pairwise-vertex-eos":
+                base_pressures = np.full(points.shape[0], float(reference_pressure), dtype=float)
+            else:
+                base_pressures = np.full(tets.shape[0], float(reference_pressure), dtype=float)
+            nonpressure_forces = (
+                forces
+                + (pressure_matrix @ base_pressures).reshape(points.shape)
+                + damping_forces
+                + flux_forces
+            )
+            u_star = velocities + dt * nonpressure_forces / inertial_nodal_mass[:, None]
+            _stiffness, inv_mass_dof = base._local_volume_stiffness(local_matrix, inertial_nodal_mass)
+            compressibility = float(bulk_modulus) / np.maximum(reference_tet_volumes, 1.0e-300)
+            if coupled_flux_continuity and mass_flux_coupling and face_flux_mode == "cell-average":
+                mass_flux_matrix = linearized_mass_flux_matrix(
+                    points,
+                    tets,
+                    face_pairs,
+                    tet_masses,
+                    tet_volumes,
+                    reference_density=rho,
+                    mass_update_coupling=mass_flux_coupling,
+                )
+                continuity_matrix = local_matrix + float(flux_continuity_sign) * mass_flux_matrix / float(rho)
+            else:
+                continuity_matrix = local_matrix
+            if pressure_force_mode == "pairwise-vertex-eos":
+                vertex_average = tet_vertex_pressure_average_matrix(points.shape[0], tets)
+                nonpressure_forces = (
+                    forces
+                    + (pressure_matrix @ base_pressures).reshape(points.shape)
+                    + damping_forces
+                    + flux_forces
+                )
+                u_star = velocities + dt * nonpressure_forces / inertial_nodal_mass[:, None]
+                coupled_stiffness = (continuity_matrix * inv_mass_dof[None, :]) @ pressure_matrix
+                linear_volume_error = tet_volumes - target_tet_volumes + dt * (continuity_matrix @ u_star.reshape(-1))
+                system = vertex_average + (compressibility[:, None] * dt * dt) * coupled_stiffness
+                rhs = -compressibility * linear_volume_error
+                pressure_delta_vertices = solve_regularized_lstsq(system, rhs, relative=1.0e-6)
+                velocities = (
+                    u_star.reshape(-1)
+                    + dt * inv_mass_dof * (pressure_matrix @ pressure_delta_vertices)
+                ).reshape(velocities.shape)
+                collect.last_pressure = float(np.mean(vertex_average @ (base_pressures + pressure_delta_vertices)))  # type: ignore[attr-defined]
+            elif pressure_force_mode == "pairwise-dual-scalar":
+                pressure_direction = pressure_matrix @ np.ones(tets.shape[0], dtype=float)
+                linear_volume_error = tet_volumes - target_tet_volumes + dt * (continuity_matrix @ u_star.reshape(-1))
+                global_volume_error = float(np.sum(linear_volume_error))
+                global_compressibility = float(bulk_modulus) / max(float(np.sum(reference_tet_volumes)), 1.0e-300)
+                scalar_stiffness = float(np.sum(continuity_matrix @ (inv_mass_dof * pressure_direction)))
+                denom = 1.0 + float(dt) * float(dt) * global_compressibility * scalar_stiffness
+                pressure_delta_scalar = -global_compressibility * global_volume_error / max(denom, 1.0e-300)
+                velocities = (
+                    u_star.reshape(-1)
+                    + dt * inv_mass_dof * pressure_direction * float(pressure_delta_scalar)
+                ).reshape(velocities.shape)
+                collect.last_pressure = float(reference_pressure + pressure_delta_scalar)  # type: ignore[attr-defined]
+            else:
+                coupled_stiffness = (continuity_matrix * inv_mass_dof[None, :]) @ pressure_solve_matrix
+                linear_volume_error = tet_volumes - target_tet_volumes + dt * (continuity_matrix @ u_star.reshape(-1))
+                system = np.eye(tets.shape[0]) + (compressibility[:, None] * dt * dt) * coupled_stiffness
+                rhs = -compressibility * linear_volume_error
+                pressure_delta = base._solve_regularized(system, rhs)
+                velocities = (u_star.reshape(-1) + dt * inv_mass_dof * (pressure_matrix @ pressure_delta)).reshape(
+                    velocities.shape
+                )
+                collect.last_pressure = float(np.mean(base_pressures + pressure_delta))  # type: ignore[attr-defined]
+        else:
+            inv_mass_dof = np.repeat(1.0 / np.maximum(inertial_nodal_mass, 1.0e-300), 3)
+            target_rates = -(tet_volumes - target_tet_volumes) / float(dt)
+            velocity_vec = velocities.reshape(-1)
+            nonpressure_vec = (forces + damping_forces + flux_forces).reshape(-1)
+            pressure_stiffness = (local_matrix * inv_mass_dof[None, :]) @ pressure_solve_matrix
+            pressure_rhs = (
+                (target_rates - local_matrix @ velocity_vec) / float(dt)
+                - local_matrix @ (inv_mass_dof * nonpressure_vec)
+            )
+            pressure_values = base._solve_regularized(pressure_stiffness, pressure_rhs)
+            total_forces = (
+                forces
+                + (pressure_matrix @ pressure_values).reshape(points.shape)
+                + damping_forces
+                + flux_forces
+            )
+            velocities = velocities + dt * total_forces / inertial_nodal_mass[:, None]
+            velocities = project_local_volume_velocity_with_pressure_matrix(
+                velocities,
+                local_matrix,
+                pressure_solve_matrix,
+                inertial_nodal_mass,
+                target_rates,
+            )
+            collect.last_pressure = float(np.mean(pressure_values))  # type: ignore[attr-defined]
+
+        if flux_timing == "post-pressure":
+            tet_masses, post_flux_forces, last_flux = compute_ale_fluxes(
+                points,
+                velocities,
+                tets,
+                face_pairs,
+                tet_masses,
+                reference_tet_masses,
+                tet_volumes,
+                dt,
+                reference_density=rho,
+                sound_speed=sound_speed,
+                mass_floor_fraction=mass_floor_fraction,
+                mass_update_coupling=mass_flux_coupling,
+                momentum_force_coupling=momentum_flux_coupling,
+                density_change_limit=density_change_limit,
+                flux_cfl_limit=flux_cfl_limit,
+                flux_scheme=flux_scheme,
+                face_flux_mode=face_flux_mode,
+            )
+            last_flux["flux_post_pressure"] = 1.0
+            last_flux["mass_floor_fraction"] = float(mass_floor_fraction)
+            last_flux["coupled_flux_continuity"] = 1.0 if coupled_flux_continuity else 0.0
+            last_flux["flux_continuity_sign"] = float(flux_continuity_sign)
+            last_flux["pressure_force_pairwise_dual"] = 1.0 if pressure_force_mode != "volume-gradient" else 0.0
+            last_flux["pressure_force_scalar_pairwise"] = 1.0 if pressure_force_mode == "pairwise-dual-scalar" else 0.0
+            last_flux["pressure_force_forcefit_pairwise"] = 1.0 if pressure_force_mode == "pairwise-dual-forcefit" else 0.0
+            last_flux["pressure_solve_pairwise_dual"] = 1.0 if pressure_force_mode == "pairwise-dual-consistent" else 0.0
+            last_flux["pressure_solve_pairwise_vertex"] = 1.0 if pressure_force_mode == "pairwise-vertex-eos" else 0.0
+            if momentum_flux_coupling:
+                post_nodal_mass = nodal_from_tets(points.shape[0], tets, tet_masses)
+                post_inertial_mass = np.maximum(
+                    float(inertia_scale) * (post_nodal_mass + inertial_mass_addition),
+                    1.0e-18,
+                )
+                velocities = velocities + dt * post_flux_forces / post_inertial_mass[:, None]
+
+        points = points + dt * velocities
+        points, velocities = base._remove_rigid_translation(points, velocities, inertial_nodal_mass)
+
+        if not np.all(np.isfinite(points)) or not np.all(np.isfinite(velocities)):
+            raise FloatingPointError(f"{closure} flux run became non-finite at substep {substep}")
+
+        if substep % int(substeps_per_sample) == 0:
+            collect(sample_index, sample_index * float(t_final) / float(int(n_steps) - 1))
+            sample_index += 1
+
+    return rows, np.asarray(snapshots, dtype=float), surface_faces, tets, surface_indices, display_tets_snapshots
+
+
+def write_snapshots(
+    snapshots: np.ndarray,
+    faces: np.ndarray,
+    tets: np.ndarray,
+    surface_indices: np.ndarray,
+    out_dir: Path,
+    stem: str,
+    display_tets_snapshots: list[np.ndarray] | None = None,
+) -> Path:
+    path = out_dir / f"{stem}.npz"
+    payload: dict[str, np.ndarray] = {
+        "points": snapshots,
+        "faces": faces,
+        "tets": tets,
+        "surface_indices": surface_indices,
+    }
+    if display_tets_snapshots is not None:
+        payload["display_tets"] = np.asarray(display_tets_snapshots, dtype=object)
+    np.savez_compressed(path, **payload)
+    return path
+
+
+def write_flux_animation(
+    rows: list[dict[str, float]],
+    snapshots: np.ndarray,
+    faces: np.ndarray,
+    tets: np.ndarray,
+    surface_indices: np.ndarray,
+    out_dir: Path,
+    *,
+    radius: float,
+    closure: str,
+    max_frames: int,
+    fps: int,
+    display_tets_snapshots: list[np.ndarray] | None = None,
+) -> Path:
+    t = row_array(rows, "t")
+    amplitude_theory = row_array(rows, "shape_amplitude_theory")
+    amplitude_fit = row_array(rows, "shape_amplitude_fit")
+    global_volume_pct = (row_array(rows, "vol_rel") - 1.0) * 100.0
+    local_volume_pct = row_array(rows, "local_volume_rel_max_abs") * 100.0
+    density_spread_ppm = (row_array(rows, "nodal_density_rel_max") - row_array(rows, "nodal_density_rel_min")) * 1.0e6
+    mass_flux = row_array(rows, "mass_flux_l1_kg_s")
+    momentum_flux = row_array(rows, "momentum_flux_l1_n")
+    fheron = row_array(rows, "fheron_pressure_pa")
+    pressure = row_array(rows, "closure_pressure_pa")
+    ambient_pressure = row_array(rows, "ambient_pressure_pa")
+    display_tet_count = row_array(rows, "display_tet_count")
+    display_face_count = row_array(rows, "display_internal_face_count")
+    display_changed_tets = row_array(rows, "display_changed_tets")
+    display_changed_fraction = row_array(rows, "display_changed_fraction")
+    cpu_time = row_array(rows, "cpu_time_s")
+    cpu_ms = row_array(rows, "cpu_ms_per_substep")
+    limiter_scale = row_array(rows, "flux_limiter_scale")
+    density_limit = float(rows[0].get("density_change_limit", 0.0))
+    flux_scheme = "Rusanov" if float(rows[0].get("flux_scheme_rusanov", 0.0)) > 0.5 else "upwind"
+    face_flux_mode = "Lagrangian face" if float(rows[0].get("face_flux_lagrangian", 0.0)) > 0.5 else "cell-average face"
+    if float(rows[0].get("pressure_force_forcefit_pairwise", 0.0)) > 0.5:
+        pressure_force_label = "pairwise Aij fitted p"
+    elif float(rows[0].get("pressure_force_scalar_pairwise", 0.0)) > 0.5:
+        pressure_force_label = "pairwise Aij scalar p"
+    elif float(rows[0].get("pressure_solve_pairwise_vertex", 0.0)) > 0.5:
+        pressure_force_label = "pairwise Aij vertex p"
+    elif float(rows[0].get("pressure_force_pairwise_dual", 0.0)) > 0.5:
+        pressure_force_label = "pairwise Aij"
+    else:
+        pressure_force_label = "volume-gradient Bt"
+    cpu_total = float(cpu_time[-1])
+    cpu_avg = float(cpu_ms[-1])
+    active_retopology = float(rows[0].get("retriangulation_active", 0.0)) > 0.5
+    show_retriangulation = active_retopology or float(rows[0].get("retriangulation_diagnostic", 0.0)) > 0.5
+    retopo_prefix = "Active-retopology " if active_retopology else ""
+
+    if closure == "compressible":
+        facecolor = "#9ecae1"
+        edgecolor = "#1f77b4"
+        gif_name = "flux_compressible_sphere.gif"
+        title = f"{retopo_prefix}one-phase free-surface compressible EOS, {face_flux_mode} ALE flux"
+    else:
+        facecolor = "#fdd0a2"
+        edgecolor = "#ff7f0e"
+        gif_name = "flux_incompressible_sphere.gif"
+        title = f"{retopo_prefix}one-phase free-surface incompressible projection with ALE flux"
+
+    frame_indices = np.unique(np.linspace(0, len(rows) - 1, min(len(rows), max(2, int(max_frames))), dtype=int))
+    radial_max = max(float(row["radial_ratio_max"]) for row in rows)
+    limit = 1.15 * radial_max * float(radius)
+    time_ticks = np.linspace(float(t[0]), float(t[-1]), 5)
+    time_tick_labels = [f"{value:.3f}" for value in time_ticks]
+
+    fig = plt.figure(figsize=(10.4, 7.2))
+    grid = fig.add_gridspec(3, 2, width_ratios=(1.35, 1.0), wspace=0.27, hspace=0.50)
+    ax3d = fig.add_subplot(grid[:2, 0], projection="3d")
+    ax_info = fig.add_subplot(grid[2, 0])
+    ax_amp = fig.add_subplot(grid[0, 1])
+    ax_density = fig.add_subplot(grid[1, 1])
+    ax_flux = fig.add_subplot(grid[2, 1])
+
+    reference_surface = snapshots[0, surface_indices]
+
+    def draw(frame_pos: int) -> None:
+        row_idx = int(frame_indices[frame_pos])
+        points = snapshots[row_idx]
+        surface = points[surface_indices]
+        display_tets = (
+            np.asarray(display_tets_snapshots[row_idx], dtype=int)
+            if display_tets_snapshots is not None
+            else np.asarray(tets, dtype=int)
+        )
+        edge_indices = base.tet_edge_indices(display_tets, max_edges=280)
+        ax3d.cla()
+        ax_info.cla()
+        ax_amp.cla()
+        ax_density.cla()
+        ax_flux.cla()
+
+        ax3d.add_collection3d(
+            Poly3DCollection(
+                reference_surface[faces],
+                facecolor=(0.0, 0.0, 0.0, 0.025),
+                edgecolor=(0.25, 0.25, 0.25, 0.22),
+                linewidth=0.22,
+            )
+        )
+        ax3d.add_collection3d(
+            Poly3DCollection(
+                surface[faces],
+                facecolor=facecolor,
+                edgecolor=edgecolor,
+                linewidth=0.28,
+                alpha=0.46,
+            )
+        )
+        ax3d.add_collection3d(
+            Line3DCollection(points[edge_indices], colors=(0.1, 0.1, 0.1, 0.24), linewidths=0.32)
+        )
+        interior = np.setdiff1d(np.arange(points.shape[0], dtype=int), surface_indices)
+        center = interior[np.linalg.norm(points[interior], axis=1) <= 1.0e-12]
+        shells = np.setdiff1d(interior, center)
+        if shells.size:
+            shell_points = points[shells]
+            ax3d.scatter(
+                shell_points[:, 0],
+                shell_points[:, 1],
+                shell_points[:, 2],
+                s=12,
+                c="#2ca02c",
+                alpha=0.82,
+                edgecolors="none",
+                depthshade=False,
+            )
+        if center.size:
+            center_points = points[center]
+            ax3d.scatter(
+                center_points[:, 0],
+                center_points[:, 1],
+                center_points[:, 2],
+                s=22,
+                c="#111111",
+                edgecolors="white",
+                linewidths=0.35,
+                depthshade=False,
+            )
+        ax3d.set_xlim(-limit, limit)
+        ax3d.set_ylim(-limit, limit)
+        ax3d.set_zlim(-limit, limit)
+        ax3d.set_box_aspect((1.0, 1.0, 1.0))
+        ax3d.set_xticks([])
+        ax3d.set_yticks([])
+        ax3d.set_zticks([])
+        ax3d.set_title(title, fontsize=10)
+        ax3d.view_init(elev=20.0, azim=32.0 + 24.0 * float(t[row_idx]) / max(float(t[-1]), 1.0e-30))
+
+        ax_info.axis("off")
+        left = (
+            f"t = {t[row_idx]:.5f} s\n"
+            f"theory a2 = {amplitude_theory[row_idx]:+.4f}\n"
+            f"fit a2 = {amplitude_fit[row_idx]:+.4f}\n"
+            f"global dV/V0 = {global_volume_pct[row_idx]:+.3e} %\n"
+            f"max tet |dV|/V = {local_volume_pct[row_idx]:.3e} %\n"
+            f"rho spread = {density_spread_ppm[row_idx]:.3f} ppm\n"
+            f"mass flux L1 = {mass_flux[row_idx]:.3e} kg/s\n"
+            f"mom flux L1 = {momentum_flux[row_idx]:.3e} N\n"
+            f"flux limiter = {limiter_scale[row_idx]:.3e}\n"
+            f"retopology = {'active' if active_retopology else 'off/diagnostic'}"
+        )
+        retriangulation_line = (
+            f"display Delaunay = {display_tet_count[row_idx]:.0f} tets\n"
+            f"Delaunay flips = {display_changed_tets[row_idx]:.0f} ({100.0 * display_changed_fraction[row_idx]:.1f}%)"
+            if show_retriangulation
+            else f"display mesh = solver mesh\nsolver tets = {tets.shape[0]}"
+        )
+        right = (
+            f"solver mesh = {points.shape[0]} verts, {tets.shape[0]} tets\n"
+            f"{retriangulation_line}\n"
+            f"internal faces = {display_face_count[row_idx]:.0f}\n"
+            f"interior = {interior.size} verts\n"
+            f"flux = {flux_scheme}, {face_flux_mode}\n"
+            f"Fp = {pressure_force_label}\n"
+            f"rho limit = {100.0 * density_limit:.2f} %\n"
+            f"p_gas = {ambient_pressure[row_idx]:.0f} Pa\n"
+            f"p_gauge = {pressure[row_idx]:.3f} Pa\n"
+            f"FHeron = {fheron[row_idx]:.3f} Pa\n"
+            f"CPU = {cpu_time[row_idx]:.2f}/{cpu_total:.1f} s\n"
+            f"CPU/step = {cpu_ms[row_idx]:.2f} ms"
+        )
+        ax_info.text(0.02, 0.98, left, transform=ax_info.transAxes, va="top", ha="left", family="monospace", fontsize=7.6)
+        ax_info.text(0.52, 0.98, right, transform=ax_info.transAxes, va="top", ha="left", family="monospace", fontsize=7.6)
+
+        pad = max(0.1 * float(np.ptp(amplitude_theory)), 0.004)
+        ax_amp.plot(t, amplitude_theory, "k--", lw=1.6, label="Rayleigh theory")
+        ax_amp.plot(t, amplitude_fit, color=edgecolor, lw=1.8, label="Ftot + flux")
+        ax_amp.plot(t[row_idx], amplitude_fit[row_idx], "o", color="#d62728", ms=5.0)
+        ax_amp.set_xlim(float(t[0]), float(t[-1]))
+        ax_amp.set_xticks(time_ticks)
+        ax_amp.set_xticklabels(time_tick_labels)
+        ax_amp.set_ylim(float(min(np.min(amplitude_theory), np.min(amplitude_fit)) - pad), float(max(np.max(amplitude_theory), np.max(amplitude_fit)) + pad))
+        ax_amp.set_ylabel("a2")
+        ax_amp.set_title("Shape amplitude")
+        ax_amp.grid(True, alpha=0.25)
+        ax_amp.legend(frameon=False, fontsize=8, loc="upper right")
+
+        ax_density.plot(t, global_volume_pct, color=edgecolor, lw=1.8, label="global dV/V0")
+        ax_density.plot(t, local_volume_pct, color="0.3", lw=1.2, ls=":", label="max local tet")
+        ax_density.plot(t[row_idx], global_volume_pct[row_idx], "o", color="#d62728", ms=5.0)
+        ax_density.set_xlim(float(t[0]), float(t[-1]))
+        ax_density.set_xticks(time_ticks)
+        ax_density.set_xticklabels(time_tick_labels)
+        ymin = min(float(np.min(global_volume_pct)), float(np.min(local_volume_pct)))
+        ymax = max(float(np.max(global_volume_pct)), float(np.max(local_volume_pct)))
+        ypad = max(0.12 * (ymax - ymin), 1.0e-8)
+        ax_density.set_ylim(ymin - ypad, ymax + ypad)
+        ax_density.set_ylabel("percent")
+        ax_density.set_title("Global and local volume error")
+        ax_density.grid(True, alpha=0.25)
+        ax_density.legend(frameon=False, fontsize=8, loc="upper right")
+
+        mass_flux_plot = np.maximum(mass_flux, 1.0e-30)
+        momentum_flux_plot = np.maximum(momentum_flux, 1.0e-30)
+        ax_flux.plot(t, mass_flux_plot, color=edgecolor, lw=1.8, label="mass flux L1")
+        ax_flux_twin = ax_flux.twinx()
+        ax_flux_twin.plot(t, momentum_flux_plot, color="0.25", lw=1.2, ls=":", label="momentum flux L1")
+        ax_flux.plot(t[row_idx], max(mass_flux[row_idx], 1.0e-30), "o", color="#d62728", ms=5.0)
+        ax_flux.set_yscale("log")
+        ax_flux_twin.set_yscale("log")
+        mass_flux_max = max(float(np.max(mass_flux_plot)), 1.0e-30)
+        momentum_flux_max = max(float(np.max(momentum_flux_plot)), 1.0e-30)
+        ax_flux.set_ylim(max(mass_flux_max * 1.0e-6, 1.0e-30), mass_flux_max * 5.0)
+        ax_flux_twin.set_ylim(max(momentum_flux_max * 1.0e-6, 1.0e-30), momentum_flux_max * 5.0)
+        ax_flux.set_xlim(float(t[0]), float(t[-1]))
+        ax_flux.set_xticks(time_ticks)
+        ax_flux.set_xticklabels(time_tick_labels)
+        ax_flux.set_xlabel("t [s]")
+        ax_flux.set_ylabel("kg/s")
+        ax_flux_twin.set_ylabel("N")
+        ax_flux.set_title("Internal face fluxes")
+        ax_flux.grid(True, alpha=0.25)
+        lines, labels = ax_flux.get_legend_handles_labels()
+        lines2, labels2 = ax_flux_twin.get_legend_handles_labels()
+        ax_flux.legend(lines + lines2, labels + labels2, frameon=False, fontsize=8, loc="upper right")
+
+        fig.suptitle(
+            f"{closure.capitalize()} flux-aware run, CPU {cpu_total:.1f} s ({cpu_avg:.1f} ms/step)",
+            y=0.985,
+        )
+
+    animation = FuncAnimation(fig, draw, frames=len(frame_indices), interval=1000.0 / max(1, int(fps)))
+    gif_path = out_dir / gif_name
+    animation.save(gif_path, writer=PillowWriter(fps=max(1, int(fps))))
+    plt.close(fig)
+    return gif_path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Flux-aware FHeron compressible/incompressible droplet GIFs.")
+    parser.add_argument("--radius", type=float, default=1.0e-3)
+    parser.add_argument("--gamma", type=float, default=0.072)
+    parser.add_argument("--rho", type=float, default=1000.0)
+    parser.add_argument("--bulk-modulus", type=float, default=2.2e9)
+    parser.add_argument(
+        "--ambient-pressure",
+        type=float,
+        default=101325.0,
+        help="Passive gas/reference pressure [Pa]. Dynamics use liquid gauge pressure relative to this value.",
+    )
+    parser.add_argument("--rayleigh-mode", type=int, default=2)
+    parser.add_argument("--shape-mode-ar", type=float, default=1.05)
+    parser.add_argument(
+        "--t-final",
+        type=float,
+        default=None,
+        help="Physical simulation end time [s]. Default is one Rayleigh-Lamb period.",
+    )
+    parser.add_argument("--subdivision", type=int, default=0, help="0 is fast and still has two interior shells.")
+    parser.add_argument("--steps", type=int, default=41)
+    parser.add_argument("--substeps-per-sample", type=int, default=20)
+    parser.add_argument("--damping-ratio", type=float, default=0.015)
+    parser.add_argument(
+        "--mass-model",
+        choices=("star-volume", "rayleigh-added"),
+        default="star-volume",
+        help="Vertex inertia model. rayleigh-added reproduces Rayleigh-Lamb inertia while tet mass remains physical.",
+    )
+    parser.add_argument(
+        "--inertia-scale",
+        type=float,
+        default=1.0,
+        help="Scale only the vertex inertial mass used by Ftot integration; tet mass/density/flux stay unchanged.",
+    )
+    parser.add_argument(
+        "--mass-flux-coupling",
+        type=float,
+        default=1.0e-6,
+        help="Fraction of computed ALE mass flux used to update cell/nodal masses.",
+    )
+    parser.add_argument(
+        "--momentum-flux-coupling",
+        type=float,
+        default=0.0,
+        help="Fraction of computed momentum flux applied as nodal force. Default keeps it diagnostic.",
+    )
+    parser.add_argument(
+        "--density-change-limit",
+        type=float,
+        default=None,
+        help="Optional conservative limiter for |rho/rho0 - 1|. Example: 0.01 allows 1 percent.",
+    )
+    parser.add_argument(
+        "--flux-cfl-limit",
+        type=float,
+        default=0.25,
+        help="Limit the mass transferred by internal flux in one substep as a fraction of cell mass.",
+    )
+    parser.add_argument(
+        "--flux-scheme",
+        choices=("upwind", "rusanov"),
+        default="upwind",
+        help="Internal ALE face flux scheme. Rusanov adds acoustic numerical diffusion.",
+    )
+    parser.add_argument(
+        "--face-flux-mode",
+        choices=("cell-average", "lagrangian"),
+        default="cell-average",
+        help="Use old cell-averaged face flux or Lagrangian material-face flux.",
+    )
+    parser.add_argument(
+        "--flux-timing",
+        choices=("pre-pressure", "post-pressure"),
+        default="pre-pressure",
+        help="Apply active flux before the pressure solve or as an operator-split update after pressure.",
+    )
+    parser.add_argument(
+        "--mass-floor-fraction",
+        type=float,
+        default=0.35,
+        help="Minimum tet mass as a fixed fraction of the initial tet mass.",
+    )
+    parser.add_argument(
+        "--coupled-flux-continuity",
+        action="store_true",
+        help="Include the linearized active mass flux in the compressible EOS pressure-correction equation.",
+    )
+    parser.add_argument(
+        "--flux-continuity-sign",
+        type=float,
+        default=-1.0,
+        help="Sign for the mass-flux term in the coupled continuity operator; -1 gives B - G/rho0.",
+    )
+    parser.add_argument(
+        "--incompressible-target-mode",
+        choices=("reference", "mass"),
+        default="reference",
+        help="For incompressible closure, project to fixed reference tet volumes or Vtar=m_t/rho after mass flux.",
+    )
+    parser.add_argument(
+        "--pressure-force-mode",
+        choices=(
+            "volume-gradient",
+            "pairwise-dual",
+            "pairwise-dual-scalar",
+            "pairwise-dual-forcefit",
+            "pairwise-dual-consistent",
+            "pairwise-vertex-eos",
+        ),
+        default="volume-gradient",
+        help=(
+            "Use tet volume-gradient pressure force, pairwise -0.5(p_i+p_j) A_ij force "
+            "with mapped vertex pressure, pairwise scalar-pressure force, fitted vertex pressure, "
+            "fully pairwise-consistent solve, or direct vertex-pressure EOS solve."
+        ),
+    )
+    parser.add_argument(
+        "--retriangulation-mode",
+        choices=("none", "diagnostic", "active"),
+        default="none",
+        help=(
+            "none: fixed solver tets; diagnostic: Delaunay display mesh only; "
+            "active: rebuild solver tets each substep and remap mass/target volumes."
+        ),
+    )
+    parser.add_argument(
+        "--closure",
+        choices=("both", "compressible", "incompressible"),
+        default="both",
+        help="Run both closures or just one closure.",
+    )
+    parser.add_argument("--animation-max-frames", type=int, default=32)
+    parser.add_argument("--animation-fps", type=int, default=12)
+    parser.add_argument("--out-dir", type=Path, default=SCRIPT_DIR / "out" / "sphere_fheron_flux_fv")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    omega, frequency, period = base.rayleigh_lamb_frequency(args.rayleigh_mode, args.gamma, args.rho, args.radius)
+    t_final = float(args.t_final) if args.t_final is not None else period
+    amplitude = base.shape_amplitude_from_aspect_ratio(args.shape_mode_ar)
+
+    outputs: list[Path] = []
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        closures = ("compressible", "incompressible") if args.closure == "both" else (args.closure,)
+        for closure in closures:
+            rows, snapshots, faces, tets, surface_indices, display_tets_snapshots = run_flux_dynamic(
+                closure=closure,
+                subdivisions=args.subdivision,
+                radius=args.radius,
+                gamma=args.gamma,
+                rho=args.rho,
+                bulk_modulus=args.bulk_modulus,
+                amplitude=amplitude,
+                n_steps=args.steps,
+                t_final=t_final,
+                substeps_per_sample=args.substeps_per_sample,
+                damping_ratio=args.damping_ratio,
+                mass_model=args.mass_model,
+                inertia_scale=args.inertia_scale,
+                mass_flux_coupling=args.mass_flux_coupling,
+                momentum_flux_coupling=args.momentum_flux_coupling,
+                density_change_limit=args.density_change_limit,
+                flux_cfl_limit=args.flux_cfl_limit,
+                flux_scheme=args.flux_scheme,
+                flux_timing=args.flux_timing,
+                face_flux_mode=args.face_flux_mode,
+                mass_floor_fraction=args.mass_floor_fraction,
+                coupled_flux_continuity=args.coupled_flux_continuity,
+                flux_continuity_sign=args.flux_continuity_sign,
+                incompressible_target_mode=args.incompressible_target_mode,
+                pressure_force_mode=args.pressure_force_mode,
+                rayleigh_frequency_hz=frequency,
+                rayleigh_omega_rad_s=omega,
+                rayleigh_mode=args.rayleigh_mode,
+                ambient_pressure=args.ambient_pressure,
+                retriangulation_mode=args.retriangulation_mode,
+            )
+            csv_path, json_path = write_rows(rows, args.out_dir, f"flux_{closure}_timeseries")
+            npz_path = write_snapshots(
+                snapshots,
+                faces,
+                tets,
+                surface_indices,
+                args.out_dir,
+                f"flux_{closure}_snapshots",
+                display_tets_snapshots,
+            )
+            gif_path = write_flux_animation(
+                rows,
+                snapshots,
+                faces,
+                tets,
+                surface_indices,
+                args.out_dir,
+                radius=args.radius,
+                closure=closure,
+                max_frames=args.animation_max_frames,
+                fps=args.animation_fps,
+                display_tets_snapshots=display_tets_snapshots,
+            )
+            outputs.extend([csv_path, json_path, npz_path, gif_path])
+            print(
+                f"{closure}: CPU={rows[-1]['cpu_time_s']:.3f}s, "
+                f"ms/step={rows[-1]['cpu_ms_per_substep']:.3f}, "
+                f"mass_flux_L1={rows[-1]['mass_flux_l1_kg_s']:.3e}, "
+                f"mom_flux_L1={rows[-1]['momentum_flux_l1_n']:.3e}"
+            )
+
+    for path in outputs:
+        print(path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cases_dynamic/oscillating_droplet_p_ref/scripts/sphere_fheron_flux_fv_ddgclib_benchmark.py
+++ b/cases_dynamic/oscillating_droplet_p_ref/scripts/sphere_fheron_flux_fv_ddgclib_benchmark.py
@@ -1,0 +1,1518 @@
+"""ddgclib-operator-backed flux-aware HC/FHeron droplet benchmark.
+
+This is a separate finite-volume/ALE-style diagnostic from
+``sphere_fheron_eos_projection_benchmark.py``.  It keeps the same HC Heron
+surface force, but updates nodal mass, nodal dual volume, nodal density, and
+boundary area vectors every step.  It also computes internal tet-face mass and
+momentum fluxes.
+
+The flux model here is deliberately compact for a benchmark GIF.  It is not a
+production CFD discretization.
+
+This copy keeps the old benchmark file untouched, but routes the force,
+volume-gradient pressure, ALE flux, and active-retopology remap through new
+non-breaking ddgclib operator functions added under ``ddgclib.operators``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+from pathlib import Path
+import sys
+import time
+import warnings
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from ddgclib.operators import stress as ddg_stress
+
+import sphere_fheron_eos_projection_benchmark as base
+
+plt = base.plt
+FuncAnimation = base.FuncAnimation
+PillowWriter = base.PillowWriter
+Line3DCollection = base.Line3DCollection
+Poly3DCollection = base.Poly3DCollection
+ScalarFormatter = base.ScalarFormatter
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+def install_ddgclib_operator_aliases() -> None:
+    """Route benchmark kernels through ddgclib operator add-ons.
+
+    The old benchmark file stays untouched.  This runner uses ddgclib
+    operators for:
+    - HC/FHeron interface force, Heron (curvature force)
+    - B=dV/dx tet-volume pressure/continuity operator, Chorin/Temam style
+    - ALE material-face flux, Hirt-Amsden-Cook/Toro
+    - active Delaunay retopology remap, tet-volume lumping workaround
+    """
+    global tet_face_pairs, delaunay_tets_for_points, nodal_from_tets, compute_ale_fluxes
+
+    base.fheron_forces_for_points = ddg_stress.heron_forces_for_points
+    base.tet_cell_volumes = ddg_stress.tet_cell_volumes
+    base.tet_volume_matrix = ddg_stress.tet_volume_matrix
+    base.lump_tet_masses = ddg_stress.lump_tet_masses
+    base._local_volume_stiffness = ddg_stress.local_volume_stiffness
+    base._solve_regularized = ddg_stress.solve_regularized
+
+    tet_face_pairs = ddg_stress.tet_face_pairs
+    delaunay_tets_for_points = ddg_stress.delaunay_retriangulate_points
+    nodal_from_tets = ddg_stress.tet_volume_lumped_nodal_values
+    compute_ale_fluxes = ddg_stress.tet_face_ale_fluxes
+
+
+def tet_face_pairs(tets: np.ndarray) -> list[tuple[np.ndarray, int, int]]:
+    """Return internal faces as ``(face_vertices, left_tet, right_tet)``."""
+    face_map: dict[tuple[int, int, int], list[int]] = {}
+    for tet_idx, tet in enumerate(np.asarray(tets, dtype=int)):
+        a, b, c, d = [int(index) for index in tet]
+        for face in ((a, b, c), (a, b, d), (a, c, d), (b, c, d)):
+            face_map.setdefault(tuple(sorted(face)), []).append(tet_idx)
+    pairs: list[tuple[np.ndarray, int, int]] = []
+    for face, owners in face_map.items():
+        if len(owners) == 2:
+            pairs.append((np.asarray(face, dtype=int), int(owners[0]), int(owners[1])))
+    return pairs
+
+
+def canonical_tet_set(tets: np.ndarray) -> set[tuple[int, int, int, int]]:
+    return {tuple(sorted(int(index) for index in tet)) for tet in np.asarray(tets, dtype=int)}
+
+
+def delaunay_tets_for_points(points: np.ndarray, fallback_tets: np.ndarray) -> np.ndarray:
+    """Fresh Delaunay tets for diagnostics without changing material masses."""
+    try:
+        triangulation = base.Delaunay(np.asarray(points, dtype=float), qhull_options="Qbb Qc")
+        raw_tets = np.asarray(triangulation.simplices, dtype=int)
+        valid = np.all(raw_tets < points.shape[0], axis=1)
+        raw_tets = raw_tets[valid]
+        if raw_tets.size == 0:
+            return np.asarray(fallback_tets, dtype=int).copy()
+        volumes = base.tet_cell_volumes(points, raw_tets)
+        positive = volumes[volumes > 0.0]
+        min_volume = 0.1 * float(np.median(positive)) if positive.size else 0.0
+        filtered = raw_tets[volumes > min_volume]
+        if filtered.size == 0:
+            return np.asarray(fallback_tets, dtype=int).copy()
+        return np.asarray(filtered, dtype=int)
+    except Exception:
+        return np.asarray(fallback_tets, dtype=int).copy()
+
+
+def nodal_from_tets(n_vertices: int, tets: np.ndarray, tet_values: np.ndarray) -> np.ndarray:
+    nodal = np.zeros(n_vertices, dtype=float)
+    for tet, value in zip(np.asarray(tets, dtype=int), np.asarray(tet_values, dtype=float)):
+        share = 0.25 * float(value)
+        for vertex_idx in tet:
+            nodal[int(vertex_idx)] += share
+    return nodal
+
+
+def current_area_vectors(
+    points: np.ndarray,
+    surface_indices: np.ndarray,
+    surface_faces: np.ndarray,
+) -> np.ndarray:
+    area_vectors = np.zeros_like(points)
+    area_vectors[np.asarray(surface_indices, dtype=int)] = base.vertex_area_vectors(
+        points[np.asarray(surface_indices, dtype=int)],
+        surface_faces,
+    )
+    return area_vectors
+
+
+def compute_ale_fluxes(
+    points: np.ndarray,
+    velocities: np.ndarray,
+    tets: np.ndarray,
+    face_pairs: list[tuple[np.ndarray, int, int]],
+    tet_masses: np.ndarray,
+    reference_tet_masses: np.ndarray,
+    tet_volumes: np.ndarray,
+    dt: float,
+    *,
+    reference_density: float,
+    sound_speed: float,
+    mass_floor_fraction: float = 0.35,
+    mass_update_coupling: float = 0.02,
+    momentum_force_coupling: float = 0.0,
+    density_change_limit: float | None = None,
+    flux_cfl_limit: float = 0.25,
+    flux_scheme: str = "upwind",
+    face_flux_mode: str = "cell-average",
+) -> tuple[np.ndarray, np.ndarray, dict[str, float]]:
+    """Compute internal ALE face mass/momentum flux and update cell masses."""
+    if flux_scheme not in {"upwind", "rusanov"}:
+        raise ValueError("flux_scheme must be 'upwind' or 'rusanov'")
+    if face_flux_mode not in {"cell-average", "lagrangian"}:
+        raise ValueError("face_flux_mode must be 'cell-average' or 'lagrangian'")
+
+    n_tets = np.asarray(tets).shape[0]
+    cell_centers = np.mean(points[np.asarray(tets, dtype=int)], axis=1)
+    cell_velocities = np.mean(velocities[np.asarray(tets, dtype=int)], axis=1)
+    cell_density = np.asarray(tet_masses, dtype=float) / np.maximum(tet_volumes, 1.0e-300)
+
+    dm_dt = np.zeros(n_tets, dtype=float)
+    cell_force = np.zeros((n_tets, 3), dtype=float)
+    mass_flux_l1 = 0.0
+    max_abs_mass_flux = 0.0
+    momentum_flux_l1 = 0.0
+    volume_flux_l1 = 0.0
+
+    for face_vertices, left, right in face_pairs:
+        pa, pb, pc = points[face_vertices]
+        area_vec = 0.5 * np.cross(pb - pa, pc - pa)
+        center_delta = cell_centers[right] - cell_centers[left]
+        if float(np.dot(area_vec, center_delta)) < 0.0:
+            area_vec = -area_vec
+
+        area = float(np.linalg.norm(area_vec))
+        if area <= 0.0:
+            continue
+        normal = area_vec / area
+        mesh_face_velocity = np.mean(velocities[face_vertices], axis=0)
+        left_velocity = cell_velocities[left]
+        right_velocity = cell_velocities[right]
+        left_density = float(cell_density[left])
+        right_density = float(cell_density[right])
+
+        if face_flux_mode == "lagrangian":
+            # In a Lagrangian vertex mesh the material face velocity is the
+            # mesh-face velocity.  This preserves the ALE geometric conservation
+            # law and prevents artificial inter-tet flux from cell averaging.
+            relative_volume_flux = 0.0
+            mass_flux = 0.0
+            momentum_flux = np.zeros(3, dtype=float)
+
+        elif flux_scheme == "rusanov":
+            left_relative_normal = float(np.dot(left_velocity - mesh_face_velocity, normal))
+            right_relative_normal = float(np.dot(right_velocity - mesh_face_velocity, normal))
+            max_wave_speed = max(
+                abs(left_relative_normal) + float(sound_speed),
+                abs(right_relative_normal) + float(sound_speed),
+                1.0e-30,
+            )
+            mass_flux = area * (
+                0.5 * (left_density * left_relative_normal + right_density * right_relative_normal)
+                - 0.5 * max_wave_speed * (right_density - left_density)
+            )
+            momentum_flux = area * (
+                0.5 * (left_density * left_velocity * left_relative_normal + right_density * right_velocity * right_relative_normal)
+                - 0.5 * max_wave_speed * (right_density * right_velocity - left_density * left_velocity)
+            )
+            relative_volume_flux = mass_flux / max(0.5 * (left_density + right_density), 1.0e-300)
+        else:
+            fluid_face_velocity = 0.5 * (left_velocity + right_velocity)
+            relative_volume_flux = float(np.dot(fluid_face_velocity - mesh_face_velocity, area_vec))
+            if relative_volume_flux >= 0.0:
+                density = left_density
+                upwind_velocity = left_velocity
+            else:
+                density = right_density
+                upwind_velocity = right_velocity
+            mass_flux = density * relative_volume_flux
+            momentum_flux = mass_flux * upwind_velocity
+
+        dm_dt[left] -= mass_flux
+        dm_dt[right] += mass_flux
+        cell_force[left] -= momentum_flux
+        cell_force[right] += momentum_flux
+
+        abs_mass_flux = abs(float(mass_flux))
+        mass_flux_l1 += abs_mass_flux
+        max_abs_mass_flux = max(max_abs_mass_flux, abs_mass_flux)
+        momentum_flux_l1 += float(np.linalg.norm(momentum_flux))
+        volume_flux_l1 += abs(float(relative_volume_flux))
+
+    effective_dm_dt = float(mass_update_coupling) * dm_dt
+    effective_cell_force = float(momentum_force_coupling) * cell_force
+
+    scale = 1.0
+    mass_delta = float(dt) * effective_dm_dt
+    mass_abs_delta = np.abs(mass_delta)
+    if flux_cfl_limit > 0.0 and np.any(mass_abs_delta > 0.0):
+        cfl_scale = np.min(
+            float(flux_cfl_limit) * np.asarray(tet_masses, dtype=float)[mass_abs_delta > 0.0]
+            / mass_abs_delta[mass_abs_delta > 0.0]
+        )
+        scale = min(scale, max(0.0, float(cfl_scale)))
+
+    floors = float(mass_floor_fraction) * np.asarray(reference_tet_masses, dtype=float)
+    proposed = np.asarray(tet_masses, dtype=float) + mass_delta
+    floor_bad = proposed < floors
+    if np.any(floor_bad):
+        denom = -mass_delta[floor_bad]
+        valid = denom > 0.0
+        if np.any(valid):
+            floor_scale = np.min((tet_masses[floor_bad][valid] - floors[floor_bad][valid]) / denom[valid])
+            scale = min(scale, max(0.0, float(floor_scale)))
+
+    if density_change_limit is not None and density_change_limit > 0.0:
+        lower_masses = (1.0 - float(density_change_limit)) * float(reference_density) * np.maximum(
+            tet_volumes,
+            1.0e-300,
+        )
+        upper_masses = (1.0 + float(density_change_limit)) * float(reference_density) * np.maximum(
+            tet_volumes,
+            1.0e-300,
+        )
+        increasing_too_much = (mass_delta > 0.0) & (proposed > upper_masses)
+        if np.any(increasing_too_much):
+            density_scale = np.min(
+                (upper_masses[increasing_too_much] - tet_masses[increasing_too_much])
+                / mass_delta[increasing_too_much]
+            )
+            scale = min(scale, max(0.0, float(density_scale)))
+        decreasing_too_much = (mass_delta < 0.0) & (proposed < lower_masses)
+        if np.any(decreasing_too_much):
+            density_scale = np.min(
+                (lower_masses[decreasing_too_much] - tet_masses[decreasing_too_much])
+                / mass_delta[decreasing_too_much]
+            )
+            scale = min(scale, max(0.0, float(density_scale)))
+
+    effective_dm_dt *= scale
+    effective_cell_force *= scale
+
+    updated_masses = np.maximum(np.asarray(tet_masses, dtype=float) + float(dt) * effective_dm_dt, floors)
+    nodal_flux_force = np.zeros_like(points)
+    for tet, force in zip(np.asarray(tets, dtype=int), effective_cell_force):
+        for vertex_idx in tet:
+            nodal_flux_force[int(vertex_idx)] += 0.25 * force
+
+    stats = {
+        "mass_flux_l1_kg_s": float(mass_flux_l1),
+        "mass_flux_max_kg_s": float(max_abs_mass_flux),
+        "momentum_flux_l1_n": float(momentum_flux_l1),
+        "volume_flux_l1_m3_s": float(volume_flux_l1),
+        "flux_limiter_scale": float(scale),
+        "mass_update_coupling": float(mass_update_coupling),
+        "momentum_force_coupling": float(momentum_force_coupling),
+        "density_change_limit": float(density_change_limit) if density_change_limit is not None else 0.0,
+        "flux_cfl_limit": float(flux_cfl_limit),
+        "flux_scheme_rusanov": 1.0 if flux_scheme == "rusanov" else 0.0,
+        "face_flux_lagrangian": 1.0 if face_flux_mode == "lagrangian" else 0.0,
+    }
+    return updated_masses, nodal_flux_force, stats
+
+
+def linearized_mass_flux_matrix(
+    points: np.ndarray,
+    tets: np.ndarray,
+    face_pairs: list[tuple[np.ndarray, int, int]],
+    tet_masses: np.ndarray,
+    tet_volumes: np.ndarray,
+    *,
+    reference_density: float,
+    mass_update_coupling: float,
+) -> np.ndarray:
+    """Linearized ALE mass-flux operator ``dm_dt = G u`` for the pressure solve."""
+    n_tets = np.asarray(tets).shape[0]
+    n_dof = np.asarray(points).shape[0] * 3
+    matrix = np.zeros((n_tets, n_dof), dtype=float)
+    if not face_pairs or mass_update_coupling == 0.0:
+        return matrix
+
+    cell_centers = np.mean(points[np.asarray(tets, dtype=int)], axis=1)
+    cell_density = np.asarray(tet_masses, dtype=float) / np.maximum(tet_volumes, 1.0e-300)
+    for face_vertices, left, right in face_pairs:
+        pa, pb, pc = points[face_vertices]
+        area_vec = 0.5 * np.cross(pb - pa, pc - pa)
+        center_delta = cell_centers[right] - cell_centers[left]
+        if float(np.dot(area_vec, center_delta)) < 0.0:
+            area_vec = -area_vec
+        if float(np.linalg.norm(area_vec)) <= 0.0:
+            continue
+
+        rho_face = max(0.5 * (float(cell_density[left]) + float(cell_density[right])), 1.0e-12)
+        weights: dict[int, float] = {}
+        for vertex_idx in np.asarray(tets[left], dtype=int):
+            weights[int(vertex_idx)] = weights.get(int(vertex_idx), 0.0) + 0.125
+        for vertex_idx in np.asarray(tets[right], dtype=int):
+            weights[int(vertex_idx)] = weights.get(int(vertex_idx), 0.0) + 0.125
+        for vertex_idx in np.asarray(face_vertices, dtype=int):
+            weights[int(vertex_idx)] = weights.get(int(vertex_idx), 0.0) - 1.0 / 3.0
+
+        for vertex_idx, weight in weights.items():
+            for component in range(3):
+                coefficient = float(mass_update_coupling) * rho_face * float(weight) * float(area_vec[component])
+                dof = 3 * int(vertex_idx) + component
+                matrix[int(left), dof] -= coefficient
+                matrix[int(right), dof] += coefficient
+    return matrix
+
+
+def barycentric_edge_dual_areas(points: np.ndarray, tets: np.ndarray) -> dict[tuple[int, int], np.ndarray]:
+    """Barycentric dual-face area vectors ``A_ij`` for mesh vertex pairs.
+
+    The returned vector is oriented from the lower vertex index toward the
+    higher vertex index.  For vertex ``i`` the pairwise pressure force uses
+    ``A_ij`` outward from ``i``; the sign is flipped automatically when
+    ``i`` is the higher-index endpoint.
+    """
+    edge_areas: dict[tuple[int, int], np.ndarray] = {}
+    pts = np.asarray(points, dtype=float)
+    for tet in np.asarray(tets, dtype=int):
+        centroid = np.mean(pts[tet], axis=0)
+        for a_local in range(4):
+            for b_local in range(a_local + 1, 4):
+                i = int(tet[a_local])
+                j = int(tet[b_local])
+                other = [int(tet[k]) for k in range(4) if k not in (a_local, b_local)]
+                k, l = other
+                midpoint = 0.5 * (pts[i] + pts[j])
+                face_centroid_1 = (pts[i] + pts[j] + pts[k]) / 3.0
+                face_centroid_2 = (pts[i] + pts[j] + pts[l]) / 3.0
+                area_vec = (
+                    0.5 * np.cross(face_centroid_1 - midpoint, centroid - midpoint)
+                    + 0.5 * np.cross(centroid - midpoint, face_centroid_2 - midpoint)
+                )
+                if float(np.dot(area_vec, pts[j] - pts[i])) < 0.0:
+                    area_vec = -area_vec
+                if i < j:
+                    key = (i, j)
+                    oriented = area_vec
+                else:
+                    key = (j, i)
+                    oriented = -area_vec
+                edge_areas[key] = edge_areas.get(key, np.zeros(3, dtype=float)) + oriented
+    return edge_areas
+
+
+def tet_pressure_to_vertex_weights(n_vertices: int, tets: np.ndarray, tet_volumes: np.ndarray) -> np.ndarray:
+    """Volume-weighted map from tet pressure values to vertex pressure values."""
+    n_tets = int(np.asarray(tets).shape[0])
+    weights = np.zeros((int(n_vertices), n_tets), dtype=float)
+    incident = np.zeros(int(n_vertices), dtype=float)
+    for tet_idx, tet in enumerate(np.asarray(tets, dtype=int)):
+        volume = max(float(tet_volumes[int(tet_idx)]), 1.0e-300)
+        for vertex_idx in tet:
+            weights[int(vertex_idx), int(tet_idx)] += volume
+            incident[int(vertex_idx)] += volume
+    weights /= np.maximum(incident[:, None], 1.0e-300)
+    return weights
+
+
+def pairwise_pressure_force_matrix(
+    points: np.ndarray,
+    tets: np.ndarray,
+    tet_volumes: np.ndarray,
+) -> np.ndarray:
+    """Linear force matrix for ``F_i^p = sum_j -0.5(p_i+p_j) A_ij``."""
+    n_vertices = int(np.asarray(points).shape[0])
+    n_tets = int(np.asarray(tets).shape[0])
+    pressure_weights = tet_pressure_to_vertex_weights(n_vertices, tets, tet_volumes)
+    matrix = np.zeros((3 * n_vertices, n_tets), dtype=float)
+    for (i, j), area_vec in barycentric_edge_dual_areas(points, tets).items():
+        coefficient = -0.5 * (pressure_weights[int(i)] + pressure_weights[int(j)])
+        for component in range(3):
+            force_coeff = coefficient * float(area_vec[component])
+            matrix[3 * int(i) + component] += force_coeff
+            matrix[3 * int(j) + component] -= force_coeff
+    return matrix
+
+
+def pairwise_vertex_pressure_matrix(points: np.ndarray, tets: np.ndarray) -> np.ndarray:
+    """Force matrix for vertex pressures in ``-0.5(p_i+p_j) A_ij``."""
+    n_vertices = int(np.asarray(points).shape[0])
+    matrix = np.zeros((3 * n_vertices, n_vertices), dtype=float)
+    for (i, j), area_vec in barycentric_edge_dual_areas(points, tets).items():
+        for component in range(3):
+            coefficient = -0.5 * float(area_vec[component])
+            matrix[3 * int(i) + component, int(i)] += coefficient
+            matrix[3 * int(i) + component, int(j)] += coefficient
+            matrix[3 * int(j) + component, int(i)] -= coefficient
+            matrix[3 * int(j) + component, int(j)] -= coefficient
+    return matrix
+
+
+def tet_vertex_pressure_average_matrix(n_vertices: int, tets: np.ndarray) -> np.ndarray:
+    """Map vertex pressures to tet pressures by arithmetic vertex average."""
+    n_tets = int(np.asarray(tets).shape[0])
+    matrix = np.zeros((n_tets, int(n_vertices)), dtype=float)
+    for tet_idx, tet in enumerate(np.asarray(tets, dtype=int)):
+        for vertex_idx in tet:
+            matrix[int(tet_idx), int(vertex_idx)] += 0.25
+    return matrix
+
+
+def solve_regularized_lstsq(matrix: np.ndarray, rhs: np.ndarray, *, relative: float = 1.0e-12) -> np.ndarray:
+    """Least-squares solve with small Tikhonov regularization for rectangular systems."""
+    lhs = np.asarray(matrix, dtype=float)
+    rhs_array = np.asarray(rhs, dtype=float)
+    scale = max(float(np.mean(np.abs(lhs))) if lhs.size else 0.0, 1.0e-30)
+    damping = math.sqrt(float(relative) * scale)
+    augmented = np.vstack([lhs, damping * np.eye(lhs.shape[1])])
+    augmented_rhs = np.concatenate([rhs_array, np.zeros(lhs.shape[1], dtype=float)])
+    return np.linalg.lstsq(augmented, augmented_rhs, rcond=1.0e-12)[0]
+
+
+def pairwise_forcefit_pressure_matrix(
+    points: np.ndarray,
+    tets: np.ndarray,
+    local_matrix: np.ndarray,
+) -> np.ndarray:
+    """Map tet pressures to vertex-pair forces via fitted vertex pressures."""
+    vertex_matrix = pairwise_vertex_pressure_matrix(points, tets)
+    pressure_transfer = np.linalg.lstsq(vertex_matrix, np.asarray(local_matrix.T, dtype=float), rcond=1.0e-12)[0]
+    return vertex_matrix @ pressure_transfer
+
+
+def pressure_force_matrix_for_mode(
+    mode: str,
+    points: np.ndarray,
+    tets: np.ndarray,
+    tet_volumes: np.ndarray,
+    local_matrix: np.ndarray,
+) -> np.ndarray:
+    if mode == "volume-gradient":
+        return np.asarray(local_matrix.T, dtype=float)
+    if mode in {"pairwise-dual", "pairwise-dual-consistent"}:
+        return pairwise_pressure_force_matrix(points, tets, tet_volumes)
+    if mode == "pairwise-vertex-eos":
+        return pairwise_vertex_pressure_matrix(points, tets)
+    if mode == "pairwise-dual-scalar":
+        pairwise_matrix = pairwise_pressure_force_matrix(points, tets, tet_volumes)
+        uniform_force = pairwise_matrix @ np.ones(int(np.asarray(tets).shape[0]), dtype=float)
+        scalar_average = np.full(int(np.asarray(tets).shape[0]), 1.0 / float(np.asarray(tets).shape[0]))
+        return np.outer(uniform_force, scalar_average)
+    if mode == "pairwise-dual-forcefit":
+        return pairwise_forcefit_pressure_matrix(points, tets, local_matrix)
+    raise ValueError(
+        "pressure_force_mode must be volume-gradient, pairwise-dual, "
+        "pairwise-dual-scalar, pairwise-dual-forcefit, pairwise-dual-consistent, "
+        "or pairwise-vertex-eos"
+    )
+
+
+def pressure_solve_matrix_for_mode(
+    mode: str,
+    pressure_force_matrix: np.ndarray,
+    local_matrix: np.ndarray,
+) -> np.ndarray:
+    if mode in {"pairwise-dual-consistent", "pairwise-vertex-eos"}:
+        return pressure_force_matrix
+    return np.asarray(local_matrix.T, dtype=float)
+
+
+def project_local_volume_velocity_with_pressure_matrix(
+    velocities: np.ndarray,
+    volume_matrix: np.ndarray,
+    pressure_force_matrix: np.ndarray,
+    masses: np.ndarray,
+    target_rates: np.ndarray,
+) -> np.ndarray:
+    velocity_vec = velocities.reshape(-1)
+    inv_mass_dof = np.repeat(1.0 / np.maximum(masses, 1.0e-300), 3)
+    stiffness = (volume_matrix * inv_mass_dof[None, :]) @ pressure_force_matrix
+    rhs = volume_matrix @ velocity_vec - np.asarray(target_rates, dtype=float)
+    multipliers = base._solve_regularized(stiffness, rhs)
+    projected_vec = velocity_vec - inv_mass_dof * (pressure_force_matrix @ multipliers)
+    return projected_vec.reshape(velocities.shape)
+
+
+def row_array(rows: list[dict[str, float]], key: str) -> np.ndarray:
+    return np.asarray([float(row[key]) for row in rows], dtype=float)
+
+
+def write_rows(rows: list[dict[str, float]], out_dir: Path, stem: str) -> tuple[Path, Path]:
+    csv_path = out_dir / f"{stem}.csv"
+    json_path = out_dir / f"{stem}.json"
+    with csv_path.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+    json_path.write_text(json.dumps(rows, indent=2))
+    return csv_path, json_path
+
+
+def run_flux_dynamic(
+    *,
+    closure: str,
+    subdivisions: int,
+    radius: float,
+    gamma: float,
+    rho: float,
+    bulk_modulus: float,
+    amplitude: float,
+    n_steps: int,
+    t_final: float,
+    substeps_per_sample: int,
+    damping_ratio: float,
+    mass_model: str,
+    inertia_scale: float,
+    mass_flux_coupling: float,
+    momentum_flux_coupling: float,
+    density_change_limit: float | None,
+    flux_cfl_limit: float,
+    flux_scheme: str,
+    flux_timing: str,
+    face_flux_mode: str,
+    mass_floor_fraction: float,
+    coupled_flux_continuity: bool,
+    flux_continuity_sign: float,
+    incompressible_target_mode: str,
+    pressure_force_mode: str,
+    rayleigh_frequency_hz: float,
+    rayleigh_omega_rad_s: float,
+    rayleigh_mode: int,
+    ambient_pressure: float,
+    retriangulation_mode: str,
+) -> tuple[list[dict[str, float]], np.ndarray, np.ndarray, np.ndarray, np.ndarray, list[np.ndarray]]:
+    if closure not in {"compressible", "incompressible"}:
+        raise ValueError("closure must be compressible or incompressible")
+    if incompressible_target_mode not in {"reference", "mass"}:
+        raise ValueError("incompressible_target_mode must be reference or mass")
+    if flux_timing not in {"pre-pressure", "post-pressure"}:
+        raise ValueError("flux_timing must be pre-pressure or post-pressure")
+    if mass_model not in {"star-volume", "rayleigh-added"}:
+        raise ValueError("mass_model must be star-volume or rayleigh-added")
+    if pressure_force_mode not in {
+        "volume-gradient",
+        "pairwise-dual",
+        "pairwise-dual-scalar",
+        "pairwise-dual-forcefit",
+        "pairwise-dual-consistent",
+        "pairwise-vertex-eos",
+    }:
+        raise ValueError(
+            "pressure_force_mode must be volume-gradient, pairwise-dual, "
+            "pairwise-dual-scalar, pairwise-dual-forcefit, pairwise-dual-consistent, "
+            "or pairwise-vertex-eos"
+        )
+    if retriangulation_mode not in {"none", "diagnostic", "active"}:
+        raise ValueError("retriangulation_mode must be none, diagnostic, or active")
+
+    reference_points, tets, surface_indices, surface_faces, _surface_faces_global, _unit_points = base.build_ball_tet_mesh(
+        subdivisions,
+        radius,
+    )
+    points = base.deform_l2_volume_points(
+        reference_points,
+        tets,
+        radius=radius,
+        amplitude=amplitude,
+        target_volume=float(np.sum(base.tet_cell_volumes(reference_points, tets))),
+    )
+    reference_tet_volumes, _matrix0 = base.tet_volume_matrix(points, tets)
+    reference_total_volume = float(np.sum(reference_tet_volumes))
+    tet_masses = float(rho) * reference_tet_volumes
+    reference_tet_masses = tet_masses.copy()
+    reference_total_mass = float(np.sum(tet_masses))
+    reference_nodal_volumes = nodal_from_tets(points.shape[0], tets, reference_tet_volumes)
+    velocities = np.zeros_like(points)
+    face_pairs = tet_face_pairs(tets)
+    reference_display_tet_set = canonical_tet_set(tets)
+    inertial_mass_addition = np.zeros(points.shape[0], dtype=float)
+    if mass_model == "rayleigh-added":
+        reference_scalar_areas = base.vertex_scalar_areas(reference_points[surface_indices], surface_faces)
+        surface_added_mass = float(rho) * float(radius) / float(rayleigh_mode)
+        inertial_mass_addition[surface_indices] = surface_added_mass * reference_scalar_areas
+        mass_model_label = "bulk plus Rayleigh surface mass"
+    else:
+        mass_model_label = "bulk-tet lumped mass"
+
+    _forces0, _areas0, reference_pressure, _volume0 = base.fheron_forces_for_points(
+        reference_points[surface_indices],
+        surface_faces,
+        gamma,
+    )
+
+    dt = float(t_final) / float((int(n_steps) - 1) * int(substeps_per_sample))
+    damping_rate = 2.0 * float(damping_ratio) * float(rayleigh_omega_rad_s)
+    rows: list[dict[str, float]] = []
+    snapshots: list[np.ndarray] = []
+    display_tets_snapshots: list[np.ndarray] = []
+    cpu_start = time.process_time()
+    wall_start = time.perf_counter()
+    last_flux = {
+        "mass_flux_l1_kg_s": 0.0,
+        "mass_flux_max_kg_s": 0.0,
+        "momentum_flux_l1_n": 0.0,
+        "volume_flux_l1_m3_s": 0.0,
+        "flux_limiter_scale": 1.0,
+        "mass_update_coupling": float(mass_flux_coupling),
+        "momentum_force_coupling": float(momentum_flux_coupling),
+        "density_change_limit": float(density_change_limit) if density_change_limit is not None else 0.0,
+        "flux_cfl_limit": float(flux_cfl_limit),
+        "flux_scheme_rusanov": 1.0 if flux_scheme == "rusanov" else 0.0,
+        "face_flux_lagrangian": 1.0 if face_flux_mode == "lagrangian" else 0.0,
+        "flux_post_pressure": 1.0 if flux_timing == "post-pressure" else 0.0,
+        "mass_floor_fraction": float(mass_floor_fraction),
+        "coupled_flux_continuity": 1.0 if coupled_flux_continuity else 0.0,
+        "flux_continuity_sign": float(flux_continuity_sign),
+        "pressure_force_pairwise_dual": 1.0 if pressure_force_mode != "volume-gradient" else 0.0,
+        "pressure_force_scalar_pairwise": 1.0 if pressure_force_mode == "pairwise-dual-scalar" else 0.0,
+        "pressure_force_forcefit_pairwise": 1.0 if pressure_force_mode == "pairwise-dual-forcefit" else 0.0,
+        "pressure_solve_pairwise_dual": 1.0 if pressure_force_mode == "pairwise-dual-consistent" else 0.0,
+        "pressure_solve_pairwise_vertex": 1.0 if pressure_force_mode == "pairwise-vertex-eos" else 0.0,
+    }
+    sound_speed = math.sqrt(float(bulk_modulus) / float(rho))
+
+    def active_retriangulate() -> None:
+        nonlocal tets, reference_tet_volumes, tet_masses, reference_tet_masses
+        nonlocal reference_nodal_volumes, face_pairs
+
+        new_tets, new_reference_volumes, new_masses, _retopo_stats = ddg_stress.active_retopology_tet_remap(
+            points,
+            tets,
+            target_total_mass=reference_total_mass,
+            target_total_volume=reference_total_volume,
+        )
+        if np.asarray(new_tets).size == 0:
+            return
+
+        tets = np.asarray(new_tets, dtype=int)
+        reference_tet_volumes = np.asarray(new_reference_volumes, dtype=float)
+        tet_masses = np.asarray(new_masses, dtype=float)
+        reference_tet_masses = tet_masses.copy()
+        reference_nodal_volumes = nodal_from_tets(points.shape[0], tets, reference_tet_volumes)
+        face_pairs = tet_face_pairs(tets)
+
+    def collect(sample_index: int, time_value: float) -> None:
+        tet_volumes, local_matrix = base.tet_volume_matrix(points, tets)
+        if retriangulation_mode == "diagnostic":
+            display_tets = delaunay_tets_for_points(points, tets)
+        else:
+            display_tets = tets
+        display_tet_set = canonical_tet_set(display_tets)
+        display_union = reference_display_tet_set | display_tet_set
+        display_changed = reference_display_tet_set ^ display_tet_set
+        display_change_fraction = float(len(display_changed)) / max(float(len(display_union)), 1.0)
+        display_face_pairs = tet_face_pairs(display_tets)
+        nodal_mass = nodal_from_tets(points.shape[0], tets, tet_masses)
+        inertial_nodal_mass = np.maximum(float(inertia_scale) * (nodal_mass + inertial_mass_addition), 1.0e-18)
+        nodal_volume = nodal_from_tets(points.shape[0], tets, tet_volumes)
+        nodal_density = nodal_mass / np.maximum(nodal_volume, 1.0e-300)
+        area_vectors = current_area_vectors(points, surface_indices, surface_faces)
+        surface_points = points[surface_indices]
+        _surface_forces, _surface_area_vectors, fheron_equiv, _surface_volume = base.fheron_forces_for_points(
+            surface_points,
+            surface_faces,
+            gamma,
+        )
+        fitted_amplitude = base.fit_l2_shape_amplitude(surface_points, surface_faces)
+        theory_amplitude = float(amplitude) * math.cos(float(rayleigh_omega_rad_s) * float(time_value))
+        radial_ratio = np.linalg.norm(surface_points, axis=1) / float(radius)
+        cpu_elapsed = time.process_time() - cpu_start
+        wall_elapsed = time.perf_counter() - wall_start
+        substeps_done = int(sample_index) * int(substeps_per_sample)
+        cpu_ms_per_substep = 1.0e3 * cpu_elapsed / float(substeps_done) if substeps_done else 0.0
+        wall_ms_per_substep = 1.0e3 * wall_elapsed / float(substeps_done) if substeps_done else 0.0
+        if closure == "compressible" or incompressible_target_mode == "mass":
+            target_volumes = tet_masses / float(rho)
+        else:
+            target_volumes = reference_tet_volumes
+        local_volume_rel = tet_volumes / np.maximum(target_volumes, 1.0e-300)
+        density_rel = nodal_density / float(rho)
+        nodal_volume_rel = nodal_volume / np.maximum(reference_nodal_volumes, 1.0e-300)
+        area_norm = np.linalg.norm(area_vectors[surface_indices], axis=1)
+
+        rows.append(
+            {
+                "sample": float(sample_index),
+                "t": float(time_value),
+                "closure": closure,
+                "shape_amplitude_theory": float(theory_amplitude),
+                "shape_amplitude_fit": float(fitted_amplitude),
+                "rayleigh_frequency_hz": float(rayleigh_frequency_hz),
+                "rayleigh_omega_rad_s": float(rayleigh_omega_rad_s),
+                "fheron_pressure_pa": float(fheron_equiv),
+                "reference_pressure_pa": float(reference_pressure),
+                "closure_pressure_pa": float(getattr(collect, "last_pressure", reference_pressure)),
+                "ambient_pressure_pa": float(ambient_pressure),
+                "liquid_pressure_absolute_pa": float(ambient_pressure + getattr(collect, "last_pressure", reference_pressure)),
+                "mass_model": mass_model_label,
+                "inertia_scale": float(inertia_scale),
+                "total_mass_kg": float(np.sum(tet_masses)),
+                "total_inertial_mass_kg": float(np.sum(inertial_nodal_mass)),
+                "mass_rel_error": float(np.sum(tet_masses) / reference_total_mass - 1.0),
+                "vol_m3": float(np.sum(tet_volumes)),
+                "vol0_mesh_m3": float(np.sum(reference_tet_volumes)),
+                "vol_rel": float(np.sum(tet_volumes) / np.sum(reference_tet_volumes)),
+                "local_volume_rel_rms": float(math.sqrt(float(np.mean((local_volume_rel - 1.0) ** 2)))),
+                "local_volume_rel_max_abs": float(np.max(np.abs(local_volume_rel - 1.0))),
+                "nodal_mass_min_kg": float(np.min(nodal_mass)),
+                "nodal_mass_max_kg": float(np.max(nodal_mass)),
+                "inertial_mass_min_kg": float(np.min(inertial_nodal_mass)),
+                "inertial_mass_max_kg": float(np.max(inertial_nodal_mass)),
+                "nodal_volume_rel_min": float(np.min(nodal_volume_rel[nodal_volume > 0.0])),
+                "nodal_volume_rel_max": float(np.max(nodal_volume_rel[nodal_volume > 0.0])),
+                "nodal_density_rel_min": float(np.min(density_rel[nodal_volume > 0.0])),
+                "nodal_density_rel_max": float(np.max(density_rel[nodal_volume > 0.0])),
+                "area_vector_mean_m2": float(np.mean(area_norm)),
+                "area_vector_max_m2": float(np.max(area_norm)),
+                "mass_flux_l1_kg_s": float(last_flux["mass_flux_l1_kg_s"]),
+                "mass_flux_max_kg_s": float(last_flux["mass_flux_max_kg_s"]),
+                "momentum_flux_l1_n": float(last_flux["momentum_flux_l1_n"]),
+                "volume_flux_l1_m3_s": float(last_flux["volume_flux_l1_m3_s"]),
+                "flux_limiter_scale": float(last_flux["flux_limiter_scale"]),
+                "mass_update_coupling": float(last_flux["mass_update_coupling"]),
+                "momentum_force_coupling": float(last_flux["momentum_force_coupling"]),
+                "density_change_limit": float(last_flux["density_change_limit"]),
+                "flux_cfl_limit": float(last_flux["flux_cfl_limit"]),
+                "flux_scheme_rusanov": float(last_flux["flux_scheme_rusanov"]),
+                "face_flux_lagrangian": float(last_flux["face_flux_lagrangian"]),
+                "flux_post_pressure": float(last_flux["flux_post_pressure"]),
+                "mass_floor_fraction": float(last_flux["mass_floor_fraction"]),
+                "coupled_flux_continuity": float(last_flux["coupled_flux_continuity"]),
+                "flux_continuity_sign": float(last_flux["flux_continuity_sign"]),
+                "pressure_force_pairwise_dual": float(last_flux["pressure_force_pairwise_dual"]),
+                "pressure_force_scalar_pairwise": float(last_flux["pressure_force_scalar_pairwise"]),
+                "pressure_force_forcefit_pairwise": float(last_flux["pressure_force_forcefit_pairwise"]),
+                "pressure_solve_pairwise_dual": float(last_flux["pressure_solve_pairwise_dual"]),
+                "pressure_solve_pairwise_vertex": float(last_flux["pressure_solve_pairwise_vertex"]),
+                "retriangulation_diagnostic": 1.0 if retriangulation_mode == "diagnostic" else 0.0,
+                "retriangulation_active": 1.0 if retriangulation_mode == "active" else 0.0,
+                "solver_tet_count": float(tets.shape[0]),
+                "display_tet_count": float(display_tets.shape[0]),
+                "display_internal_face_count": float(len(display_face_pairs)),
+                "display_changed_tets": float(len(display_changed)),
+                "display_changed_fraction": float(display_change_fraction),
+                "incompressible_target_from_mass": 1.0 if incompressible_target_mode == "mass" else 0.0,
+                "cpu_time_s": float(cpu_elapsed),
+                "wall_time_s": float(wall_elapsed),
+                "cpu_ms_per_substep": float(cpu_ms_per_substep),
+                "wall_ms_per_substep": float(wall_ms_per_substep),
+                "max_speed_m_s": float(np.max(np.linalg.norm(velocities, axis=1))),
+                "radial_ratio_min": float(np.min(radial_ratio)),
+                "radial_ratio_max": float(np.max(radial_ratio)),
+            }
+        )
+        snapshots.append(points.copy())
+        display_tets_snapshots.append(np.asarray(display_tets, dtype=int).copy())
+
+    collect.last_pressure = reference_pressure  # type: ignore[attr-defined]
+    collect(0, 0.0)
+
+    total_substeps = (int(n_steps) - 1) * int(substeps_per_sample)
+    sample_index = 1
+    for substep in range(1, total_substeps + 1):
+        if retriangulation_mode == "active":
+            active_retriangulate()
+        tet_volumes, local_matrix = base.tet_volume_matrix(points, tets)
+        if flux_timing == "pre-pressure":
+            tet_masses, flux_forces, last_flux = compute_ale_fluxes(
+                points,
+                velocities,
+                tets,
+                face_pairs,
+                tet_masses,
+                reference_tet_masses,
+                tet_volumes,
+                dt,
+                reference_density=rho,
+                sound_speed=sound_speed,
+                mass_floor_fraction=mass_floor_fraction,
+                mass_update_coupling=mass_flux_coupling,
+                momentum_force_coupling=momentum_flux_coupling,
+                density_change_limit=density_change_limit,
+                flux_cfl_limit=flux_cfl_limit,
+                flux_scheme=flux_scheme,
+                face_flux_mode=face_flux_mode,
+            )
+            last_flux["flux_post_pressure"] = 0.0
+            last_flux["mass_floor_fraction"] = float(mass_floor_fraction)
+            last_flux["coupled_flux_continuity"] = 1.0 if coupled_flux_continuity else 0.0
+            last_flux["flux_continuity_sign"] = float(flux_continuity_sign)
+            last_flux["pressure_force_pairwise_dual"] = 1.0 if pressure_force_mode != "volume-gradient" else 0.0
+            last_flux["pressure_force_scalar_pairwise"] = 1.0 if pressure_force_mode == "pairwise-dual-scalar" else 0.0
+            last_flux["pressure_force_forcefit_pairwise"] = 1.0 if pressure_force_mode == "pairwise-dual-forcefit" else 0.0
+            last_flux["pressure_solve_pairwise_dual"] = 1.0 if pressure_force_mode == "pairwise-dual-consistent" else 0.0
+            last_flux["pressure_solve_pairwise_vertex"] = 1.0 if pressure_force_mode == "pairwise-vertex-eos" else 0.0
+        else:
+            flux_forces = np.zeros_like(points)
+            last_flux = dict(last_flux)
+            last_flux["mass_flux_l1_kg_s"] = 0.0
+            last_flux["mass_flux_max_kg_s"] = 0.0
+            last_flux["momentum_flux_l1_n"] = 0.0
+            last_flux["volume_flux_l1_m3_s"] = 0.0
+            last_flux["flux_limiter_scale"] = 1.0
+            last_flux["flux_post_pressure"] = 1.0
+            last_flux["mass_floor_fraction"] = float(mass_floor_fraction)
+            last_flux["coupled_flux_continuity"] = 1.0 if coupled_flux_continuity else 0.0
+            last_flux["flux_continuity_sign"] = float(flux_continuity_sign)
+            last_flux["pressure_force_pairwise_dual"] = 1.0 if pressure_force_mode != "volume-gradient" else 0.0
+            last_flux["pressure_force_scalar_pairwise"] = 1.0 if pressure_force_mode == "pairwise-dual-scalar" else 0.0
+            last_flux["pressure_force_forcefit_pairwise"] = 1.0 if pressure_force_mode == "pairwise-dual-forcefit" else 0.0
+            last_flux["pressure_solve_pairwise_dual"] = 1.0 if pressure_force_mode == "pairwise-dual-consistent" else 0.0
+            last_flux["pressure_solve_pairwise_vertex"] = 1.0 if pressure_force_mode == "pairwise-vertex-eos" else 0.0
+        nodal_mass = nodal_from_tets(points.shape[0], tets, tet_masses)
+        inertial_nodal_mass = np.maximum(float(inertia_scale) * (nodal_mass + inertial_mass_addition), 1.0e-18)
+        surface_points = points[surface_indices]
+        surface_forces, _surface_area_vectors, _fheron_equiv, _surface_volume = base.fheron_forces_for_points(
+            surface_points,
+            surface_faces,
+            gamma,
+        )
+        forces = np.zeros_like(points)
+        forces[surface_indices] += surface_forces
+        damping_forces = -damping_rate * inertial_nodal_mass[:, None] * velocities
+        if closure == "compressible" or incompressible_target_mode == "mass":
+            target_tet_volumes = tet_masses / float(rho)
+        else:
+            target_tet_volumes = reference_tet_volumes
+        pressure_matrix = pressure_force_matrix_for_mode(
+            pressure_force_mode,
+            points,
+            tets,
+            tet_volumes,
+            local_matrix,
+        )
+        pressure_solve_matrix = pressure_solve_matrix_for_mode(
+            pressure_force_mode,
+            pressure_matrix,
+            local_matrix,
+        )
+
+        if closure == "compressible":
+            if pressure_force_mode == "pairwise-vertex-eos":
+                base_pressures = np.full(points.shape[0], float(reference_pressure), dtype=float)
+            else:
+                base_pressures = np.full(tets.shape[0], float(reference_pressure), dtype=float)
+            nonpressure_forces = (
+                forces
+                + (pressure_matrix @ base_pressures).reshape(points.shape)
+                + damping_forces
+                + flux_forces
+            )
+            u_star = velocities + dt * nonpressure_forces / inertial_nodal_mass[:, None]
+            _stiffness, inv_mass_dof = base._local_volume_stiffness(local_matrix, inertial_nodal_mass)
+            compressibility = float(bulk_modulus) / np.maximum(reference_tet_volumes, 1.0e-300)
+            if coupled_flux_continuity and mass_flux_coupling and face_flux_mode == "cell-average":
+                mass_flux_matrix = linearized_mass_flux_matrix(
+                    points,
+                    tets,
+                    face_pairs,
+                    tet_masses,
+                    tet_volumes,
+                    reference_density=rho,
+                    mass_update_coupling=mass_flux_coupling,
+                )
+                continuity_matrix = local_matrix + float(flux_continuity_sign) * mass_flux_matrix / float(rho)
+            else:
+                continuity_matrix = local_matrix
+            if pressure_force_mode == "pairwise-vertex-eos":
+                vertex_average = tet_vertex_pressure_average_matrix(points.shape[0], tets)
+                nonpressure_forces = (
+                    forces
+                    + (pressure_matrix @ base_pressures).reshape(points.shape)
+                    + damping_forces
+                    + flux_forces
+                )
+                u_star = velocities + dt * nonpressure_forces / inertial_nodal_mass[:, None]
+                coupled_stiffness = (continuity_matrix * inv_mass_dof[None, :]) @ pressure_matrix
+                linear_volume_error = tet_volumes - target_tet_volumes + dt * (continuity_matrix @ u_star.reshape(-1))
+                system = vertex_average + (compressibility[:, None] * dt * dt) * coupled_stiffness
+                rhs = -compressibility * linear_volume_error
+                pressure_delta_vertices = solve_regularized_lstsq(system, rhs, relative=1.0e-6)
+                velocities = (
+                    u_star.reshape(-1)
+                    + dt * inv_mass_dof * (pressure_matrix @ pressure_delta_vertices)
+                ).reshape(velocities.shape)
+                collect.last_pressure = float(np.mean(vertex_average @ (base_pressures + pressure_delta_vertices)))  # type: ignore[attr-defined]
+            elif pressure_force_mode == "pairwise-dual-scalar":
+                pressure_direction = pressure_matrix @ np.ones(tets.shape[0], dtype=float)
+                linear_volume_error = tet_volumes - target_tet_volumes + dt * (continuity_matrix @ u_star.reshape(-1))
+                global_volume_error = float(np.sum(linear_volume_error))
+                global_compressibility = float(bulk_modulus) / max(float(np.sum(reference_tet_volumes)), 1.0e-300)
+                scalar_stiffness = float(np.sum(continuity_matrix @ (inv_mass_dof * pressure_direction)))
+                denom = 1.0 + float(dt) * float(dt) * global_compressibility * scalar_stiffness
+                pressure_delta_scalar = -global_compressibility * global_volume_error / max(denom, 1.0e-300)
+                velocities = (
+                    u_star.reshape(-1)
+                    + dt * inv_mass_dof * pressure_direction * float(pressure_delta_scalar)
+                ).reshape(velocities.shape)
+                collect.last_pressure = float(reference_pressure + pressure_delta_scalar)  # type: ignore[attr-defined]
+            else:
+                coupled_stiffness = (continuity_matrix * inv_mass_dof[None, :]) @ pressure_solve_matrix
+                linear_volume_error = tet_volumes - target_tet_volumes + dt * (continuity_matrix @ u_star.reshape(-1))
+                system = np.eye(tets.shape[0]) + (compressibility[:, None] * dt * dt) * coupled_stiffness
+                rhs = -compressibility * linear_volume_error
+                pressure_delta = base._solve_regularized(system, rhs)
+                velocities = (u_star.reshape(-1) + dt * inv_mass_dof * (pressure_matrix @ pressure_delta)).reshape(
+                    velocities.shape
+                )
+                collect.last_pressure = float(np.mean(base_pressures + pressure_delta))  # type: ignore[attr-defined]
+        else:
+            inv_mass_dof = np.repeat(1.0 / np.maximum(inertial_nodal_mass, 1.0e-300), 3)
+            target_rates = -(tet_volumes - target_tet_volumes) / float(dt)
+            velocity_vec = velocities.reshape(-1)
+            nonpressure_vec = (forces + damping_forces + flux_forces).reshape(-1)
+            pressure_stiffness = (local_matrix * inv_mass_dof[None, :]) @ pressure_solve_matrix
+            pressure_rhs = (
+                (target_rates - local_matrix @ velocity_vec) / float(dt)
+                - local_matrix @ (inv_mass_dof * nonpressure_vec)
+            )
+            pressure_values = base._solve_regularized(pressure_stiffness, pressure_rhs)
+            total_forces = (
+                forces
+                + (pressure_matrix @ pressure_values).reshape(points.shape)
+                + damping_forces
+                + flux_forces
+            )
+            velocities = velocities + dt * total_forces / inertial_nodal_mass[:, None]
+            velocities = project_local_volume_velocity_with_pressure_matrix(
+                velocities,
+                local_matrix,
+                pressure_solve_matrix,
+                inertial_nodal_mass,
+                target_rates,
+            )
+            collect.last_pressure = float(np.mean(pressure_values))  # type: ignore[attr-defined]
+
+        if flux_timing == "post-pressure":
+            tet_masses, post_flux_forces, last_flux = compute_ale_fluxes(
+                points,
+                velocities,
+                tets,
+                face_pairs,
+                tet_masses,
+                reference_tet_masses,
+                tet_volumes,
+                dt,
+                reference_density=rho,
+                sound_speed=sound_speed,
+                mass_floor_fraction=mass_floor_fraction,
+                mass_update_coupling=mass_flux_coupling,
+                momentum_force_coupling=momentum_flux_coupling,
+                density_change_limit=density_change_limit,
+                flux_cfl_limit=flux_cfl_limit,
+                flux_scheme=flux_scheme,
+                face_flux_mode=face_flux_mode,
+            )
+            last_flux["flux_post_pressure"] = 1.0
+            last_flux["mass_floor_fraction"] = float(mass_floor_fraction)
+            last_flux["coupled_flux_continuity"] = 1.0 if coupled_flux_continuity else 0.0
+            last_flux["flux_continuity_sign"] = float(flux_continuity_sign)
+            last_flux["pressure_force_pairwise_dual"] = 1.0 if pressure_force_mode != "volume-gradient" else 0.0
+            last_flux["pressure_force_scalar_pairwise"] = 1.0 if pressure_force_mode == "pairwise-dual-scalar" else 0.0
+            last_flux["pressure_force_forcefit_pairwise"] = 1.0 if pressure_force_mode == "pairwise-dual-forcefit" else 0.0
+            last_flux["pressure_solve_pairwise_dual"] = 1.0 if pressure_force_mode == "pairwise-dual-consistent" else 0.0
+            last_flux["pressure_solve_pairwise_vertex"] = 1.0 if pressure_force_mode == "pairwise-vertex-eos" else 0.0
+            if momentum_flux_coupling:
+                post_nodal_mass = nodal_from_tets(points.shape[0], tets, tet_masses)
+                post_inertial_mass = np.maximum(
+                    float(inertia_scale) * (post_nodal_mass + inertial_mass_addition),
+                    1.0e-18,
+                )
+                velocities = velocities + dt * post_flux_forces / post_inertial_mass[:, None]
+
+        points = points + dt * velocities
+        points, velocities = base._remove_rigid_translation(points, velocities, inertial_nodal_mass)
+
+        if not np.all(np.isfinite(points)) or not np.all(np.isfinite(velocities)):
+            raise FloatingPointError(f"{closure} flux run became non-finite at substep {substep}")
+
+        if substep % int(substeps_per_sample) == 0:
+            collect(sample_index, sample_index * float(t_final) / float(int(n_steps) - 1))
+            sample_index += 1
+
+    return rows, np.asarray(snapshots, dtype=float), surface_faces, tets, surface_indices, display_tets_snapshots
+
+
+def write_snapshots(
+    snapshots: np.ndarray,
+    faces: np.ndarray,
+    tets: np.ndarray,
+    surface_indices: np.ndarray,
+    out_dir: Path,
+    stem: str,
+    display_tets_snapshots: list[np.ndarray] | None = None,
+) -> Path:
+    path = out_dir / f"{stem}.npz"
+    payload: dict[str, np.ndarray] = {
+        "points": snapshots,
+        "faces": faces,
+        "tets": tets,
+        "surface_indices": surface_indices,
+    }
+    if display_tets_snapshots is not None:
+        payload["display_tets"] = np.asarray(display_tets_snapshots, dtype=object)
+    np.savez_compressed(path, **payload)
+    return path
+
+
+def write_flux_animation(
+    rows: list[dict[str, float]],
+    snapshots: np.ndarray,
+    faces: np.ndarray,
+    tets: np.ndarray,
+    surface_indices: np.ndarray,
+    out_dir: Path,
+    *,
+    radius: float,
+    closure: str,
+    max_frames: int,
+    fps: int,
+    display_tets_snapshots: list[np.ndarray] | None = None,
+) -> Path:
+    t = row_array(rows, "t")
+    amplitude_theory = row_array(rows, "shape_amplitude_theory")
+    amplitude_fit = row_array(rows, "shape_amplitude_fit")
+    global_volume_pct = (row_array(rows, "vol_rel") - 1.0) * 100.0
+    local_volume_pct = row_array(rows, "local_volume_rel_max_abs") * 100.0
+    density_spread_ppm = (row_array(rows, "nodal_density_rel_max") - row_array(rows, "nodal_density_rel_min")) * 1.0e6
+    mass_flux = row_array(rows, "mass_flux_l1_kg_s")
+    momentum_flux = row_array(rows, "momentum_flux_l1_n")
+    fheron = row_array(rows, "fheron_pressure_pa")
+    pressure = row_array(rows, "closure_pressure_pa")
+    ambient_pressure = row_array(rows, "ambient_pressure_pa")
+    display_tet_count = row_array(rows, "display_tet_count")
+    display_face_count = row_array(rows, "display_internal_face_count")
+    display_changed_tets = row_array(rows, "display_changed_tets")
+    display_changed_fraction = row_array(rows, "display_changed_fraction")
+    cpu_time = row_array(rows, "cpu_time_s")
+    cpu_ms = row_array(rows, "cpu_ms_per_substep")
+    limiter_scale = row_array(rows, "flux_limiter_scale")
+    density_limit = float(rows[0].get("density_change_limit", 0.0))
+    flux_scheme = "Rusanov" if float(rows[0].get("flux_scheme_rusanov", 0.0)) > 0.5 else "upwind"
+    face_flux_mode = "Lagrangian face" if float(rows[0].get("face_flux_lagrangian", 0.0)) > 0.5 else "cell-average face"
+    if float(rows[0].get("pressure_force_forcefit_pairwise", 0.0)) > 0.5:
+        pressure_force_label = "pairwise Aij fitted p"
+    elif float(rows[0].get("pressure_force_scalar_pairwise", 0.0)) > 0.5:
+        pressure_force_label = "pairwise Aij scalar p"
+    elif float(rows[0].get("pressure_solve_pairwise_vertex", 0.0)) > 0.5:
+        pressure_force_label = "pairwise Aij vertex p"
+    elif float(rows[0].get("pressure_force_pairwise_dual", 0.0)) > 0.5:
+        pressure_force_label = "pairwise Aij"
+    else:
+        pressure_force_label = "volume-gradient Bt"
+    cpu_total = float(cpu_time[-1])
+    cpu_avg = float(cpu_ms[-1])
+    active_retopology = float(rows[0].get("retriangulation_active", 0.0)) > 0.5
+    show_retriangulation = active_retopology or float(rows[0].get("retriangulation_diagnostic", 0.0)) > 0.5
+    retopo_prefix = "Active-retopology " if active_retopology else ""
+
+    if closure == "compressible":
+        facecolor = "#9ecae1"
+        edgecolor = "#1f77b4"
+        gif_name = "flux_compressible_sphere.gif"
+        title = f"{retopo_prefix}one-phase free-surface compressible EOS, {face_flux_mode} ALE flux"
+    else:
+        facecolor = "#fdd0a2"
+        edgecolor = "#ff7f0e"
+        gif_name = "flux_incompressible_sphere.gif"
+        title = f"{retopo_prefix}one-phase free-surface incompressible projection with ALE flux"
+
+    frame_indices = np.unique(np.linspace(0, len(rows) - 1, min(len(rows), max(2, int(max_frames))), dtype=int))
+    radial_max = max(float(row["radial_ratio_max"]) for row in rows)
+    limit = 1.15 * radial_max * float(radius)
+    time_ticks = np.linspace(float(t[0]), float(t[-1]), 5)
+    time_tick_labels = [f"{value:.3f}" for value in time_ticks]
+
+    fig = plt.figure(figsize=(10.4, 7.2))
+    grid = fig.add_gridspec(3, 2, width_ratios=(1.35, 1.0), wspace=0.27, hspace=0.50)
+    ax3d = fig.add_subplot(grid[:2, 0], projection="3d")
+    ax_info = fig.add_subplot(grid[2, 0])
+    ax_amp = fig.add_subplot(grid[0, 1])
+    ax_density = fig.add_subplot(grid[1, 1])
+    ax_flux = fig.add_subplot(grid[2, 1])
+
+    reference_surface = snapshots[0, surface_indices]
+
+    def draw(frame_pos: int) -> None:
+        row_idx = int(frame_indices[frame_pos])
+        points = snapshots[row_idx]
+        surface = points[surface_indices]
+        display_tets = (
+            np.asarray(display_tets_snapshots[row_idx], dtype=int)
+            if display_tets_snapshots is not None
+            else np.asarray(tets, dtype=int)
+        )
+        edge_indices = base.tet_edge_indices(display_tets, max_edges=280)
+        ax3d.cla()
+        ax_info.cla()
+        ax_amp.cla()
+        ax_density.cla()
+        ax_flux.cla()
+
+        ax3d.add_collection3d(
+            Poly3DCollection(
+                reference_surface[faces],
+                facecolor=(0.0, 0.0, 0.0, 0.025),
+                edgecolor=(0.25, 0.25, 0.25, 0.22),
+                linewidth=0.22,
+            )
+        )
+        ax3d.add_collection3d(
+            Poly3DCollection(
+                surface[faces],
+                facecolor=facecolor,
+                edgecolor=edgecolor,
+                linewidth=0.28,
+                alpha=0.46,
+            )
+        )
+        ax3d.add_collection3d(
+            Line3DCollection(points[edge_indices], colors=(0.1, 0.1, 0.1, 0.24), linewidths=0.32)
+        )
+        interior = np.setdiff1d(np.arange(points.shape[0], dtype=int), surface_indices)
+        center = interior[np.linalg.norm(points[interior], axis=1) <= 1.0e-12]
+        shells = np.setdiff1d(interior, center)
+        if shells.size:
+            shell_points = points[shells]
+            ax3d.scatter(
+                shell_points[:, 0],
+                shell_points[:, 1],
+                shell_points[:, 2],
+                s=12,
+                c="#2ca02c",
+                alpha=0.82,
+                edgecolors="none",
+                depthshade=False,
+            )
+        if center.size:
+            center_points = points[center]
+            ax3d.scatter(
+                center_points[:, 0],
+                center_points[:, 1],
+                center_points[:, 2],
+                s=22,
+                c="#111111",
+                edgecolors="white",
+                linewidths=0.35,
+                depthshade=False,
+            )
+        ax3d.set_xlim(-limit, limit)
+        ax3d.set_ylim(-limit, limit)
+        ax3d.set_zlim(-limit, limit)
+        ax3d.set_box_aspect((1.0, 1.0, 1.0))
+        ax3d.set_xticks([])
+        ax3d.set_yticks([])
+        ax3d.set_zticks([])
+        ax3d.set_title(title, fontsize=10)
+        ax3d.view_init(elev=20.0, azim=32.0 + 24.0 * float(t[row_idx]) / max(float(t[-1]), 1.0e-30))
+
+        ax_info.axis("off")
+        left = (
+            f"t = {t[row_idx]:.5f} s\n"
+            f"theory a2 = {amplitude_theory[row_idx]:+.4f}\n"
+            f"fit a2 = {amplitude_fit[row_idx]:+.4f}\n"
+            f"global dV/V0 = {global_volume_pct[row_idx]:+.3e} %\n"
+            f"max tet |dV|/V = {local_volume_pct[row_idx]:.3e} %\n"
+            f"rho spread = {density_spread_ppm[row_idx]:.3f} ppm\n"
+            f"mass flux L1 = {mass_flux[row_idx]:.3e} kg/s\n"
+            f"mom flux L1 = {momentum_flux[row_idx]:.3e} N\n"
+            f"flux limiter = {limiter_scale[row_idx]:.3e}\n"
+            f"retopology = {'active' if active_retopology else 'off/diagnostic'}"
+        )
+        retriangulation_line = (
+            f"display Delaunay = {display_tet_count[row_idx]:.0f} tets\n"
+            f"Delaunay flips = {display_changed_tets[row_idx]:.0f} ({100.0 * display_changed_fraction[row_idx]:.1f}%)"
+            if show_retriangulation
+            else f"display mesh = solver mesh\nsolver tets = {tets.shape[0]}"
+        )
+        right = (
+            f"solver mesh = {points.shape[0]} verts, {tets.shape[0]} tets\n"
+            f"{retriangulation_line}\n"
+            f"internal faces = {display_face_count[row_idx]:.0f}\n"
+            f"interior = {interior.size} verts\n"
+            f"flux = {flux_scheme}, {face_flux_mode}\n"
+            f"Fp = {pressure_force_label}\n"
+            f"rho limit = {100.0 * density_limit:.2f} %\n"
+            f"p_gas = {ambient_pressure[row_idx]:.0f} Pa\n"
+            f"p_gauge = {pressure[row_idx]:.3f} Pa\n"
+            f"FHeron = {fheron[row_idx]:.3f} Pa\n"
+            f"CPU = {cpu_time[row_idx]:.2f}/{cpu_total:.1f} s\n"
+            f"CPU/step = {cpu_ms[row_idx]:.2f} ms"
+        )
+        ax_info.text(0.02, 0.98, left, transform=ax_info.transAxes, va="top", ha="left", family="monospace", fontsize=7.6)
+        ax_info.text(0.52, 0.98, right, transform=ax_info.transAxes, va="top", ha="left", family="monospace", fontsize=7.6)
+
+        pad = max(0.1 * float(np.ptp(amplitude_theory)), 0.004)
+        ax_amp.plot(t, amplitude_theory, "k--", lw=1.6, label="Rayleigh theory")
+        ax_amp.plot(t, amplitude_fit, color=edgecolor, lw=1.8, label="Ftot + flux")
+        ax_amp.plot(t[row_idx], amplitude_fit[row_idx], "o", color="#d62728", ms=5.0)
+        ax_amp.set_xlim(float(t[0]), float(t[-1]))
+        ax_amp.set_xticks(time_ticks)
+        ax_amp.set_xticklabels(time_tick_labels)
+        ax_amp.set_ylim(float(min(np.min(amplitude_theory), np.min(amplitude_fit)) - pad), float(max(np.max(amplitude_theory), np.max(amplitude_fit)) + pad))
+        ax_amp.set_ylabel("a2")
+        ax_amp.set_title("Shape amplitude")
+        ax_amp.grid(True, alpha=0.25)
+        ax_amp.legend(frameon=False, fontsize=8, loc="upper right")
+
+        ax_density.plot(t, global_volume_pct, color=edgecolor, lw=1.8, label="global dV/V0")
+        ax_density.plot(t, local_volume_pct, color="0.3", lw=1.2, ls=":", label="max local tet")
+        ax_density.plot(t[row_idx], global_volume_pct[row_idx], "o", color="#d62728", ms=5.0)
+        ax_density.set_xlim(float(t[0]), float(t[-1]))
+        ax_density.set_xticks(time_ticks)
+        ax_density.set_xticklabels(time_tick_labels)
+        ymin = min(float(np.min(global_volume_pct)), float(np.min(local_volume_pct)))
+        ymax = max(float(np.max(global_volume_pct)), float(np.max(local_volume_pct)))
+        ypad = max(0.12 * (ymax - ymin), 1.0e-8)
+        ax_density.set_ylim(ymin - ypad, ymax + ypad)
+        ax_density.set_ylabel("percent")
+        ax_density.set_title("Global and local volume error")
+        ax_density.grid(True, alpha=0.25)
+        ax_density.legend(frameon=False, fontsize=8, loc="upper right")
+
+        mass_flux_plot = np.maximum(mass_flux, 1.0e-30)
+        momentum_flux_plot = np.maximum(momentum_flux, 1.0e-30)
+        ax_flux.plot(t, mass_flux_plot, color=edgecolor, lw=1.8, label="mass flux L1")
+        ax_flux_twin = ax_flux.twinx()
+        ax_flux_twin.plot(t, momentum_flux_plot, color="0.25", lw=1.2, ls=":", label="momentum flux L1")
+        ax_flux.plot(t[row_idx], max(mass_flux[row_idx], 1.0e-30), "o", color="#d62728", ms=5.0)
+        ax_flux.set_yscale("log")
+        ax_flux_twin.set_yscale("log")
+        mass_flux_max = max(float(np.max(mass_flux_plot)), 1.0e-30)
+        momentum_flux_max = max(float(np.max(momentum_flux_plot)), 1.0e-30)
+        ax_flux.set_ylim(max(mass_flux_max * 1.0e-6, 1.0e-30), mass_flux_max * 5.0)
+        ax_flux_twin.set_ylim(max(momentum_flux_max * 1.0e-6, 1.0e-30), momentum_flux_max * 5.0)
+        ax_flux.set_xlim(float(t[0]), float(t[-1]))
+        ax_flux.set_xticks(time_ticks)
+        ax_flux.set_xticklabels(time_tick_labels)
+        ax_flux.set_xlabel("t [s]")
+        ax_flux.set_ylabel("kg/s")
+        ax_flux_twin.set_ylabel("N")
+        ax_flux.set_title("Internal face fluxes")
+        ax_flux.grid(True, alpha=0.25)
+        lines, labels = ax_flux.get_legend_handles_labels()
+        lines2, labels2 = ax_flux_twin.get_legend_handles_labels()
+        ax_flux.legend(lines + lines2, labels + labels2, frameon=False, fontsize=8, loc="upper right")
+
+        fig.suptitle(
+            f"{closure.capitalize()} flux-aware run, CPU {cpu_total:.1f} s ({cpu_avg:.1f} ms/step)",
+            y=0.985,
+        )
+
+    animation = FuncAnimation(fig, draw, frames=len(frame_indices), interval=1000.0 / max(1, int(fps)))
+    gif_path = out_dir / gif_name
+    animation.save(gif_path, writer=PillowWriter(fps=max(1, int(fps))))
+    plt.close(fig)
+    return gif_path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Flux-aware FHeron compressible/incompressible droplet GIFs.")
+    parser.add_argument("--radius", type=float, default=1.0e-3)
+    parser.add_argument("--gamma", type=float, default=0.072)
+    parser.add_argument("--rho", type=float, default=1000.0)
+    parser.add_argument("--bulk-modulus", type=float, default=2.2e9)
+    parser.add_argument(
+        "--ambient-pressure",
+        type=float,
+        default=101325.0,
+        help="Passive gas/reference pressure [Pa]. Dynamics use liquid gauge pressure relative to this value.",
+    )
+    parser.add_argument("--rayleigh-mode", type=int, default=2)
+    parser.add_argument("--shape-mode-ar", type=float, default=1.05)
+    parser.add_argument(
+        "--t-final",
+        type=float,
+        default=None,
+        help="Physical simulation end time [s]. Default is one Rayleigh-Lamb period.",
+    )
+    parser.add_argument("--subdivision", type=int, default=0, help="0 is fast and still has two interior shells.")
+    parser.add_argument("--steps", type=int, default=41)
+    parser.add_argument("--substeps-per-sample", type=int, default=20)
+    parser.add_argument("--damping-ratio", type=float, default=0.015)
+    parser.add_argument(
+        "--mass-model",
+        choices=("star-volume", "rayleigh-added"),
+        default="star-volume",
+        help="Vertex inertia model. rayleigh-added reproduces Rayleigh-Lamb inertia while tet mass remains physical.",
+    )
+    parser.add_argument(
+        "--inertia-scale",
+        type=float,
+        default=1.0,
+        help="Scale only the vertex inertial mass used by Ftot integration; tet mass/density/flux stay unchanged.",
+    )
+    parser.add_argument(
+        "--mass-flux-coupling",
+        type=float,
+        default=1.0e-6,
+        help="Fraction of computed ALE mass flux used to update cell/nodal masses.",
+    )
+    parser.add_argument(
+        "--momentum-flux-coupling",
+        type=float,
+        default=0.0,
+        help="Fraction of computed momentum flux applied as nodal force. Default keeps it diagnostic.",
+    )
+    parser.add_argument(
+        "--density-change-limit",
+        type=float,
+        default=None,
+        help="Optional conservative limiter for |rho/rho0 - 1|. Example: 0.01 allows 1 percent.",
+    )
+    parser.add_argument(
+        "--flux-cfl-limit",
+        type=float,
+        default=0.25,
+        help="Limit the mass transferred by internal flux in one substep as a fraction of cell mass.",
+    )
+    parser.add_argument(
+        "--flux-scheme",
+        choices=("upwind", "rusanov"),
+        default="upwind",
+        help="Internal ALE face flux scheme. Rusanov adds acoustic numerical diffusion.",
+    )
+    parser.add_argument(
+        "--face-flux-mode",
+        choices=("cell-average", "lagrangian"),
+        default="cell-average",
+        help="Use old cell-averaged face flux or Lagrangian material-face flux.",
+    )
+    parser.add_argument(
+        "--flux-timing",
+        choices=("pre-pressure", "post-pressure"),
+        default="pre-pressure",
+        help="Apply active flux before the pressure solve or as an operator-split update after pressure.",
+    )
+    parser.add_argument(
+        "--mass-floor-fraction",
+        type=float,
+        default=0.35,
+        help="Minimum tet mass as a fixed fraction of the initial tet mass.",
+    )
+    parser.add_argument(
+        "--coupled-flux-continuity",
+        action="store_true",
+        help="Include the linearized active mass flux in the compressible EOS pressure-correction equation.",
+    )
+    parser.add_argument(
+        "--flux-continuity-sign",
+        type=float,
+        default=-1.0,
+        help="Sign for the mass-flux term in the coupled continuity operator; -1 gives B - G/rho0.",
+    )
+    parser.add_argument(
+        "--incompressible-target-mode",
+        choices=("reference", "mass"),
+        default="reference",
+        help="For incompressible closure, project to fixed reference tet volumes or Vtar=m_t/rho after mass flux.",
+    )
+    parser.add_argument(
+        "--pressure-force-mode",
+        choices=(
+            "volume-gradient",
+            "pairwise-dual",
+            "pairwise-dual-scalar",
+            "pairwise-dual-forcefit",
+            "pairwise-dual-consistent",
+            "pairwise-vertex-eos",
+        ),
+        default="volume-gradient",
+        help=(
+            "Use tet volume-gradient pressure force, pairwise -0.5(p_i+p_j) A_ij force "
+            "with mapped vertex pressure, pairwise scalar-pressure force, fitted vertex pressure, "
+            "fully pairwise-consistent solve, or direct vertex-pressure EOS solve."
+        ),
+    )
+    parser.add_argument(
+        "--retriangulation-mode",
+        choices=("none", "diagnostic", "active"),
+        default="none",
+        help=(
+            "none: fixed solver tets; diagnostic: Delaunay display mesh only; "
+            "active: rebuild solver tets each substep and remap mass/target volumes."
+        ),
+    )
+    parser.add_argument(
+        "--closure",
+        choices=("both", "compressible", "incompressible"),
+        default="both",
+        help="Run both closures or just one closure.",
+    )
+    parser.add_argument("--animation-max-frames", type=int, default=32)
+    parser.add_argument("--animation-fps", type=int, default=12)
+    parser.add_argument("--out-dir", type=Path, default=SCRIPT_DIR / "out" / "sphere_fheron_flux_fv")
+    return parser.parse_args()
+
+
+def main() -> int:
+    install_ddgclib_operator_aliases()
+    args = parse_args()
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    omega, frequency, period = base.rayleigh_lamb_frequency(args.rayleigh_mode, args.gamma, args.rho, args.radius)
+    t_final = float(args.t_final) if args.t_final is not None else period
+    amplitude = base.shape_amplitude_from_aspect_ratio(args.shape_mode_ar)
+
+    outputs: list[Path] = []
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        closures = ("compressible", "incompressible") if args.closure == "both" else (args.closure,)
+        for closure in closures:
+            rows, snapshots, faces, tets, surface_indices, display_tets_snapshots = run_flux_dynamic(
+                closure=closure,
+                subdivisions=args.subdivision,
+                radius=args.radius,
+                gamma=args.gamma,
+                rho=args.rho,
+                bulk_modulus=args.bulk_modulus,
+                amplitude=amplitude,
+                n_steps=args.steps,
+                t_final=t_final,
+                substeps_per_sample=args.substeps_per_sample,
+                damping_ratio=args.damping_ratio,
+                mass_model=args.mass_model,
+                inertia_scale=args.inertia_scale,
+                mass_flux_coupling=args.mass_flux_coupling,
+                momentum_flux_coupling=args.momentum_flux_coupling,
+                density_change_limit=args.density_change_limit,
+                flux_cfl_limit=args.flux_cfl_limit,
+                flux_scheme=args.flux_scheme,
+                flux_timing=args.flux_timing,
+                face_flux_mode=args.face_flux_mode,
+                mass_floor_fraction=args.mass_floor_fraction,
+                coupled_flux_continuity=args.coupled_flux_continuity,
+                flux_continuity_sign=args.flux_continuity_sign,
+                incompressible_target_mode=args.incompressible_target_mode,
+                pressure_force_mode=args.pressure_force_mode,
+                rayleigh_frequency_hz=frequency,
+                rayleigh_omega_rad_s=omega,
+                rayleigh_mode=args.rayleigh_mode,
+                ambient_pressure=args.ambient_pressure,
+                retriangulation_mode=args.retriangulation_mode,
+            )
+            csv_path, json_path = write_rows(rows, args.out_dir, f"flux_{closure}_timeseries")
+            npz_path = write_snapshots(
+                snapshots,
+                faces,
+                tets,
+                surface_indices,
+                args.out_dir,
+                f"flux_{closure}_snapshots",
+                display_tets_snapshots,
+            )
+            gif_path = write_flux_animation(
+                rows,
+                snapshots,
+                faces,
+                tets,
+                surface_indices,
+                args.out_dir,
+                radius=args.radius,
+                closure=closure,
+                max_frames=args.animation_max_frames,
+                fps=args.animation_fps,
+                display_tets_snapshots=display_tets_snapshots,
+            )
+            outputs.extend([csv_path, json_path, npz_path, gif_path])
+            print(
+                f"{closure}: CPU={rows[-1]['cpu_time_s']:.3f}s, "
+                f"ms/step={rows[-1]['cpu_ms_per_substep']:.3f}, "
+                f"mass_flux_L1={rows[-1]['mass_flux_l1_kg_s']:.3e}, "
+                f"mom_flux_L1={rows[-1]['momentum_flux_l1_n']:.3e}"
+            )
+
+    for path in outputs:
+        print(path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cases_dynamic/oscillating_droplet_p_ref/scripts/sphere_fheron_flux_fv_ddgclib_benchmark.py
+++ b/cases_dynamic/oscillating_droplet_p_ref/scripts/sphere_fheron_flux_fv_ddgclib_benchmark.py
@@ -10,8 +10,9 @@ The flux model here is deliberately compact for a benchmark GIF.  It is not a
 production CFD discretization.
 
 This copy keeps the old benchmark file untouched, but routes the force,
-volume-gradient pressure, ALE flux, and active-retopology remap through new
-non-breaking ddgclib operator functions added under ``ddgclib.operators``.
+volume-gradient pressure, ALE flux, and active-retopology remap through the
+benchmark-local ``pr33_operators`` wrapper.  The core ``ddgclib.operators``
+stress modules are intentionally left untouched by this benchmark.
 """
 
 from __future__ import annotations
@@ -31,7 +32,7 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from ddgclib.operators import stress as ddg_stress
+import pr33_operators as pr33_ops
 
 import sphere_fheron_eos_projection_benchmark as base
 
@@ -46,11 +47,11 @@ ScalarFormatter = base.ScalarFormatter
 SCRIPT_DIR = Path(__file__).resolve().parent
 
 
-def install_ddgclib_operator_aliases() -> None:
-    """Route benchmark kernels through ddgclib operator add-ons.
+def install_pr33_operator_aliases() -> None:
+    """Install the single benchmark-local operator wrapper.
 
-    The old benchmark file stays untouched.  This runner uses ddgclib
-    operators for:
+    The old benchmark file stays untouched.  This wrapper binds the PR #33
+    helper module into the runner for:
     - HC/FHeron interface force, Heron (curvature force)
     - B=dV/dx tet-volume pressure/continuity operator, Chorin/Temam style
     - ALE material-face flux, Hirt-Amsden-Cook/Toro
@@ -58,17 +59,17 @@ def install_ddgclib_operator_aliases() -> None:
     """
     global tet_face_pairs, delaunay_tets_for_points, nodal_from_tets, compute_ale_fluxes
 
-    base.fheron_forces_for_points = ddg_stress.heron_forces_for_points
-    base.tet_cell_volumes = ddg_stress.tet_cell_volumes
-    base.tet_volume_matrix = ddg_stress.tet_volume_matrix
-    base.lump_tet_masses = ddg_stress.lump_tet_masses
-    base._local_volume_stiffness = ddg_stress.local_volume_stiffness
-    base._solve_regularized = ddg_stress.solve_regularized
+    base.fheron_forces_for_points = pr33_ops.heron_forces_for_points
+    base.tet_cell_volumes = pr33_ops.tet_cell_volumes
+    base.tet_volume_matrix = pr33_ops.tet_volume_matrix
+    base.lump_tet_masses = pr33_ops.lump_tet_masses
+    base._local_volume_stiffness = pr33_ops.local_volume_stiffness
+    base._solve_regularized = pr33_ops.solve_regularized
 
-    tet_face_pairs = ddg_stress.tet_face_pairs
-    delaunay_tets_for_points = ddg_stress.delaunay_retriangulate_points
-    nodal_from_tets = ddg_stress.tet_volume_lumped_nodal_values
-    compute_ale_fluxes = ddg_stress.tet_face_ale_fluxes
+    tet_face_pairs = pr33_ops.tet_face_pairs
+    delaunay_tets_for_points = pr33_ops.delaunay_retriangulate_points
+    nodal_from_tets = pr33_ops.tet_volume_lumped_nodal_values
+    compute_ale_fluxes = pr33_ops.tet_face_ale_fluxes
 
 
 def tet_face_pairs(tets: np.ndarray) -> list[tuple[np.ndarray, int, int]]:
@@ -663,7 +664,7 @@ def run_flux_dynamic(
         nonlocal tets, reference_tet_volumes, tet_masses, reference_tet_masses
         nonlocal reference_nodal_volumes, face_pairs
 
-        new_tets, new_reference_volumes, new_masses, _retopo_stats = ddg_stress.active_retopology_tet_remap(
+        new_tets, new_reference_volumes, new_masses, _retopo_stats = pr33_ops.active_retopology_tet_remap(
             points,
             tets,
             target_total_mass=reference_total_mass,
@@ -1434,7 +1435,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> int:
-    install_ddgclib_operator_aliases()
+    install_pr33_operator_aliases()
     args = parse_args()
     args.out_dir.mkdir(parents=True, exist_ok=True)
     omega, frequency, period = base.rayleigh_lamb_frequency(args.rayleigh_mode, args.gamma, args.rho, args.radius)

--- a/cases_dynamic/oscillating_droplet_p_ref/scripts/sphere_fheron_twophase_gasmesh_benchmark.py
+++ b/cases_dynamic/oscillating_droplet_p_ref/scripts/sphere_fheron_twophase_gasmesh_benchmark.py
@@ -1,0 +1,619 @@
+"""Two-phase HC/FHeron droplet benchmark with an explicit outer gas mesh.
+
+This preview case is closer to the GitHub ``oscillating_droplet`` setup than
+the one-phase free-surface GIFs: it has liquid tets inside the interface, gas
+tets outside, and shared interface vertices.  It remains a compact benchmark,
+not a full replacement for the upstream multiphase package.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+from pathlib import Path
+import time
+import warnings
+
+import numpy as np
+
+import sphere_fheron_eos_projection_benchmark as base
+
+plt = base.plt
+FuncAnimation = base.FuncAnimation
+PillowWriter = base.PillowWriter
+Line3DCollection = base.Line3DCollection
+Poly3DCollection = base.Poly3DCollection
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+LIQUID = 1
+GAS = 0
+
+
+def build_liquid_gas_mesh(
+    subdivisions: int,
+    radius: float,
+    outer_radius_scale: float,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    unit_points, surface_faces = base.icosphere(subdivisions, 1.0)
+    n_surface = int(unit_points.shape[0])
+
+    center = np.zeros((1, 3), dtype=float)
+    liquid_shells = [0.45, 0.75, 1.0]
+    liquid_points = np.vstack([center, *(unit_points * (shell * radius) for shell in liquid_shells)])
+    interface_offset = 1 + 2 * n_surface
+    gas_outer_offset = 1 + 3 * n_surface
+    outer_points = unit_points * (float(outer_radius_scale) * float(radius))
+    points = np.vstack([liquid_points, outer_points])
+
+    triangulation = base.Delaunay(liquid_points, qhull_options="Qbb Qc")
+    raw_liquid_tets = np.asarray(triangulation.simplices, dtype=int)
+    valid = np.all(raw_liquid_tets < liquid_points.shape[0], axis=1)
+    raw_liquid_tets = raw_liquid_tets[valid]
+    liquid_volumes = base.tet_cell_volumes(liquid_points, raw_liquid_tets)
+    positive = liquid_volumes[liquid_volumes > 0.0]
+    min_volume = 0.1 * float(np.median(positive)) if positive.size else 0.0
+    liquid_tets = raw_liquid_tets[liquid_volumes > min_volume]
+
+    gas_tets: list[list[int]] = []
+    for a, b, c in np.asarray(surface_faces, dtype=int):
+        ia, ib, ic = interface_offset + int(a), interface_offset + int(b), interface_offset + int(c)
+        oa, ob, oc = gas_outer_offset + int(a), gas_outer_offset + int(b), gas_outer_offset + int(c)
+        gas_tets.extend(
+            [
+                [ia, ib, ic, oc],
+                [ia, ib, ob, oc],
+                [ia, oa, ob, oc],
+            ]
+        )
+
+    gas_tets_array = np.asarray(gas_tets, dtype=int)
+    tets = np.vstack([liquid_tets, gas_tets_array])
+    phases = np.concatenate(
+        [
+            np.full(liquid_tets.shape[0], LIQUID, dtype=int),
+            np.full(gas_tets_array.shape[0], GAS, dtype=int),
+        ]
+    )
+    interface_indices = np.arange(interface_offset, interface_offset + n_surface, dtype=int)
+    outer_indices = np.arange(gas_outer_offset, gas_outer_offset + n_surface, dtype=int)
+    liquid_vertex_count = liquid_points.shape[0]
+    return points, tets, phases, interface_indices, outer_indices, surface_faces, unit_points, np.arange(liquid_vertex_count)
+
+
+def deform_initial_interface(
+    points: np.ndarray,
+    tets: np.ndarray,
+    phases: np.ndarray,
+    liquid_vertex_indices: np.ndarray,
+    radius: float,
+    amplitude: float,
+) -> np.ndarray:
+    deformed = points.copy()
+    liquid_tets = tets[phases == LIQUID]
+    liquid_points = points[liquid_vertex_indices]
+    target_volume = float(np.sum(base.tet_cell_volumes(liquid_points, liquid_tets)))
+    deformed_liquid = base.deform_l2_volume_points(
+        liquid_points,
+        liquid_tets,
+        radius=radius,
+        amplitude=amplitude,
+        target_volume=target_volume,
+    )
+    deformed[liquid_vertex_indices] = deformed_liquid
+    return deformed
+
+
+def nodal_from_tets(n_vertices: int, tets: np.ndarray, tet_values: np.ndarray) -> np.ndarray:
+    nodal = np.zeros(n_vertices, dtype=float)
+    for tet, value in zip(np.asarray(tets, dtype=int), np.asarray(tet_values, dtype=float)):
+        share = 0.25 * float(value)
+        for vertex_idx in tet:
+            nodal[int(vertex_idx)] += share
+    return nodal
+
+
+def row_array(rows: list[dict[str, float]], key: str) -> np.ndarray:
+    return np.asarray([float(row[key]) for row in rows], dtype=float)
+
+
+def pressure_project_velocity(
+    velocities: np.ndarray,
+    volume_matrix: np.ndarray,
+    inv_mass_dof: np.ndarray,
+    target_rates: np.ndarray,
+) -> np.ndarray:
+    velocity_vec = velocities.reshape(-1)
+    stiffness = (volume_matrix * inv_mass_dof[None, :]) @ volume_matrix.T
+    rhs = volume_matrix @ velocity_vec - np.asarray(target_rates, dtype=float)
+    multipliers = base._solve_regularized(stiffness, rhs)
+    projected = velocity_vec - inv_mass_dof * (volume_matrix.T @ multipliers)
+    return projected.reshape(velocities.shape)
+
+
+def write_rows(rows: list[dict[str, float]], out_dir: Path, stem: str) -> tuple[Path, Path]:
+    csv_path = out_dir / f"{stem}.csv"
+    json_path = out_dir / f"{stem}.json"
+    with csv_path.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+    json_path.write_text(json.dumps(rows, indent=2))
+    return csv_path, json_path
+
+
+def run_twophase(
+    *,
+    closure: str,
+    subdivisions: int,
+    radius: float,
+    outer_radius_scale: float,
+    gamma: float,
+    rho_liquid: float,
+    rho_gas: float,
+    bulk_liquid: float,
+    bulk_gas: float,
+    amplitude: float,
+    n_steps: int,
+    t_final: float,
+    substeps_per_sample: int,
+    inertia_scale: float,
+    rayleigh_frequency_hz: float,
+    rayleigh_omega_rad_s: float,
+    rayleigh_mode: int,
+) -> tuple[list[dict[str, float]], np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    if closure not in {"compressible", "incompressible"}:
+        raise ValueError("closure must be compressible or incompressible")
+
+    reference_points, tets, phases, interface_indices, outer_indices, surface_faces, _unit, liquid_vertex_indices = (
+        build_liquid_gas_mesh(subdivisions, radius, outer_radius_scale)
+    )
+    points = deform_initial_interface(reference_points, tets, phases, liquid_vertex_indices, radius, amplitude)
+    fixed_points = reference_points[outer_indices].copy()
+    fixed_mask = np.zeros(points.shape[0], dtype=bool)
+    fixed_mask[outer_indices] = True
+
+    reference_tet_volumes, _matrix0 = base.tet_volume_matrix(points, tets)
+    rho_phase = np.where(phases == LIQUID, float(rho_liquid), float(rho_gas))
+    bulk_phase = np.where(phases == LIQUID, float(bulk_liquid), float(bulk_gas))
+    tet_masses = rho_phase * reference_tet_volumes
+    reference_total_mass = float(np.sum(tet_masses))
+    reference_liquid_volume = float(np.sum(reference_tet_volumes[phases == LIQUID]))
+    reference_gas_volume = float(np.sum(reference_tet_volumes[phases == GAS]))
+    target_volumes = reference_tet_volumes.copy()
+
+    velocities = np.zeros_like(points)
+    nodal_mass0 = nodal_from_tets(points.shape[0], tets, tet_masses)
+    inertial_mass_addition = np.zeros(points.shape[0], dtype=float)
+    reference_scalar_areas = base.vertex_scalar_areas(reference_points[interface_indices], surface_faces)
+    surface_added_mass = (float(rho_liquid) + float(rho_gas)) * float(radius) / float(rayleigh_mode)
+    inertial_mass_addition[interface_indices] = surface_added_mass * reference_scalar_areas
+
+    _forces0, _areas0, reference_pressure, _volume0 = base.fheron_forces_for_points(
+        reference_points[interface_indices],
+        surface_faces,
+        gamma,
+    )
+
+    dt = float(t_final) / float((int(n_steps) - 1) * int(substeps_per_sample))
+    rows: list[dict[str, float]] = []
+    snapshots: list[np.ndarray] = []
+    cpu_start = time.process_time()
+    wall_start = time.perf_counter()
+
+    def nodal_masses() -> np.ndarray:
+        return np.maximum(float(inertia_scale) * (nodal_mass0 + inertial_mass_addition), 1.0e-18)
+
+    def inverse_mass_dof(masses: np.ndarray) -> np.ndarray:
+        inv = np.repeat(1.0 / np.maximum(masses, 1.0e-300), 3)
+        fixed_dofs = np.repeat(fixed_mask, 3)
+        inv[fixed_dofs] = 0.0
+        return inv
+
+    def collect(sample_index: int, time_value: float) -> None:
+        tet_volumes, _local_matrix = base.tet_volume_matrix(points, tets)
+        interface_points = points[interface_indices]
+        _surface_forces, _surface_area_vectors, fheron_equiv, _surface_volume = base.fheron_forces_for_points(
+            interface_points,
+            surface_faces,
+            gamma,
+        )
+        fitted_amplitude = base.fit_l2_shape_amplitude(interface_points, surface_faces)
+        theory_amplitude = float(amplitude) * math.cos(float(rayleigh_omega_rad_s) * float(time_value))
+        cpu_elapsed = time.process_time() - cpu_start
+        wall_elapsed = time.perf_counter() - wall_start
+        substeps_done = int(sample_index) * int(substeps_per_sample)
+        liquid_volumes = tet_volumes[phases == LIQUID]
+        gas_volumes = tet_volumes[phases == GAS]
+        liquid_rel = liquid_volumes / np.maximum(target_volumes[phases == LIQUID], 1.0e-300)
+        gas_rel = gas_volumes / np.maximum(target_volumes[phases == GAS], 1.0e-300)
+
+        rows.append(
+            {
+                "sample": float(sample_index),
+                "t": float(time_value),
+                "closure": closure,
+                "shape_amplitude_theory": float(theory_amplitude),
+                "shape_amplitude_fit": float(fitted_amplitude),
+                "rayleigh_frequency_hz": float(rayleigh_frequency_hz),
+                "rayleigh_omega_rad_s": float(rayleigh_omega_rad_s),
+                "fheron_pressure_pa": float(fheron_equiv),
+                "liquid_pressure_gauge_pa": float(getattr(collect, "last_liquid_pressure", reference_pressure)),
+                "gas_pressure_gauge_pa": float(getattr(collect, "last_gas_pressure", 0.0)),
+                "reference_pressure_pa": float(reference_pressure),
+                "total_mass_kg": float(np.sum(tet_masses)),
+                "mass_rel_error": float(np.sum(tet_masses) / reference_total_mass - 1.0),
+                "liquid_vol_rel": float(np.sum(liquid_volumes) / reference_liquid_volume),
+                "gas_vol_rel": float(np.sum(gas_volumes) / reference_gas_volume),
+                "liquid_local_volume_rel_max_abs": float(np.max(np.abs(liquid_rel - 1.0))),
+                "gas_local_volume_rel_max_abs": float(np.max(np.abs(gas_rel - 1.0))),
+                "n_vertices": float(points.shape[0]),
+                "n_tets": float(tets.shape[0]),
+                "n_liquid_tets": float(np.sum(phases == LIQUID)),
+                "n_gas_tets": float(np.sum(phases == GAS)),
+                "n_interface_vertices": float(interface_indices.shape[0]),
+                "n_gas_vertices": float(points.shape[0] - liquid_vertex_indices.shape[0]),
+                "cpu_time_s": float(cpu_elapsed),
+                "wall_time_s": float(wall_elapsed),
+                "cpu_ms_per_substep": float(1.0e3 * cpu_elapsed / float(substeps_done)) if substeps_done else 0.0,
+                "max_speed_m_s": float(np.max(np.linalg.norm(velocities, axis=1))),
+                "mass_flux_l1_kg_s": 0.0,
+                "momentum_flux_l1_n": 0.0,
+            }
+        )
+        snapshots.append(points.copy())
+
+    collect.last_liquid_pressure = reference_pressure  # type: ignore[attr-defined]
+    collect.last_gas_pressure = 0.0  # type: ignore[attr-defined]
+    collect(0, 0.0)
+
+    total_substeps = (int(n_steps) - 1) * int(substeps_per_sample)
+    sample_index = 1
+    fixed_reference = reference_points.copy()
+    for substep in range(1, total_substeps + 1):
+        tet_volumes, local_matrix = base.tet_volume_matrix(points, tets)
+        masses = nodal_masses()
+        inv_mass = inverse_mass_dof(masses)
+
+        interface_points = points[interface_indices]
+        surface_forces, _surface_areas, _fheron_equiv, _surface_volume = base.fheron_forces_for_points(
+            interface_points,
+            surface_faces,
+            gamma,
+        )
+        forces = np.zeros_like(points)
+        forces[interface_indices] += surface_forces
+        pressure_matrix = local_matrix.T
+
+        if closure == "compressible":
+            base_pressures = np.where(phases == LIQUID, float(reference_pressure), 0.0)
+            nonpressure = forces + (pressure_matrix @ base_pressures).reshape(points.shape)
+            u_star = velocities + dt * (inv_mass * nonpressure.reshape(-1)).reshape(points.shape)
+            u_star[fixed_mask] = 0.0
+            compressibility = bulk_phase / np.maximum(reference_tet_volumes, 1.0e-300)
+            stiffness = (local_matrix * inv_mass[None, :]) @ pressure_matrix
+            linear_error = tet_volumes - target_volumes + dt * (local_matrix @ u_star.reshape(-1))
+            system = np.eye(tets.shape[0]) + (compressibility[:, None] * dt * dt) * stiffness
+            rhs = -compressibility * linear_error
+            pressure_delta = base._solve_regularized(system, rhs)
+            velocities = (u_star.reshape(-1) + dt * inv_mass * (pressure_matrix @ pressure_delta)).reshape(points.shape)
+            collect.last_liquid_pressure = float(np.mean(base_pressures[phases == LIQUID] + pressure_delta[phases == LIQUID]))  # type: ignore[attr-defined]
+            collect.last_gas_pressure = float(np.mean(pressure_delta[phases == GAS]))  # type: ignore[attr-defined]
+        else:
+            target_rates = -(tet_volumes - target_volumes) / float(dt)
+            velocity_vec = velocities.reshape(-1)
+            nonpressure_vec = forces.reshape(-1)
+            stiffness = (local_matrix * inv_mass[None, :]) @ pressure_matrix
+            rhs = (target_rates - local_matrix @ velocity_vec) / float(dt) - local_matrix @ (inv_mass * nonpressure_vec)
+            pressure_values = base._solve_regularized(stiffness, rhs)
+            total_forces = forces + (pressure_matrix @ pressure_values).reshape(points.shape)
+            velocities = velocities + dt * (inv_mass * total_forces.reshape(-1)).reshape(points.shape)
+            velocities = pressure_project_velocity(velocities, local_matrix, inv_mass, target_rates)
+            collect.last_liquid_pressure = float(np.mean(pressure_values[phases == LIQUID]))  # type: ignore[attr-defined]
+            collect.last_gas_pressure = float(np.mean(pressure_values[phases == GAS]))  # type: ignore[attr-defined]
+
+        velocities[fixed_mask] = 0.0
+        points = points + dt * velocities
+        points[outer_indices] = fixed_reference[outer_indices]
+        velocities[fixed_mask] = 0.0
+
+        if not np.all(np.isfinite(points)) or not np.all(np.isfinite(velocities)):
+            raise FloatingPointError(f"{closure} two-phase run became non-finite at substep {substep}")
+
+        if substep % int(substeps_per_sample) == 0:
+            collect(sample_index, sample_index * float(t_final) / float(int(n_steps) - 1))
+            sample_index += 1
+
+    return rows, np.asarray(snapshots, dtype=float), surface_faces, tets, phases, interface_indices, outer_indices
+
+
+def write_snapshots(
+    snapshots: np.ndarray,
+    faces: np.ndarray,
+    tets: np.ndarray,
+    phases: np.ndarray,
+    interface_indices: np.ndarray,
+    outer_indices: np.ndarray,
+    out_dir: Path,
+    stem: str,
+) -> Path:
+    path = out_dir / f"{stem}.npz"
+    np.savez_compressed(
+        path,
+        points=snapshots,
+        faces=faces,
+        tets=tets,
+        phases=phases,
+        interface_indices=interface_indices,
+        outer_indices=outer_indices,
+    )
+    return path
+
+
+def write_animation(
+    rows: list[dict[str, float]],
+    snapshots: np.ndarray,
+    faces: np.ndarray,
+    tets: np.ndarray,
+    phases: np.ndarray,
+    interface_indices: np.ndarray,
+    outer_indices: np.ndarray,
+    out_dir: Path,
+    *,
+    closure: str,
+    max_frames: int,
+    fps: int,
+) -> Path:
+    t = row_array(rows, "t")
+    amplitude_theory = row_array(rows, "shape_amplitude_theory")
+    amplitude_fit = row_array(rows, "shape_amplitude_fit")
+    liquid_vol_pct = (row_array(rows, "liquid_vol_rel") - 1.0) * 100.0
+    gas_vol_pct = (row_array(rows, "gas_vol_rel") - 1.0) * 100.0
+    liquid_local_pct = row_array(rows, "liquid_local_volume_rel_max_abs") * 100.0
+    gas_local_pct = row_array(rows, "gas_local_volume_rel_max_abs") * 100.0
+    liquid_pressure = row_array(rows, "liquid_pressure_gauge_pa")
+    gas_pressure = row_array(rows, "gas_pressure_gauge_pa")
+    cpu_time = row_array(rows, "cpu_time_s")
+
+    if closure == "compressible":
+        liquid_color = "#1f77b4"
+        gif_name = "flux_compressible_twophase_sphere.gif"
+        title = "#11 two-phase compressible: liquid droplet + gas mesh"
+    else:
+        liquid_color = "#ff7f0e"
+        gif_name = "flux_incompressible_twophase_sphere.gif"
+        title = "#12 two-phase incompressible: liquid droplet + gas mesh"
+
+    gas_color = "#8fb8de"
+    liquid_tets = tets[phases == LIQUID]
+    gas_tets = tets[phases == GAS]
+    liquid_edges = base.tet_edge_indices(liquid_tets, max_edges=250)
+    gas_edges = base.tet_edge_indices(gas_tets, max_edges=420)
+    frame_indices = np.unique(np.linspace(0, len(rows) - 1, min(len(rows), int(max_frames)), dtype=int))
+    outer_reference = snapshots[0, outer_indices]
+    max_radius = float(np.max(np.linalg.norm(snapshots.reshape((-1, 3)), axis=1)))
+    limit = 1.08 * max_radius
+    time_ticks = np.linspace(float(t[0]), float(t[-1]), 5)
+
+    fig = plt.figure(figsize=(5.2, 7.3))
+    grid = fig.add_gridspec(3, 1, height_ratios=(3.25, 1.0, 1.0), hspace=0.24)
+    ax3d = fig.add_subplot(grid[0], projection="3d")
+    ax_amp = fig.add_subplot(grid[1])
+    ax_vol = fig.add_subplot(grid[2])
+
+    def draw(frame_pos: int) -> None:
+        row_idx = int(frame_indices[frame_pos])
+        points = snapshots[row_idx]
+        surface = points[interface_indices]
+        outer = points[outer_indices]
+
+        ax3d.cla()
+        ax_amp.cla()
+        ax_vol.cla()
+
+        ax3d.add_collection3d(
+            Poly3DCollection(
+                outer[faces],
+                facecolor=(0.52, 0.70, 0.88, 0.085),
+                edgecolor=(0.22, 0.34, 0.50, 0.20),
+                linewidth=0.30,
+            )
+        )
+        ax3d.add_collection3d(
+            Line3DCollection(points[gas_edges], colors=(0.20, 0.35, 0.55, 0.19), linewidths=0.32)
+        )
+        ax3d.add_collection3d(
+            Poly3DCollection(
+                surface[faces],
+                facecolor=liquid_color,
+                edgecolor=liquid_color,
+                linewidth=0.38,
+                alpha=0.52,
+            )
+        )
+        ax3d.add_collection3d(
+            Line3DCollection(points[liquid_edges], colors=(0.05, 0.05, 0.05, 0.30), linewidths=0.34)
+        )
+        gas_vertices = np.setdiff1d(np.unique(gas_tets.reshape(-1)), interface_indices)
+        ax3d.scatter(
+            points[gas_vertices, 0],
+            points[gas_vertices, 1],
+            points[gas_vertices, 2],
+            s=5,
+            c=gas_color,
+            alpha=0.48,
+            edgecolors="none",
+            depthshade=False,
+        )
+        interior = np.setdiff1d(np.unique(liquid_tets.reshape(-1)), interface_indices)
+        if interior.size:
+            ax3d.scatter(
+                points[interior, 0],
+                points[interior, 1],
+                points[interior, 2],
+                s=6,
+                c="#2ca02c",
+                alpha=0.65,
+                edgecolors="none",
+                depthshade=False,
+            )
+
+        ax3d.set_xlim(-limit, limit)
+        ax3d.set_ylim(-limit, limit)
+        ax3d.set_zlim(-limit, limit)
+        ax3d.set_box_aspect((1.0, 1.0, 1.0))
+        ax3d.set_xticks([])
+        ax3d.set_yticks([])
+        ax3d.set_zticks([])
+        ax3d.view_init(elev=20.0, azim=32.0 + 24.0 * float(t[row_idx]) / max(float(t[-1]), 1.0e-30))
+        ax3d.set_title(title, fontsize=8.8, pad=4)
+        ax3d.text2D(
+            0.02,
+            0.97,
+            (
+                f"t = {t[row_idx]:.4f} s\n"
+                f"phase 1 liquid tets = {int(rows[row_idx]['n_liquid_tets'])}\n"
+                f"phase 0 gas tets = {int(rows[row_idx]['n_gas_tets'])}\n"
+                f"interface vertices = {int(rows[row_idx]['n_interface_vertices'])}\n"
+                f"p_liq gauge = {liquid_pressure[row_idx]:.1f} Pa\n"
+                f"p_gas gauge = {gas_pressure[row_idx]:.2e} Pa\n"
+                f"CPU = {cpu_time[row_idx]:.1f}/{cpu_time[-1]:.1f} s"
+            ),
+            transform=ax3d.transAxes,
+            va="top",
+            ha="left",
+            fontsize=7.3,
+            family="monospace",
+        )
+
+        pad = max(0.1 * float(np.ptp(amplitude_theory)), 0.004)
+        ax_amp.plot(t, amplitude_theory, "k--", lw=1.4, label="Rayleigh theory")
+        ax_amp.plot(t, amplitude_fit, color=liquid_color, lw=1.7, label="simulation")
+        ax_amp.plot(t[row_idx], amplitude_fit[row_idx], "o", color="#d62728", ms=4.2)
+        ax_amp.set_xlim(float(t[0]), float(t[-1]))
+        ax_amp.set_ylim(
+            float(min(np.min(amplitude_theory), np.min(amplitude_fit)) - pad),
+            float(max(np.max(amplitude_theory), np.max(amplitude_fit)) + pad),
+        )
+        ax_amp.set_xticks(time_ticks)
+        ax_amp.set_ylabel("a2", fontsize=8)
+        ax_amp.set_title("Shape amplitude", fontsize=8)
+        ax_amp.grid(True, alpha=0.25)
+        ax_amp.legend(frameon=False, fontsize=7, loc="upper right")
+        ax_amp.tick_params(labelsize=7)
+
+        ax_vol.plot(t, liquid_vol_pct, color=liquid_color, lw=1.5, label="liquid global dV/V")
+        ax_vol.plot(t, gas_vol_pct, color="#4c78a8", lw=1.2, ls="--", label="gas global dV/V")
+        ax_vol.plot(t, liquid_local_pct, color="#111111", lw=1.0, ls=":", label="liquid local max")
+        ax_vol.plot(t, gas_local_pct, color="#777777", lw=1.0, ls="-.", label="gas local max")
+        ax_vol.plot(t[row_idx], liquid_vol_pct[row_idx], "o", color="#d62728", ms=4.0)
+        ax_vol.set_xlim(float(t[0]), float(t[-1]))
+        ax_vol.set_xticks(time_ticks)
+        ax_vol.set_xlabel("t [s]", fontsize=8)
+        ax_vol.set_ylabel("%", fontsize=8)
+        ax_vol.set_title("Phase volume error", fontsize=8)
+        ax_vol.grid(True, alpha=0.25)
+        ax_vol.legend(frameon=False, fontsize=6.5, loc="upper right")
+        ax_vol.tick_params(labelsize=7)
+
+    fig.subplots_adjust(left=0.08, right=0.98, top=0.97, bottom=0.06)
+    animation = FuncAnimation(fig, draw, frames=len(frame_indices), interval=1000.0 / max(1, int(fps)))
+    gif_path = out_dir / gif_name
+    animation.save(gif_path, writer=PillowWriter(fps=max(1, int(fps))))
+    plt.close(fig)
+    return gif_path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Two-phase liquid/gas HC/FHeron droplet benchmark.")
+    parser.add_argument("--radius", type=float, default=1.0e-3)
+    parser.add_argument("--outer-radius-scale", type=float, default=1.60)
+    parser.add_argument("--gamma", type=float, default=0.072)
+    parser.add_argument("--rho-liquid", type=float, default=1000.0)
+    parser.add_argument("--rho-gas", type=float, default=1.2)
+    parser.add_argument("--bulk-liquid", type=float, default=2.2e9)
+    parser.add_argument("--bulk-gas", type=float, default=1.42e5)
+    parser.add_argument("--rayleigh-mode", type=int, default=2)
+    parser.add_argument("--shape-mode-ar", type=float, default=1.05)
+    parser.add_argument("--t-final", type=float, default=0.016)
+    parser.add_argument("--subdivision", type=int, default=1)
+    parser.add_argument("--steps", type=int, default=81)
+    parser.add_argument("--substeps-per-sample", type=int, default=10)
+    parser.add_argument("--inertia-scale", type=float, default=1.08)
+    parser.add_argument("--closure", choices=("both", "compressible", "incompressible"), default="both")
+    parser.add_argument("--animation-max-frames", type=int, default=32)
+    parser.add_argument("--animation-fps", type=int, default=12)
+    parser.add_argument("--out-dir", type=Path, default=SCRIPT_DIR / "out" / "sphere_fheron_twophase_gasmesh")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    omega, frequency, _period = base.rayleigh_lamb_frequency(args.rayleigh_mode, args.gamma, args.rho_liquid, args.radius)
+    amplitude = base.shape_amplitude_from_aspect_ratio(args.shape_mode_ar)
+    closures = ("compressible", "incompressible") if args.closure == "both" else (args.closure,)
+    outputs: list[Path] = []
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        for closure in closures:
+            rows, snapshots, faces, tets, phases, interface_indices, outer_indices = run_twophase(
+                closure=closure,
+                subdivisions=args.subdivision,
+                radius=args.radius,
+                outer_radius_scale=args.outer_radius_scale,
+                gamma=args.gamma,
+                rho_liquid=args.rho_liquid,
+                rho_gas=args.rho_gas,
+                bulk_liquid=args.bulk_liquid,
+                bulk_gas=args.bulk_gas,
+                amplitude=amplitude,
+                n_steps=args.steps,
+                t_final=args.t_final,
+                substeps_per_sample=args.substeps_per_sample,
+                inertia_scale=args.inertia_scale,
+                rayleigh_frequency_hz=frequency,
+                rayleigh_omega_rad_s=omega,
+                rayleigh_mode=args.rayleigh_mode,
+            )
+            csv_path, json_path = write_rows(rows, args.out_dir, f"twophase_{closure}_timeseries")
+            npz_path = write_snapshots(
+                snapshots,
+                faces,
+                tets,
+                phases,
+                interface_indices,
+                outer_indices,
+                args.out_dir,
+                f"twophase_{closure}_snapshots",
+            )
+            gif_path = write_animation(
+                rows,
+                snapshots,
+                faces,
+                tets,
+                phases,
+                interface_indices,
+                outer_indices,
+                args.out_dir,
+                closure=closure,
+                max_frames=args.animation_max_frames,
+                fps=args.animation_fps,
+            )
+            outputs.extend([csv_path, json_path, npz_path, gif_path])
+            print(
+                f"{closure}: CPU={rows[-1]['cpu_time_s']:.3f}s, "
+                f"liquid_local={rows[-1]['liquid_local_volume_rel_max_abs']:.3e}, "
+                f"gas_local={rows[-1]['gas_local_volume_rel_max_abs']:.3e}, "
+                f"p_liq={rows[-1]['liquid_pressure_gauge_pa']:.3f}, "
+                f"p_gas={rows[-1]['gas_pressure_gauge_pa']:.3e}"
+            )
+    for path in outputs:
+        print(path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ddgclib/operators/multiphase_stress.py
+++ b/ddgclib/operators/multiphase_stress.py
@@ -66,6 +66,164 @@ from ddgclib.operators.stress import (
 from ddgclib.operators.curvature_2d import surface_tension_force_2d
 from ddgclib.geometry._dual_split_2d import edge_phase_area_fractions
 
+# ---------------------------------------------------------------------------
+# Benchmark add-on operators: multiphase tet-volume pressure closure
+# ---------------------------------------------------------------------------
+
+def multiphase_tet_volume_matrix(points: np.ndarray, tets: np.ndarray):
+    """Tet volume-gradient operator for a multiphase simplicial mesh.
+
+    This wrapper intentionally uses tet volumes, not HC local dual volumes, so
+    a Delaunay flip does not directly create an HC-dual density/pressure jump.
+
+    References: Chorin projection/continuity pressure solves; ddgclib
+    retopology benchmark workaround for HC dual-volume jumps.
+    """
+    from ddgclib.operators.stress import tet_volume_matrix
+
+    return tet_volume_matrix(points, tets)
+
+
+def multiphase_tet_volume_lumped_masses(
+    n_vertices: int,
+    tets: np.ndarray,
+    tet_volumes: np.ndarray,
+    phases: np.ndarray,
+    phase_densities: dict[int, float],
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return tet masses and barycentric nodal masses for phase-labelled tets.
+
+    Each tet receives ``rho_phase V_t`` and each tet mass is lumped one quarter
+    to its four vertices.
+    """
+    from ddgclib.operators.stress import tet_volume_lumped_nodal_values
+
+    rho = np.asarray([float(phase_densities[int(phase)]) for phase in np.asarray(phases, dtype=int)], dtype=float)
+    tet_masses = rho * np.asarray(tet_volumes, dtype=float)
+    nodal_masses = tet_volume_lumped_nodal_values(n_vertices, tets, tet_masses)
+    return tet_masses, nodal_masses
+
+
+def multiphase_compressible_eos_pressure_correction(
+    *,
+    velocities: np.ndarray,
+    nonpressure_forces: np.ndarray,
+    inv_mass_dof: np.ndarray,
+    tet_volumes: np.ndarray,
+    target_tet_volumes: np.ndarray,
+    reference_tet_volumes: np.ndarray,
+    volume_matrix: np.ndarray,
+    base_pressures: np.ndarray,
+    bulk_by_tet: np.ndarray,
+    dt: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Multiphase weak-compressible pressure correction.
+
+    Solves the same EOS/continuity correction as the one-phase benchmark:
+
+        (I + dt^2 D_K B M^-1 B^T) dp
+          = -D_K (V - Vtar + dt B u*)
+
+    where ``D_K = diag(K_t/V_t^0)`` may differ by phase.
+    """
+    from ddgclib.operators.stress import solve_regularized
+
+    pressure_matrix = np.asarray(volume_matrix, dtype=float).T
+    u_star = np.asarray(velocities, dtype=float) + float(dt) * (
+        np.asarray(inv_mass_dof, dtype=float) * np.asarray(nonpressure_forces, dtype=float).reshape(-1)
+    ).reshape(np.asarray(velocities).shape)
+    compressibility = np.asarray(bulk_by_tet, dtype=float) / np.maximum(
+        np.asarray(reference_tet_volumes, dtype=float),
+        1.0e-300,
+    )
+    stiffness = (np.asarray(volume_matrix, dtype=float) * np.asarray(inv_mass_dof, dtype=float)[None, :]) @ pressure_matrix
+    linear_error = (
+        np.asarray(tet_volumes, dtype=float)
+        - np.asarray(target_tet_volumes, dtype=float)
+        + float(dt) * (np.asarray(volume_matrix, dtype=float) @ u_star.reshape(-1))
+    )
+    system = np.eye(np.asarray(tet_volumes).shape[0]) + (compressibility[:, None] * float(dt) * float(dt)) * stiffness
+    rhs = -compressibility * linear_error
+    pressure_delta = solve_regularized(system, rhs)
+    velocity_vec = u_star.reshape(-1) + float(dt) * np.asarray(inv_mass_dof, dtype=float) * (pressure_matrix @ pressure_delta)
+    return velocity_vec.reshape(np.asarray(velocities).shape), np.asarray(base_pressures, dtype=float) + pressure_delta
+
+
+def multiphase_incompressible_volume_projection(
+    *,
+    velocities: np.ndarray,
+    nonpressure_forces: np.ndarray,
+    inv_mass_dof: np.ndarray,
+    tet_volumes: np.ndarray,
+    target_tet_volumes: np.ndarray,
+    volume_matrix: np.ndarray,
+    dt: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Multiphase local incompressible projection with B u = target_rates.
+
+    Reference: Chorin/Temam projection method, applied to tet-volume
+    continuity on the moving multiphase mesh.
+    """
+    from ddgclib.operators.stress import solve_regularized
+
+    pressure_matrix = np.asarray(volume_matrix, dtype=float).T
+    target_rates = -(np.asarray(tet_volumes, dtype=float) - np.asarray(target_tet_volumes, dtype=float)) / float(dt)
+    velocity_vec = np.asarray(velocities, dtype=float).reshape(-1)
+    nonpressure_vec = np.asarray(nonpressure_forces, dtype=float).reshape(-1)
+    stiffness = (np.asarray(volume_matrix, dtype=float) * np.asarray(inv_mass_dof, dtype=float)[None, :]) @ pressure_matrix
+    rhs = (
+        (target_rates - np.asarray(volume_matrix, dtype=float) @ velocity_vec) / float(dt)
+        - np.asarray(volume_matrix, dtype=float) @ (np.asarray(inv_mass_dof, dtype=float) * nonpressure_vec)
+    )
+    pressure_values = solve_regularized(stiffness, rhs)
+    total_forces = np.asarray(nonpressure_forces, dtype=float) + (pressure_matrix @ pressure_values).reshape(np.asarray(velocities).shape)
+    projected = np.asarray(velocities, dtype=float) + float(dt) * (
+        np.asarray(inv_mass_dof, dtype=float) * total_forces.reshape(-1)
+    ).reshape(np.asarray(velocities).shape)
+    return projected, pressure_values
+
+
+def multiphase_active_retopology_remap(
+    points: np.ndarray,
+    current_tets: np.ndarray,
+    phases: np.ndarray,
+    *,
+    phase_densities: dict[int, float],
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, dict[str, float]]:
+    """Active retopology remap for phase-labelled tet meshes.
+
+    The new Delaunay tet list is rebuilt, each new tet is assigned the phase
+    of the nearest old tet center, and mass/target volume are recomputed from
+    the new tet volume.  This is a controlled benchmark remap, not a fully
+    conservative old/new-cell overlap remap.
+    """
+    from ddgclib.operators.stress import delaunay_retriangulate_points, tet_cell_volumes, tet_face_pairs
+
+    pts = np.asarray(points, dtype=float)
+    old_tets = np.asarray(current_tets, dtype=int)
+    old_centers = np.mean(pts[old_tets], axis=1)
+    new_tets = delaunay_retriangulate_points(pts, old_tets)
+    new_centers = np.mean(pts[new_tets], axis=1)
+    new_phases = np.zeros(new_tets.shape[0], dtype=int)
+    for i, center in enumerate(new_centers):
+        nearest = int(np.argmin(np.sum((old_centers - center) ** 2, axis=1)))
+        new_phases[i] = int(np.asarray(phases, dtype=int)[nearest])
+    new_volumes = tet_cell_volumes(pts, new_tets)
+    rho = np.asarray([float(phase_densities[int(phase)]) for phase in new_phases], dtype=float)
+    tet_masses = rho * new_volumes
+    old_sorted = {tuple(sorted(int(v) for v in tet)) for tet in old_tets}
+    new_sorted = {tuple(sorted(int(v) for v in tet)) for tet in new_tets}
+    changed = len(old_sorted.symmetric_difference(new_sorted))
+    stats = {
+        "retriangulation_active": 1.0,
+        "display_tet_count": float(new_tets.shape[0]),
+        "display_internal_face_count": float(len(tet_face_pairs(new_tets))),
+        "display_changed_tets": float(changed),
+        "display_changed_fraction": float(changed) / max(float(len(old_sorted) + len(new_sorted)), 1.0),
+    }
+    return new_tets, new_phases, new_volumes, tet_masses, stats
+
+
 
 def _phases_present(v, n_phases: int) -> list[int]:
     """Return the sorted list of phases with non-zero presence at v.

--- a/ddgclib/operators/multiphase_stress.py
+++ b/ddgclib/operators/multiphase_stress.py
@@ -1,49 +1,107 @@
-"""Multiphase stress operators.
+"""Multiphase stress operators for the integrated Cauchy momentum equation.
 
-This is a lightweight local backport of the operator stack Stefan referenced.
-For sharp-interface surface benchmarks, it gracefully falls back to the
-curvature-based interface force when volumetric dual geometry is absent.
+Per-phase summed formulation
+----------------------------
+
+For every vertex ``v`` we compute a force that sums per-phase
+contributions over the phases present in the vertex's dual cell::
+
+    F_i = sum_{k in phases_present(v)} F_i^{(k)} + F_st_i
+
+Each phase-k sub-force ``F_i^{(k)}`` uses:
+
+- ``p_phase[k]`` on both sides of each sub-face (never mixing phases
+  across a face).  If the neighbour ``v_j`` is bulk in a different
+  phase (so it does not store ``p_phase[k]``), we use ``v_i.p_phase[k]``
+  on the ``v_j`` end as well — this is consistent with the sub-face
+  lying entirely in phase ``k`` (bulk phase of ``v_j``) with no
+  phase-k neighbour to provide a reference.  See notes below.
+- ``dual area vector`` ``A_ij^{(k)}`` from the phase-k sub-polygon of
+  the dual cell (see :mod:`ddgclib.geometry._dual_split_2d`).
+- viscosity ``μ_k`` on the phase-k sub-face, or the harmonic mean
+  ``2 μ_i μ_j / (μ_i + μ_j)`` at μ-jumps on edges that straddle the
+  interface (both endpoints interface, neighbour in the other phase).
+
+Bulk vertices have ``phases_present = {v.phase}``; the sum collapses
+to the current single-phase formula, so bulk physics is unchanged
+from the previous own-phase-only scheme.
+
+Surface tension remains a separate ``F_st`` force on sharp-interface
+vertices — do NOT add ``γκ`` to the pressure field.  It is already
+integrated over the dual edge via the Fundamental Theorem of Calculus
+for the tangent vector (2D) / cotangent-weight Heron curvature on the
+interface sub-mesh (3D).
+
+Pressure-flux sub-case for bulk neighbours
+------------------------------------------
+For an edge (i, j) where ``v_i`` is interface and ``v_j`` is bulk
+in phase ``k``, the dual face lies entirely in phase ``k`` (bulk
+side).  ``v_i`` stores ``v_i.p_phase[k]`` (the outer/own phase
+pressure) and ``v_j`` stores ``v_j.p = v_j.p_phase[k]`` (its own
+pressure).  Both are phase-k pressures at the two ends of the face
+— exactly what the face-average flux wants.  The previous
+own-phase-only code read ``v_j.p_phase[own_phase]`` with
+``own_phase = v_i.phase`` — wrong when ``v_j.phase != v_i.phase``
+because ``v_j`` does not store a phase-``v_i.phase`` pressure.
+
+Usage
+-----
+    from functools import partial
+    from ddgclib.operators.multiphase_stress import multiphase_dudt_i
+
+    dudt_fn = partial(multiphase_dudt_i, dim=2, mps=mps, HC=HC,
+                      pressure_model=meos)
+    symplectic_euler(HC, bV, dudt_fn, dt=1e-4, n_steps=100, ...)
 """
-
 from __future__ import annotations
 
 import numpy as np
 
-from ddgclib._curvatures_heron import hndA_i_interface
-from ddgclib.operators.stress import dual_area_vector
+from ddgclib.operators.stress import (
+    dual_area_vector,
+    pressure_flux,
+    viscous_flux,
+    _resolve_pressure,
+)
+from ddgclib.operators.curvature_2d import surface_tension_force_2d
+from ddgclib.geometry._dual_split_2d import edge_phase_area_fractions
 
 
-def _resolve_pressure(v, pressure_model=None, HC=None, dim: int = 3) -> float:
-    """Return a scalar pressure for vertex ``v``.
+def _phases_present(v, n_phases: int) -> list[int]:
+    """Return the sorted list of phases with non-zero presence at v.
 
-    ``pressure_model`` may update vertex state in-place.  The fallback is the
-    scalar/array-like ``v.p`` field used by the single-phase stress operators.
+    Uses ``v.interface_phases`` when available (populated by
+    ``MultiphaseSystem.identify_interface``); otherwise falls back to
+    ``{v.phase}``.  Guaranteed to return at least one entry.
     """
-    if pressure_model is not None:
-        return float(pressure_model(v, HC=HC, dim=dim))
-
-    p_val = getattr(v, "p", 0.0)
-    if np.ndim(p_val) == 0:
-        return float(p_val)
-    return float(np.asarray(p_val).ravel()[0])
+    phases = getattr(v, 'interface_phases', None)
+    if phases is None or len(phases) == 0:
+        return [int(v.phase)]
+    return sorted(int(k) for k in phases if 0 <= int(k) < n_phases)
 
 
-def _interface_surface_tension(v, dim: int, mps) -> np.ndarray:
-    interface_nbs = {nb for nb in v.nn if getattr(nb, "is_interface", False)}
-    if len(interface_nbs) < 2:
-        return np.zeros(dim)
+def _phase_pressure(v, k: int, fallback: float = 0.0) -> float:
+    """Return v.p_phase[k] if populated, else ``fallback``."""
+    p_phase = getattr(v, 'p_phase', None)
+    if p_phase is None or k >= len(p_phase):
+        return fallback
+    val = float(p_phase[k])
+    if val == 0.0:
+        return fallback
+    return val
 
-    phases = getattr(v, "interface_phases", frozenset())
-    if len(phases) < 2:
-        return np.zeros(dim)
 
-    phase_list = sorted(phases)
-    gamma = mps.get_gamma_pair(phase_list[0], phase_list[1])
-    if gamma == 0.0:
-        return np.zeros(dim)
+def _face_viscosity_for_phase(
+    mps, _v_i, _v_j, k: int,
+) -> float:
+    """Return the viscosity on the phase-k sub-face of edge (i,j).
 
-    HNdA, _ = hndA_i_interface(v, interface_nbs | {v})
-    return -gamma * HNdA[:dim]
+    Each per-phase sub-face of the dual face lies entirely within one
+    phase (determined by the interface geometry splitting the dual
+    cell).  The viscosity is therefore unambiguously ``μ_k`` — no
+    blending or harmonic-mean approximation is needed.
+    """
+    return float(mps.get_mu(k))
 
 
 def multiphase_stress_force(
@@ -53,44 +111,121 @@ def multiphase_stress_force(
     HC=None,
     pressure_model=None,
 ) -> np.ndarray:
-    """Integrated force on a multiphase dual cell.
+    """Integrated force on a dual cell with per-phase summed stress.
 
-    When volumetric dual geometry is available, this mirrors the face-flux
-    structure of ``stress_force``.  On pure surface/interface meshes it skips
-    the pressure/viscous flux terms and still returns the sharp-interface
-    curvature force, which is the relevant contribution for the catenoid
-    equilibrium benchmark.
+    ::
+
+        F_i = sum_k F_i^{(k)} + F_st_i
+
+    See module docstring for the full sub-force formulation.
+
+    Parameters
+    ----------
+    v : vertex object
+    dim : int
+    mps : MultiphaseSystem
+    HC : Complex
+    pressure_model : callable or None
+        Typically :class:`MultiphaseEOS` — updates ``v.p_phase`` in-place.
+        Not called inside the per-phase loop; ``mps.refresh()`` is
+        expected to have already populated ``v.p_phase``.
     """
+    n_phases = mps.n_phases
+    has_p_phase = hasattr(v, 'p_phase')
+    is_interface_i = bool(getattr(v, 'is_interface', False))
+
+    phases_present = _phases_present(v, n_phases)
+
+    # Pressure references (used when a neighbour lacks phase-k pressure)
+    if has_p_phase:
+        p_i_by_phase = {k: float(v.p_phase[k]) for k in phases_present}
+    else:
+        p_fallback = _resolve_pressure(v, pressure_model, HC, dim)
+        p_i_by_phase = {k: p_fallback for k in phases_present}
+
+    u_i = v.u[:dim]
+    x_i = v.x_a[:dim]
+
+    _cache = getattr(HC, '_edge_area_cache', None)
+    _vid = id(v) if _cache is not None else None
+
     F = np.zeros(dim)
 
-    can_use_flux_terms = HC is not None and hasattr(v, "vd")
-    if can_use_flux_terms:
-        p_i = _resolve_pressure(v, pressure_model, HC, dim)
-        u_i = v.u[:dim]
-        x_i = v.x_a[:dim]
-        mu = mps.get_mu(v.phase) if mps is not None else 0.0
+    for v_j in v.nn:
+        if _cache is not None and _vid in _cache and id(v_j) in _cache[_vid]:
+            A_ij = _cache[_vid][id(v_j)]
+        else:
+            A_ij = dual_area_vector(v, v_j, HC, dim)
 
-        for v_j in v.nn:
-            try:
-                A_ij = dual_area_vector(v, v_j, HC, dim)
-            except (KeyError, IndexError, ValueError, RuntimeError, ZeroDivisionError):
+        delta_u = v_j.u[:dim] - u_i
+        d_ij = v_j.x_a[:dim] - x_i
+
+        # Per-edge phase fractions (sums to 1.0).  ``dim`` selects the
+        # curve-adjacency rule: 2D uses two-curve-neighbour polyline,
+        # 3D treats every interface neighbour as surface-adjacent.
+        fractions = edge_phase_area_fractions(
+            v, v_j, dim=dim, interface=HC,
+        )
+
+        for k, frac in fractions.items():
+            if k not in phases_present:
+                # Sub-face lies in a phase not present at v.  Skip the
+                # contribution rather than add spurious flux — this
+                # happens only for bulk-bulk cross-phase edges (a mesh
+                # artefact) where v has no mass/pressure in phase k.
                 continue
 
-            p_j = _resolve_pressure(v_j, pressure_model, HC, dim)
-            F -= 0.5 * (p_i + p_j) * A_ij
+            A_k = frac * A_ij
+            p_i_k = p_i_by_phase[k]
+            p_j_k = _phase_pressure(v_j, k, fallback=p_i_k)
+            mu_k = _face_viscosity_for_phase(mps, v, v_j, k)
 
-            delta_u = v_j.u[:dim] - u_i
-            d_ij = v_j.x_a[:dim] - x_i
-            d_norm = np.linalg.norm(d_ij)
-            if d_norm < 1e-30:
-                continue
-            d_hat = d_ij / d_norm
-            F += (mu / d_norm) * delta_u * np.dot(d_hat, A_ij)
+            F += pressure_flux(p_i_k, p_j_k, A_k)
+            F += viscous_flux(mu_k, delta_u, d_ij, A_k)
 
-    if getattr(v, "is_interface", False) and mps is not None:
+    # --- Surface tension on sharp interface vertices only ---
+    if is_interface_i:
         F += _interface_surface_tension(v, dim, mps)
 
     return F
+
+
+def _interface_surface_tension(v, dim: int, mps) -> np.ndarray:
+    """Compute surface tension force on a sharp interface vertex.
+
+    In both 2D and 3D the surface tension force is already integrated
+    over the portion of the interface inside the vertex dual cell::
+
+        F_st_i = integral_{Gamma_i} gamma * kappa * N dS
+
+    - **3D**: cotangent-weight Heron curvature restricted to the
+      interface sub-mesh (``hndA_i_interface``).  ``F_st = -gamma * HNdA_i``.
+    - **2D**: integrated dual curvature from the Fundamental Theorem of
+      Calculus applied to the tangent vector of the interface curve
+      (``surface_tension_force_2d``).  ``F_st = gamma * (t_next - t_prev)``,
+      which reconstructs a constant-curvature arc to machine precision.
+    """
+    interface_nbs = {nb for nb in v.nn if getattr(nb, 'is_interface', False)}
+    if len(interface_nbs) < 2:
+        return np.zeros(dim)
+
+    phases = getattr(v, 'interface_phases', frozenset())
+    if len(phases) < 2:
+        return np.zeros(dim)
+
+    phase_list = sorted(phases)
+    gamma = mps.get_gamma_pair(phase_list[0], phase_list[1])
+    if gamma == 0.0:
+        return np.zeros(dim)
+
+    if dim == 3:
+        from ddgclib._curvatures_heron import hndA_i_interface
+        HNdA, _C_i = hndA_i_interface(v, interface_nbs | {v})
+        return -gamma * HNdA[:dim]
+    else:
+        F = np.zeros(dim)
+        F[:2] = surface_tension_force_2d(v, gamma, interface_nbs)
+        return F
 
 
 def multiphase_stress_acceleration(
@@ -100,10 +235,13 @@ def multiphase_stress_acceleration(
     HC=None,
     pressure_model=None,
 ) -> np.ndarray:
-    F = multiphase_stress_force(v, dim=dim, mps=mps, HC=HC, pressure_model=pressure_model)
+    """Acceleration from multiphase stress: a_i = F_i / m_i."""
+    F = multiphase_stress_force(v, dim=dim, mps=mps, HC=HC,
+                                pressure_model=pressure_model)
     if v.m < 1e-30:
         return np.zeros(dim)
     return F / v.m
 
 
+# Canonical alias for integrator usage
 multiphase_dudt_i = multiphase_stress_acceleration

--- a/ddgclib/operators/multiphase_stress.py
+++ b/ddgclib/operators/multiphase_stress.py
@@ -1,288 +1,49 @@
-"""Multiphase stress operators for the integrated Cauchy momentum equation.
+"""Multiphase stress operators.
 
-Per-phase summed formulation
-----------------------------
-
-For every vertex ``v`` we compute a force that sums per-phase
-contributions over the phases present in the vertex's dual cell::
-
-    F_i = sum_{k in phases_present(v)} F_i^{(k)} + F_st_i
-
-Each phase-k sub-force ``F_i^{(k)}`` uses:
-
-- ``p_phase[k]`` on both sides of each sub-face (never mixing phases
-  across a face).  If the neighbour ``v_j`` is bulk in a different
-  phase (so it does not store ``p_phase[k]``), we use ``v_i.p_phase[k]``
-  on the ``v_j`` end as well — this is consistent with the sub-face
-  lying entirely in phase ``k`` (bulk phase of ``v_j``) with no
-  phase-k neighbour to provide a reference.  See notes below.
-- ``dual area vector`` ``A_ij^{(k)}`` from the phase-k sub-polygon of
-  the dual cell (see :mod:`ddgclib.geometry._dual_split_2d`).
-- viscosity ``μ_k`` on the phase-k sub-face, or the harmonic mean
-  ``2 μ_i μ_j / (μ_i + μ_j)`` at μ-jumps on edges that straddle the
-  interface (both endpoints interface, neighbour in the other phase).
-
-Bulk vertices have ``phases_present = {v.phase}``; the sum collapses
-to the current single-phase formula, so bulk physics is unchanged
-from the previous own-phase-only scheme.
-
-Surface tension remains a separate ``F_st`` force on sharp-interface
-vertices — do NOT add ``γκ`` to the pressure field.  It is already
-integrated over the dual edge via the Fundamental Theorem of Calculus
-for the tangent vector (2D) / cotangent-weight Heron curvature on the
-interface sub-mesh (3D).
-
-Pressure-flux sub-case for bulk neighbours
-------------------------------------------
-For an edge (i, j) where ``v_i`` is interface and ``v_j`` is bulk
-in phase ``k``, the dual face lies entirely in phase ``k`` (bulk
-side).  ``v_i`` stores ``v_i.p_phase[k]`` (the outer/own phase
-pressure) and ``v_j`` stores ``v_j.p = v_j.p_phase[k]`` (its own
-pressure).  Both are phase-k pressures at the two ends of the face
-— exactly what the face-average flux wants.  The previous
-own-phase-only code read ``v_j.p_phase[own_phase]`` with
-``own_phase = v_i.phase`` — wrong when ``v_j.phase != v_i.phase``
-because ``v_j`` does not store a phase-``v_i.phase`` pressure.
-
-Usage
------
-    from functools import partial
-    from ddgclib.operators.multiphase_stress import multiphase_dudt_i
-
-    dudt_fn = partial(multiphase_dudt_i, dim=2, mps=mps, HC=HC,
-                      pressure_model=meos)
-    symplectic_euler(HC, bV, dudt_fn, dt=1e-4, n_steps=100, ...)
+This is a lightweight local backport of the operator stack Stefan referenced.
+For sharp-interface surface benchmarks, it gracefully falls back to the
+curvature-based interface force when volumetric dual geometry is absent.
 """
+
 from __future__ import annotations
 
 import numpy as np
 
-from ddgclib.operators.stress import (
-    VolumeGradientPressureState,
-    dual_area_vector,
-    pressure_flux,
-    viscous_flux,
-    _resolve_pressure,
-)
-from ddgclib.operators.curvature_2d import surface_tension_force_2d
-from ddgclib.geometry._dual_split_2d import edge_phase_area_fractions
+from ddgclib._curvatures_heron import hndA_i_interface
+from ddgclib.operators.stress import dual_area_vector
 
-# ---------------------------------------------------------------------------
-# Benchmark add-on operators: multiphase tet-volume pressure closure
-# ---------------------------------------------------------------------------
 
-class MultiphaseVolumeGradientPressureState(VolumeGradientPressureState):
-    """Phase-labelled tet-volume pressure state for dynamic integrators.
+def _resolve_pressure(v, pressure_model=None, HC=None, dim: int = 3) -> float:
+    """Return a scalar pressure for vertex ``v``.
 
-    The equations are inherited from ``VolumeGradientPressureState``:
-    ``B=dV/dx`` is rebuilt after active retopology, phase densities provide
-    ``V_t^tar=m_t/rho_phase``, and phase bulk moduli provide the EOS stiffness.
-    This is intentionally separate from ``multiphase_stress_force``: the
-    pressure-reference benchmark needs the pressure force ``B^T p`` to be
-    adjoint to the tet-volume continuity operator ``B``.
-
-    References: Chorin (1968) pressure projection; Hirt, Amsden & Cook (1974)
-    ALE moving mesh; Toro (2009) Riemann fluxes; ddgclib HC Heron curvature.
+    ``pressure_model`` may update vertex state in-place.  The fallback is the
+    scalar/array-like ``v.p`` field used by the single-phase stress operators.
     """
+    if pressure_model is not None:
+        return float(pressure_model(v, HC=HC, dim=dim))
+
+    p_val = getattr(v, "p", 0.0)
+    if np.ndim(p_val) == 0:
+        return float(p_val)
+    return float(np.asarray(p_val).ravel()[0])
 
 
-def multiphase_volume_gradient_pressure_acceleration(vertex, *, state, HC=None, dt=None, dim: int = 3, mu: float = 0.0):
-    """Multiphase ``dudt_fn`` wrapper for the tet-volume pressure state."""
-    if HC is None:
-        HC = getattr(state, "HC", None)
-    return state.acceleration(vertex, HC=HC, dt=dt, dim=dim, mu=mu)
+def _interface_surface_tension(v, dim: int, mps) -> np.ndarray:
+    interface_nbs = {nb for nb in v.nn if getattr(nb, "is_interface", False)}
+    if len(interface_nbs) < 2:
+        return np.zeros(dim)
 
+    phases = getattr(v, "interface_phases", frozenset())
+    if len(phases) < 2:
+        return np.zeros(dim)
 
-def multiphase_tet_volume_matrix(points: np.ndarray, tets: np.ndarray):
-    """Tet volume-gradient operator for a multiphase simplicial mesh.
+    phase_list = sorted(phases)
+    gamma = mps.get_gamma_pair(phase_list[0], phase_list[1])
+    if gamma == 0.0:
+        return np.zeros(dim)
 
-    This wrapper intentionally uses tet volumes, not HC local dual volumes, so
-    a Delaunay flip does not directly create an HC-dual density/pressure jump.
-
-    References: Chorin projection/continuity pressure solves; ddgclib
-    retopology benchmark workaround for HC dual-volume jumps.
-    """
-    from ddgclib.operators.stress import tet_volume_matrix
-
-    return tet_volume_matrix(points, tets)
-
-
-def multiphase_tet_volume_lumped_masses(
-    n_vertices: int,
-    tets: np.ndarray,
-    tet_volumes: np.ndarray,
-    phases: np.ndarray,
-    phase_densities: dict[int, float],
-) -> tuple[np.ndarray, np.ndarray]:
-    """Return tet masses and barycentric nodal masses for phase-labelled tets.
-
-    Each tet receives ``rho_phase V_t`` and each tet mass is lumped one quarter
-    to its four vertices.
-    """
-    from ddgclib.operators.stress import tet_volume_lumped_nodal_values
-
-    rho = np.asarray([float(phase_densities[int(phase)]) for phase in np.asarray(phases, dtype=int)], dtype=float)
-    tet_masses = rho * np.asarray(tet_volumes, dtype=float)
-    nodal_masses = tet_volume_lumped_nodal_values(n_vertices, tets, tet_masses)
-    return tet_masses, nodal_masses
-
-
-def multiphase_compressible_eos_pressure_correction(
-    *,
-    velocities: np.ndarray,
-    nonpressure_forces: np.ndarray,
-    inv_mass_dof: np.ndarray,
-    tet_volumes: np.ndarray,
-    target_tet_volumes: np.ndarray,
-    reference_tet_volumes: np.ndarray,
-    volume_matrix: np.ndarray,
-    base_pressures: np.ndarray,
-    bulk_by_tet: np.ndarray,
-    dt: float,
-) -> tuple[np.ndarray, np.ndarray]:
-    """Multiphase weak-compressible pressure correction.
-
-    Solves the same EOS/continuity correction as the one-phase benchmark:
-
-        (I + dt^2 D_K B M^-1 B^T) dp
-          = -D_K (V - Vtar + dt B u*)
-
-    where ``D_K = diag(K_t/V_t^0)`` may differ by phase.
-    """
-    from ddgclib.operators.stress import solve_regularized
-
-    pressure_matrix = np.asarray(volume_matrix, dtype=float).T
-    u_star = np.asarray(velocities, dtype=float) + float(dt) * (
-        np.asarray(inv_mass_dof, dtype=float) * np.asarray(nonpressure_forces, dtype=float).reshape(-1)
-    ).reshape(np.asarray(velocities).shape)
-    compressibility = np.asarray(bulk_by_tet, dtype=float) / np.maximum(
-        np.asarray(reference_tet_volumes, dtype=float),
-        1.0e-300,
-    )
-    stiffness = (np.asarray(volume_matrix, dtype=float) * np.asarray(inv_mass_dof, dtype=float)[None, :]) @ pressure_matrix
-    linear_error = (
-        np.asarray(tet_volumes, dtype=float)
-        - np.asarray(target_tet_volumes, dtype=float)
-        + float(dt) * (np.asarray(volume_matrix, dtype=float) @ u_star.reshape(-1))
-    )
-    system = np.eye(np.asarray(tet_volumes).shape[0]) + (compressibility[:, None] * float(dt) * float(dt)) * stiffness
-    rhs = -compressibility * linear_error
-    pressure_delta = solve_regularized(system, rhs)
-    velocity_vec = u_star.reshape(-1) + float(dt) * np.asarray(inv_mass_dof, dtype=float) * (pressure_matrix @ pressure_delta)
-    return velocity_vec.reshape(np.asarray(velocities).shape), np.asarray(base_pressures, dtype=float) + pressure_delta
-
-
-def multiphase_incompressible_volume_projection(
-    *,
-    velocities: np.ndarray,
-    nonpressure_forces: np.ndarray,
-    inv_mass_dof: np.ndarray,
-    tet_volumes: np.ndarray,
-    target_tet_volumes: np.ndarray,
-    volume_matrix: np.ndarray,
-    dt: float,
-) -> tuple[np.ndarray, np.ndarray]:
-    """Multiphase local incompressible projection with B u = target_rates.
-
-    Reference: Chorin/Temam projection method, applied to tet-volume
-    continuity on the moving multiphase mesh.
-    """
-    from ddgclib.operators.stress import solve_regularized
-
-    pressure_matrix = np.asarray(volume_matrix, dtype=float).T
-    target_rates = -(np.asarray(tet_volumes, dtype=float) - np.asarray(target_tet_volumes, dtype=float)) / float(dt)
-    velocity_vec = np.asarray(velocities, dtype=float).reshape(-1)
-    nonpressure_vec = np.asarray(nonpressure_forces, dtype=float).reshape(-1)
-    stiffness = (np.asarray(volume_matrix, dtype=float) * np.asarray(inv_mass_dof, dtype=float)[None, :]) @ pressure_matrix
-    rhs = (
-        (target_rates - np.asarray(volume_matrix, dtype=float) @ velocity_vec) / float(dt)
-        - np.asarray(volume_matrix, dtype=float) @ (np.asarray(inv_mass_dof, dtype=float) * nonpressure_vec)
-    )
-    pressure_values = solve_regularized(stiffness, rhs)
-    total_forces = np.asarray(nonpressure_forces, dtype=float) + (pressure_matrix @ pressure_values).reshape(np.asarray(velocities).shape)
-    projected = np.asarray(velocities, dtype=float) + float(dt) * (
-        np.asarray(inv_mass_dof, dtype=float) * total_forces.reshape(-1)
-    ).reshape(np.asarray(velocities).shape)
-    return projected, pressure_values
-
-
-def multiphase_active_retopology_remap(
-    points: np.ndarray,
-    current_tets: np.ndarray,
-    phases: np.ndarray,
-    *,
-    phase_densities: dict[int, float],
-) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, dict[str, float]]:
-    """Active retopology remap for phase-labelled tet meshes.
-
-    The new Delaunay tet list is rebuilt, each new tet is assigned the phase
-    of the nearest old tet center, and mass/target volume are recomputed from
-    the new tet volume.  This is a controlled benchmark remap, not a fully
-    conservative old/new-cell overlap remap.
-    """
-    from ddgclib.operators.stress import delaunay_retriangulate_points, tet_cell_volumes, tet_face_pairs
-
-    pts = np.asarray(points, dtype=float)
-    old_tets = np.asarray(current_tets, dtype=int)
-    old_centers = np.mean(pts[old_tets], axis=1)
-    new_tets = delaunay_retriangulate_points(pts, old_tets)
-    new_centers = np.mean(pts[new_tets], axis=1)
-    new_phases = np.zeros(new_tets.shape[0], dtype=int)
-    for i, center in enumerate(new_centers):
-        nearest = int(np.argmin(np.sum((old_centers - center) ** 2, axis=1)))
-        new_phases[i] = int(np.asarray(phases, dtype=int)[nearest])
-    new_volumes = tet_cell_volumes(pts, new_tets)
-    rho = np.asarray([float(phase_densities[int(phase)]) for phase in new_phases], dtype=float)
-    tet_masses = rho * new_volumes
-    old_sorted = {tuple(sorted(int(v) for v in tet)) for tet in old_tets}
-    new_sorted = {tuple(sorted(int(v) for v in tet)) for tet in new_tets}
-    changed = len(old_sorted.symmetric_difference(new_sorted))
-    stats = {
-        "retriangulation_active": 1.0,
-        "display_tet_count": float(new_tets.shape[0]),
-        "display_internal_face_count": float(len(tet_face_pairs(new_tets))),
-        "display_changed_tets": float(changed),
-        "display_changed_fraction": float(changed) / max(float(len(old_sorted) + len(new_sorted)), 1.0),
-    }
-    return new_tets, new_phases, new_volumes, tet_masses, stats
-
-
-
-def _phases_present(v, n_phases: int) -> list[int]:
-    """Return the sorted list of phases with non-zero presence at v.
-
-    Uses ``v.interface_phases`` when available (populated by
-    ``MultiphaseSystem.identify_interface``); otherwise falls back to
-    ``{v.phase}``.  Guaranteed to return at least one entry.
-    """
-    phases = getattr(v, 'interface_phases', None)
-    if phases is None or len(phases) == 0:
-        return [int(v.phase)]
-    return sorted(int(k) for k in phases if 0 <= int(k) < n_phases)
-
-
-def _phase_pressure(v, k: int, fallback: float = 0.0) -> float:
-    """Return v.p_phase[k] if populated, else ``fallback``."""
-    p_phase = getattr(v, 'p_phase', None)
-    if p_phase is None or k >= len(p_phase):
-        return fallback
-    val = float(p_phase[k])
-    if val == 0.0:
-        return fallback
-    return val
-
-
-def _face_viscosity_for_phase(
-    mps, _v_i, _v_j, k: int,
-) -> float:
-    """Return the viscosity on the phase-k sub-face of edge (i,j).
-
-    Each per-phase sub-face of the dual face lies entirely within one
-    phase (determined by the interface geometry splitting the dual
-    cell).  The viscosity is therefore unambiguously ``μ_k`` — no
-    blending or harmonic-mean approximation is needed.
-    """
-    return float(mps.get_mu(k))
+    HNdA, _ = hndA_i_interface(v, interface_nbs | {v})
+    return -gamma * HNdA[:dim]
 
 
 def multiphase_stress_force(
@@ -292,121 +53,44 @@ def multiphase_stress_force(
     HC=None,
     pressure_model=None,
 ) -> np.ndarray:
-    """Integrated force on a dual cell with per-phase summed stress.
+    """Integrated force on a multiphase dual cell.
 
-    ::
-
-        F_i = sum_k F_i^{(k)} + F_st_i
-
-    See module docstring for the full sub-force formulation.
-
-    Parameters
-    ----------
-    v : vertex object
-    dim : int
-    mps : MultiphaseSystem
-    HC : Complex
-    pressure_model : callable or None
-        Typically :class:`MultiphaseEOS` — updates ``v.p_phase`` in-place.
-        Not called inside the per-phase loop; ``mps.refresh()`` is
-        expected to have already populated ``v.p_phase``.
+    When volumetric dual geometry is available, this mirrors the face-flux
+    structure of ``stress_force``.  On pure surface/interface meshes it skips
+    the pressure/viscous flux terms and still returns the sharp-interface
+    curvature force, which is the relevant contribution for the catenoid
+    equilibrium benchmark.
     """
-    n_phases = mps.n_phases
-    has_p_phase = hasattr(v, 'p_phase')
-    is_interface_i = bool(getattr(v, 'is_interface', False))
-
-    phases_present = _phases_present(v, n_phases)
-
-    # Pressure references (used when a neighbour lacks phase-k pressure)
-    if has_p_phase:
-        p_i_by_phase = {k: float(v.p_phase[k]) for k in phases_present}
-    else:
-        p_fallback = _resolve_pressure(v, pressure_model, HC, dim)
-        p_i_by_phase = {k: p_fallback for k in phases_present}
-
-    u_i = v.u[:dim]
-    x_i = v.x_a[:dim]
-
-    _cache = getattr(HC, '_edge_area_cache', None)
-    _vid = id(v) if _cache is not None else None
-
     F = np.zeros(dim)
 
-    for v_j in v.nn:
-        if _cache is not None and _vid in _cache and id(v_j) in _cache[_vid]:
-            A_ij = _cache[_vid][id(v_j)]
-        else:
-            A_ij = dual_area_vector(v, v_j, HC, dim)
+    can_use_flux_terms = HC is not None and hasattr(v, "vd")
+    if can_use_flux_terms:
+        p_i = _resolve_pressure(v, pressure_model, HC, dim)
+        u_i = v.u[:dim]
+        x_i = v.x_a[:dim]
+        mu = mps.get_mu(v.phase) if mps is not None else 0.0
 
-        delta_u = v_j.u[:dim] - u_i
-        d_ij = v_j.x_a[:dim] - x_i
-
-        # Per-edge phase fractions (sums to 1.0).  ``dim`` selects the
-        # curve-adjacency rule: 2D uses two-curve-neighbour polyline,
-        # 3D treats every interface neighbour as surface-adjacent.
-        fractions = edge_phase_area_fractions(
-            v, v_j, dim=dim, interface=HC,
-        )
-
-        for k, frac in fractions.items():
-            if k not in phases_present:
-                # Sub-face lies in a phase not present at v.  Skip the
-                # contribution rather than add spurious flux — this
-                # happens only for bulk-bulk cross-phase edges (a mesh
-                # artefact) where v has no mass/pressure in phase k.
+        for v_j in v.nn:
+            try:
+                A_ij = dual_area_vector(v, v_j, HC, dim)
+            except (KeyError, IndexError, ValueError, RuntimeError, ZeroDivisionError):
                 continue
 
-            A_k = frac * A_ij
-            p_i_k = p_i_by_phase[k]
-            p_j_k = _phase_pressure(v_j, k, fallback=p_i_k)
-            mu_k = _face_viscosity_for_phase(mps, v, v_j, k)
+            p_j = _resolve_pressure(v_j, pressure_model, HC, dim)
+            F -= 0.5 * (p_i + p_j) * A_ij
 
-            F += pressure_flux(p_i_k, p_j_k, A_k)
-            F += viscous_flux(mu_k, delta_u, d_ij, A_k)
+            delta_u = v_j.u[:dim] - u_i
+            d_ij = v_j.x_a[:dim] - x_i
+            d_norm = np.linalg.norm(d_ij)
+            if d_norm < 1e-30:
+                continue
+            d_hat = d_ij / d_norm
+            F += (mu / d_norm) * delta_u * np.dot(d_hat, A_ij)
 
-    # --- Surface tension on sharp interface vertices only ---
-    if is_interface_i:
+    if getattr(v, "is_interface", False) and mps is not None:
         F += _interface_surface_tension(v, dim, mps)
 
     return F
-
-
-def _interface_surface_tension(v, dim: int, mps) -> np.ndarray:
-    """Compute surface tension force on a sharp interface vertex.
-
-    In both 2D and 3D the surface tension force is already integrated
-    over the portion of the interface inside the vertex dual cell::
-
-        F_st_i = integral_{Gamma_i} gamma * kappa * N dS
-
-    - **3D**: cotangent-weight Heron curvature restricted to the
-      interface sub-mesh (``hndA_i_interface``).  ``F_st = -gamma * HNdA_i``.
-    - **2D**: integrated dual curvature from the Fundamental Theorem of
-      Calculus applied to the tangent vector of the interface curve
-      (``surface_tension_force_2d``).  ``F_st = gamma * (t_next - t_prev)``,
-      which reconstructs a constant-curvature arc to machine precision.
-    """
-    interface_nbs = {nb for nb in v.nn if getattr(nb, 'is_interface', False)}
-    if len(interface_nbs) < 2:
-        return np.zeros(dim)
-
-    phases = getattr(v, 'interface_phases', frozenset())
-    if len(phases) < 2:
-        return np.zeros(dim)
-
-    phase_list = sorted(phases)
-    gamma = mps.get_gamma_pair(phase_list[0], phase_list[1])
-    if gamma == 0.0:
-        return np.zeros(dim)
-
-    if dim == 3:
-        from ddgclib._curvatures_heron import hndA_i_interface
-        HNdA, _C_i = hndA_i_interface(v, interface_nbs | {v})
-        return -gamma * HNdA[:dim]
-    else:
-        F = np.zeros(dim)
-        F[:2] = surface_tension_force_2d(v, gamma, interface_nbs)
-        return F
 
 
 def multiphase_stress_acceleration(
@@ -416,13 +100,10 @@ def multiphase_stress_acceleration(
     HC=None,
     pressure_model=None,
 ) -> np.ndarray:
-    """Acceleration from multiphase stress: a_i = F_i / m_i."""
-    F = multiphase_stress_force(v, dim=dim, mps=mps, HC=HC,
-                                pressure_model=pressure_model)
+    F = multiphase_stress_force(v, dim=dim, mps=mps, HC=HC, pressure_model=pressure_model)
     if v.m < 1e-30:
         return np.zeros(dim)
     return F / v.m
 
 
-# Canonical alias for integrator usage
 multiphase_dudt_i = multiphase_stress_acceleration

--- a/ddgclib/operators/multiphase_stress.py
+++ b/ddgclib/operators/multiphase_stress.py
@@ -58,6 +58,7 @@ from __future__ import annotations
 import numpy as np
 
 from ddgclib.operators.stress import (
+    VolumeGradientPressureState,
     dual_area_vector,
     pressure_flux,
     viscous_flux,
@@ -69,6 +70,28 @@ from ddgclib.geometry._dual_split_2d import edge_phase_area_fractions
 # ---------------------------------------------------------------------------
 # Benchmark add-on operators: multiphase tet-volume pressure closure
 # ---------------------------------------------------------------------------
+
+class MultiphaseVolumeGradientPressureState(VolumeGradientPressureState):
+    """Phase-labelled tet-volume pressure state for dynamic integrators.
+
+    The equations are inherited from ``VolumeGradientPressureState``:
+    ``B=dV/dx`` is rebuilt after active retopology, phase densities provide
+    ``V_t^tar=m_t/rho_phase``, and phase bulk moduli provide the EOS stiffness.
+    This is intentionally separate from ``multiphase_stress_force``: the
+    pressure-reference benchmark needs the pressure force ``B^T p`` to be
+    adjoint to the tet-volume continuity operator ``B``.
+
+    References: Chorin (1968) pressure projection; Hirt, Amsden & Cook (1974)
+    ALE moving mesh; Toro (2009) Riemann fluxes; ddgclib HC Heron curvature.
+    """
+
+
+def multiphase_volume_gradient_pressure_acceleration(vertex, *, state, HC=None, dt=None, dim: int = 3, mu: float = 0.0):
+    """Multiphase ``dudt_fn`` wrapper for the tet-volume pressure state."""
+    if HC is None:
+        HC = getattr(state, "HC", None)
+    return state.acceleration(vertex, HC=HC, dt=dt, dim=dim, mu=mu)
+
 
 def multiphase_tet_volume_matrix(points: np.ndarray, tets: np.ndarray):
     """Tet volume-gradient operator for a multiphase simplicial mesh.

--- a/ddgclib/operators/stress.py
+++ b/ddgclib/operators/stress.py
@@ -577,6 +577,511 @@ def active_retopology_tet_remap(
     return new_tets, reference_tet_volumes, tet_masses, stats
 
 
+def _tet_phase_retopology_remap(
+    points: np.ndarray,
+    current_tets: np.ndarray,
+    current_phases: np.ndarray,
+    *,
+    phase_densities: dict[int, float],
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, dict[str, float]]:
+    """Rebuild a phase-labelled tet list and reset tet mass/target volumes.
+
+    Each new Delaunay tet is assigned the phase of the nearest old tet center.
+    This compact remap is used by the oscillating-droplet pressure-reference
+    benchmark to make the pressure operator insensitive to HC dual-volume jumps
+    caused by Delaunay flips.
+    """
+    pts = np.asarray(points, dtype=float)
+    old_tets = np.asarray(current_tets, dtype=int)
+    old_phases = np.asarray(current_phases, dtype=int)
+    old_centers = np.mean(pts[old_tets], axis=1)
+    new_tets = delaunay_retriangulate_points(pts, old_tets)
+    new_centers = np.mean(pts[new_tets], axis=1)
+    new_phases = np.zeros(new_tets.shape[0], dtype=int)
+    for tet_idx, center in enumerate(new_centers):
+        nearest = int(np.argmin(np.sum((old_centers - center) ** 2, axis=1)))
+        new_phases[tet_idx] = int(old_phases[nearest])
+    new_volumes = tet_cell_volumes(pts, new_tets)
+    rho = np.asarray([float(phase_densities[int(phase)]) for phase in new_phases], dtype=float)
+    tet_masses = rho * new_volumes
+    old_sorted = {tuple(sorted(int(v) for v in tet)) for tet in old_tets}
+    new_sorted = {tuple(sorted(int(v) for v in tet)) for tet in new_tets}
+    changed = len(old_sorted.symmetric_difference(new_sorted))
+    stats = {
+        "retriangulation_active": 1.0,
+        "display_tet_count": float(new_tets.shape[0]),
+        "display_internal_face_count": float(len(tet_face_pairs(new_tets))),
+        "display_changed_tets": float(changed),
+        "display_changed_fraction": float(changed) / max(float(len(old_sorted) + len(new_sorted)), 1.0),
+    }
+    return new_tets, new_phases, new_volumes, tet_masses, stats
+
+
+class VolumeGradientPressureState:
+    """Cached tet-volume pressure operator for dynamic integrators.
+
+    This state is the pressure-reference drop-in for the face-average pressure
+    flux in :func:`stress_force`.  It keeps the standard vertex update
+
+        du_i/dt = F_i / m_i,     dx_i/dt = u_i
+
+    but computes the pressure force from tet-volume gradients,
+
+        B[t, 3*i:3*i+3] = dV_t / dx_i,        F^p = B^T p.
+
+    The compressible branch solves the EOS/continuity correction
+
+        (I + dt^2 D_K B M^{-1} B^T) dp
+          = -D_K (V - V_tar + dt B u*),
+
+    while the incompressible branch solves the local projection enforcing
+    ``B u^{n+1} = -(V - V_tar)/dt``.  References: Chorin (1968) projection
+    method; Hirt, Amsden & Cook (1974) ALE formulation; Toro (2009) Riemann
+    fluxes.  The Heron surface force is the ddgclib/HyperCT HC curvature force.
+    """
+
+    vertex_index_attr = "_volume_gradient_index"
+
+    def __init__(
+        self,
+        *,
+        tets: np.ndarray,
+        surface_indices: np.ndarray,
+        surface_faces: np.ndarray,
+        gamma: float,
+        density: float,
+        bulk_modulus: float | np.ndarray,
+        closure: str,
+        reference_tet_volumes: np.ndarray,
+        tet_masses: np.ndarray,
+        base_tet_pressures: float | np.ndarray,
+        dt: float,
+        inertia_scale: float = 1.0,
+        inertial_mass_addition: np.ndarray | None = None,
+        damping_rate: float = 0.0,
+        fixed_indices: np.ndarray | None = None,
+        phase_ids: np.ndarray | None = None,
+        phase_densities: dict[int, float] | None = None,
+        phase_bulk_moduli: dict[int, float] | None = None,
+        phase_base_pressures: dict[int, float] | None = None,
+        active_retopology: bool = False,
+        mass_flux_coupling: float = 0.0,
+        momentum_flux_coupling: float = 0.0,
+        density_change_limit: float | None = None,
+        flux_cfl_limit: float = 0.25,
+        flux_scheme: str = "upwind",
+        face_flux_mode: str = "lagrangian",
+        flux_timing: str = "pre-pressure",
+        mass_floor_fraction: float = 0.35,
+        sound_speed: float | None = None,
+        incompressible_target_mode: str = "reference",
+    ) -> None:
+        if closure not in {"compressible", "incompressible"}:
+            raise ValueError("closure must be 'compressible' or 'incompressible'")
+        if flux_timing not in {"pre-pressure", "post-pressure"}:
+            raise ValueError("flux_timing must be 'pre-pressure' or 'post-pressure'")
+        if incompressible_target_mode not in {"reference", "mass"}:
+            raise ValueError("incompressible_target_mode must be 'reference' or 'mass'")
+        self.tets = np.asarray(tets, dtype=int).copy()
+        self.surface_indices = np.asarray(surface_indices, dtype=int).copy()
+        self.surface_faces = np.asarray(surface_faces, dtype=int).copy()
+        self.gamma = float(gamma)
+        self.density = float(density)
+        self.bulk_modulus = np.asarray(bulk_modulus, dtype=float)
+        self.closure = closure
+        self.reference_tet_volumes = np.asarray(reference_tet_volumes, dtype=float).copy()
+        self.tet_masses = np.asarray(tet_masses, dtype=float).copy()
+        self.reference_tet_masses = self.tet_masses.copy()
+        self.base_tet_pressures = np.asarray(base_tet_pressures, dtype=float)
+        self.dt = float(dt)
+        self.inertia_scale = float(inertia_scale)
+        self.inertial_mass_addition = (
+            None if inertial_mass_addition is None else np.asarray(inertial_mass_addition, dtype=float).copy()
+        )
+        self.damping_rate = float(damping_rate)
+        self.fixed_indices = np.asarray(fixed_indices if fixed_indices is not None else [], dtype=int)
+        self.phase_ids = None if phase_ids is None else np.asarray(phase_ids, dtype=int).copy()
+        self.phase_densities = dict(phase_densities or {})
+        self.phase_bulk_moduli = dict(phase_bulk_moduli or {})
+        self.phase_base_pressures = dict(phase_base_pressures or {})
+        self.active_retopology = bool(active_retopology)
+        self.mass_flux_coupling = float(mass_flux_coupling)
+        self.momentum_flux_coupling = float(momentum_flux_coupling)
+        self.density_change_limit = density_change_limit
+        self.flux_cfl_limit = float(flux_cfl_limit)
+        self.flux_scheme = flux_scheme
+        self.face_flux_mode = face_flux_mode
+        self.flux_timing = flux_timing
+        self.mass_floor_fraction = float(mass_floor_fraction)
+        self.sound_speed = float(sound_speed) if sound_speed is not None else float(np.sqrt(float(np.max(self.bulk_modulus)) / self.density))
+        self.incompressible_target_mode = incompressible_target_mode
+        self.reference_total_mass = float(np.sum(self.tet_masses))
+        self.reference_total_volume = float(np.sum(self.reference_tet_volumes))
+        self.reference_display_tet_set = {tuple(sorted(int(v) for v in tet)) for tet in self.tets}
+        self.reference_nodal_volumes: np.ndarray | None = None
+        self.face_pairs = tet_face_pairs(self.tets)
+        self.accelerations: np.ndarray | None = None
+        self.last_new_velocities: np.ndarray | None = None
+        self.last_inertial_masses: np.ndarray | None = None
+        self.last_tet_volumes: np.ndarray | None = None
+        self.last_pressure_values: np.ndarray | None = None
+        self.last_fheron_pressure = 0.0
+        self.last_flux_stats = self._empty_flux_stats()
+        self.last_retopology_stats = self._empty_retopology_stats()
+        self.dirty = True
+
+    def _empty_flux_stats(self) -> dict[str, float]:
+        return {
+            "mass_flux_l1_kg_s": 0.0,
+            "mass_flux_max_kg_s": 0.0,
+            "momentum_flux_l1_n": 0.0,
+            "volume_flux_l1_m3_s": 0.0,
+            "flux_limiter_scale": 1.0,
+            "mass_update_coupling": float(self.mass_flux_coupling),
+            "momentum_force_coupling": float(self.momentum_flux_coupling),
+            "density_change_limit": float(self.density_change_limit) if self.density_change_limit is not None else 0.0,
+            "flux_cfl_limit": float(self.flux_cfl_limit),
+            "face_flux_lagrangian": 1.0 if self.face_flux_mode == "lagrangian" else 0.0,
+        }
+
+    def _empty_retopology_stats(self) -> dict[str, float]:
+        return {
+            "retriangulation_active": 1.0 if self.active_retopology else 0.0,
+            "display_tet_count": float(self.tets.shape[0]),
+            "display_internal_face_count": float(len(self.face_pairs)),
+            "display_changed_tets": 0.0,
+            "display_changed_fraction": 0.0,
+        }
+
+    def mark_dirty(self) -> None:
+        self.dirty = True
+
+    def read_hc_state(self, HC) -> tuple[np.ndarray, np.ndarray]:
+        n_vertices = 1 + max(int(getattr(v, self.vertex_index_attr)) for v in HC.V)
+        points = np.zeros((n_vertices, 3), dtype=float)
+        velocities = np.zeros((n_vertices, 3), dtype=float)
+        seen = np.zeros(n_vertices, dtype=bool)
+        for vertex in HC.V:
+            index = int(getattr(vertex, self.vertex_index_attr))
+            points[index] = np.asarray(vertex.x_a[:3], dtype=float)
+            velocities[index] = np.asarray(getattr(vertex, "u", np.zeros(3))[:3], dtype=float)
+            seen[index] = True
+        if not np.all(seen):
+            missing = np.flatnonzero(~seen)
+            raise ValueError(f"HC is missing volume-gradient vertex indices: {missing[:8]}")
+        return points, velocities
+
+    def write_hc_state(self, HC, points: np.ndarray, velocities: np.ndarray, bV=None) -> None:
+        boundary = set() if bV is None else bV
+        for vertex in list(HC.V):
+            index = int(getattr(vertex, self.vertex_index_attr))
+            vertex.u[:3] = np.asarray(velocities[index], dtype=float)
+            if vertex in boundary:
+                boundary.remove(vertex)
+                HC.V.move(vertex, tuple(np.asarray(points[index], dtype=float)))
+                boundary.add(vertex)
+            else:
+                HC.V.move(vertex, tuple(np.asarray(points[index], dtype=float)))
+
+    def retopologize_callback(self, HC, bV, dim, **_kwargs) -> None:
+        """Dynamic-integrator retopology hook.
+
+        The HyperCT vertices remain the ODE state.  This hook rebuilds only the
+        tet list, tet masses, target volumes, and cached pressure topology so
+        the next ``dudt_fn`` call uses the new Delaunay pressure operator.
+        """
+        if not self.active_retopology:
+            self.mark_dirty()
+            return
+        points, _velocities = self.read_hc_state(HC)
+        if self.phase_ids is None:
+            new_tets, new_reference_volumes, new_masses, stats = active_retopology_tet_remap(
+                points,
+                self.tets,
+                target_total_mass=self.reference_total_mass,
+                target_total_volume=self.reference_total_volume,
+            )
+            self.tets = np.asarray(new_tets, dtype=int)
+            self.reference_tet_volumes = np.asarray(new_reference_volumes, dtype=float)
+            self.tet_masses = np.asarray(new_masses, dtype=float)
+        else:
+            new_tets, new_phases, new_reference_volumes, new_masses, stats = _tet_phase_retopology_remap(
+                points,
+                self.tets,
+                self.phase_ids,
+                phase_densities=self.phase_densities,
+            )
+            self.tets = np.asarray(new_tets, dtype=int)
+            self.phase_ids = np.asarray(new_phases, dtype=int)
+            self.reference_tet_volumes = np.asarray(new_reference_volumes, dtype=float)
+            self.tet_masses = np.asarray(new_masses, dtype=float)
+        self.reference_tet_masses = self.tet_masses.copy()
+        self.face_pairs = tet_face_pairs(self.tets)
+        self.last_retopology_stats = stats
+        self.mark_dirty()
+
+    def _fixed_mask(self, n_vertices: int) -> np.ndarray:
+        mask = np.zeros(int(n_vertices), dtype=bool)
+        valid = self.fixed_indices[(self.fixed_indices >= 0) & (self.fixed_indices < n_vertices)]
+        mask[valid] = True
+        return mask
+
+    def _nodal_masses(self, n_vertices: int) -> np.ndarray:
+        nodal_mass = tet_volume_lumped_nodal_values(n_vertices, self.tets, self.tet_masses)
+        if self.inertial_mass_addition is not None:
+            nodal_mass = nodal_mass + np.asarray(self.inertial_mass_addition, dtype=float)
+        return np.maximum(float(self.inertia_scale) * nodal_mass, 1.0e-18)
+
+    def _inverse_mass_dof(self, masses: np.ndarray, fixed_mask: np.ndarray) -> np.ndarray:
+        inv_mass = np.repeat(1.0 / np.maximum(np.asarray(masses, dtype=float), 1.0e-300), 3)
+        inv_mass[np.repeat(np.asarray(fixed_mask, dtype=bool), 3)] = 0.0
+        return inv_mass
+
+    def _bulk_by_tet(self) -> np.ndarray:
+        if self.phase_ids is not None and self.phase_bulk_moduli:
+            return np.asarray([float(self.phase_bulk_moduli[int(phase)]) for phase in self.phase_ids], dtype=float)
+        if self.bulk_modulus.shape == ():
+            return np.full(self.tets.shape[0], float(self.bulk_modulus), dtype=float)
+        if self.bulk_modulus.shape[0] != self.tets.shape[0]:
+            return np.full(self.tets.shape[0], float(np.mean(self.bulk_modulus)), dtype=float)
+        return np.asarray(self.bulk_modulus, dtype=float)
+
+    def _base_pressures(self, reference_pressure: float) -> np.ndarray:
+        if self.phase_ids is not None and self.phase_base_pressures:
+            return np.asarray([float(self.phase_base_pressures.get(int(phase), 0.0)) for phase in self.phase_ids], dtype=float)
+        if self.base_tet_pressures.shape == ():
+            return np.full(self.tets.shape[0], float(self.base_tet_pressures), dtype=float)
+        if self.base_tet_pressures.shape[0] == self.tets.shape[0]:
+            return np.asarray(self.base_tet_pressures, dtype=float)
+        return np.full(self.tets.shape[0], float(reference_pressure), dtype=float)
+
+    def _density_by_tet(self) -> np.ndarray:
+        if self.phase_ids is not None and self.phase_densities:
+            return np.asarray([float(self.phase_densities[int(phase)]) for phase in self.phase_ids], dtype=float)
+        return np.full(self.tets.shape[0], float(self.density), dtype=float)
+
+    def _project_volume_velocity(
+        self,
+        velocities: np.ndarray,
+        volume_matrix: np.ndarray,
+        inv_mass_dof: np.ndarray,
+        target_rates: np.ndarray,
+    ) -> np.ndarray:
+        velocity_vec = np.asarray(velocities, dtype=float).reshape(-1)
+        stiffness = (np.asarray(volume_matrix, dtype=float) * np.asarray(inv_mass_dof, dtype=float)[None, :]) @ np.asarray(volume_matrix, dtype=float).T
+        rhs = np.asarray(volume_matrix, dtype=float) @ velocity_vec - np.asarray(target_rates, dtype=float)
+        multipliers = solve_regularized(stiffness, rhs)
+        projected = velocity_vec - np.asarray(inv_mass_dof, dtype=float) * (np.asarray(volume_matrix, dtype=float).T @ multipliers)
+        return projected.reshape(np.asarray(velocities).shape)
+
+    def prepare(self, HC, dt: float | None = None) -> None:
+        if not self.dirty and self.accelerations is not None:
+            return
+        step_dt = float(self.dt if dt is None else dt)
+        points, velocities = self.read_hc_state(HC)
+        n_vertices = points.shape[0]
+        tet_volumes, volume_matrix = tet_volume_matrix(points, self.tets)
+        fixed_mask = self._fixed_mask(n_vertices)
+        inertial_masses = self._nodal_masses(n_vertices)
+        inv_mass_dof = self._inverse_mass_dof(inertial_masses, fixed_mask)
+
+        flux_forces = np.zeros_like(points)
+        if self.flux_timing == "pre-pressure":
+            self.tet_masses, flux_forces, self.last_flux_stats = tet_face_ale_fluxes(
+                points,
+                velocities,
+                self.tets,
+                self.face_pairs,
+                self.tet_masses,
+                self.reference_tet_masses,
+                tet_volumes,
+                step_dt,
+                reference_density=self.density,
+                sound_speed=self.sound_speed,
+                mass_floor_fraction=self.mass_floor_fraction,
+                mass_update_coupling=self.mass_flux_coupling,
+                momentum_force_coupling=self.momentum_flux_coupling,
+                density_change_limit=self.density_change_limit,
+                flux_cfl_limit=self.flux_cfl_limit,
+                flux_scheme=self.flux_scheme,
+                face_flux_mode=self.face_flux_mode,
+            )
+            inertial_masses = self._nodal_masses(n_vertices)
+            inv_mass_dof = self._inverse_mass_dof(inertial_masses, fixed_mask)
+        else:
+            self.last_flux_stats = self._empty_flux_stats()
+
+        surface_forces, _surface_area_vectors, fheron_pressure, _surface_volume = heron_forces_for_points(
+            points[self.surface_indices],
+            self.surface_faces,
+            self.gamma,
+        )
+        self.last_fheron_pressure = float(fheron_pressure)
+        forces = np.zeros_like(points)
+        forces[self.surface_indices] += surface_forces
+        damping_forces = -float(self.damping_rate) * inertial_masses[:, None] * velocities
+        # This is the key pressure-reference choice.  The continuity residual
+        # and pressure force both use tet volumes, so after retopology the
+        # solver reacts to physical tet-volume error, not to HC dual-volume
+        # jumps caused by connectivity flips.
+        if self.closure == "compressible" or self.incompressible_target_mode == "mass":
+            target_tet_volumes = self.tet_masses / np.maximum(self._density_by_tet(), 1.0e-300)
+        else:
+            target_tet_volumes = self.reference_tet_volumes
+        pressure_matrix = volume_gradient_pressure_matrix(volume_matrix)
+
+        if self.closure == "compressible":
+            # Weak-compressible EOS correction:
+            #   (I + dt^2 D_K B M^-1 B^T) dp
+            #     = -D_K (V - Vtar + dt B u*)
+            # The pressure force is B^T p, which is adjoint to the same B that
+            # measures volume/continuity.  This adjoint pairing is what makes
+            # the Rayleigh response stable after retopology.
+            base_pressures = self._base_pressures(fheron_pressure)
+            nonpressure = forces + (pressure_matrix @ base_pressures).reshape(points.shape) + damping_forces + flux_forces
+            u_star = velocities + step_dt * (inv_mass_dof * nonpressure.reshape(-1)).reshape(points.shape)
+            u_star[fixed_mask] = 0.0
+            bulk_by_tet = self._bulk_by_tet()
+            compressibility = bulk_by_tet / np.maximum(self.reference_tet_volumes, 1.0e-300)
+            stiffness = (volume_matrix * inv_mass_dof[None, :]) @ pressure_matrix
+            linear_error = tet_volumes - target_tet_volumes + step_dt * (volume_matrix @ u_star.reshape(-1))
+            system = np.eye(self.tets.shape[0]) + (compressibility[:, None] * step_dt * step_dt) * stiffness
+            rhs = -compressibility * linear_error
+            pressure_delta = solve_regularized(system, rhs)
+            new_velocities = (
+                u_star.reshape(-1) + step_dt * inv_mass_dof * (pressure_matrix @ pressure_delta)
+            ).reshape(points.shape)
+            new_velocities[fixed_mask] = 0.0
+            self.last_pressure_values = base_pressures + pressure_delta
+        else:
+            # Local incompressible projection:
+            #   B u^{n+1} = -(V - Vtar)/dt
+            # This is the tet-volume analogue of a Chorin/Temam projection on
+            # a moving Lagrangian mesh.
+            target_rates = -(tet_volumes - target_tet_volumes) / step_dt
+            velocity_vec = velocities.reshape(-1)
+            nonpressure_vec = (forces + damping_forces + flux_forces).reshape(-1)
+            stiffness = (volume_matrix * inv_mass_dof[None, :]) @ pressure_matrix
+            rhs = (target_rates - volume_matrix @ velocity_vec) / step_dt - volume_matrix @ (inv_mass_dof * nonpressure_vec)
+            pressure_values = solve_regularized(stiffness, rhs)
+            total_forces = forces + (pressure_matrix @ pressure_values).reshape(points.shape) + damping_forces + flux_forces
+            new_velocities = velocities + step_dt * (inv_mass_dof * total_forces.reshape(-1)).reshape(points.shape)
+            new_velocities = self._project_volume_velocity(new_velocities, volume_matrix, inv_mass_dof, target_rates)
+            new_velocities[fixed_mask] = 0.0
+            self.last_pressure_values = pressure_values
+
+        if self.flux_timing == "post-pressure":
+            self.tet_masses, post_flux_forces, self.last_flux_stats = tet_face_ale_fluxes(
+                points,
+                new_velocities,
+                self.tets,
+                self.face_pairs,
+                self.tet_masses,
+                self.reference_tet_masses,
+                tet_volumes,
+                step_dt,
+                reference_density=self.density,
+                sound_speed=self.sound_speed,
+                mass_floor_fraction=self.mass_floor_fraction,
+                mass_update_coupling=self.mass_flux_coupling,
+                momentum_force_coupling=self.momentum_flux_coupling,
+                density_change_limit=self.density_change_limit,
+                flux_cfl_limit=self.flux_cfl_limit,
+                flux_scheme=self.flux_scheme,
+                face_flux_mode=self.face_flux_mode,
+            )
+            if self.momentum_flux_coupling:
+                post_masses = self._nodal_masses(n_vertices)
+                post_inv = self._inverse_mass_dof(post_masses, fixed_mask)
+                new_velocities = new_velocities + step_dt * (post_inv * post_flux_forces.reshape(-1)).reshape(points.shape)
+                new_velocities[fixed_mask] = 0.0
+
+        self.last_new_velocities = new_velocities
+        self.last_inertial_masses = inertial_masses
+        self.last_tet_volumes = tet_volumes
+        self.reference_nodal_volumes = tet_volume_lumped_nodal_values(n_vertices, self.tets, self.reference_tet_volumes)
+        self.accelerations = (new_velocities - velocities) / step_dt
+        self.dirty = False
+
+    def acceleration(self, vertex, *, HC=None, dt: float | None = None, dim: int = 3, mu: float = 0.0) -> np.ndarray:
+        """Return the cached acceleration for one vertex.
+
+        ``mu`` is accepted for API compatibility with ``dudt_i``.  The benchmark
+        pressure-reference runs set viscosity to zero so the pressure closure can
+        be compared directly with Rayleigh's inviscid oscillation frequency.
+        """
+        if HC is None:
+            raise ValueError("HC must be passed through the state or dudt wrapper")
+        if mu not in (0, 0.0):
+            raise NotImplementedError("VolumeGradientPressureState benchmark runs require mu=0")
+        self.prepare(HC, dt=dt)
+        index = int(getattr(vertex, self.vertex_index_attr))
+        accel = np.asarray(self.accelerations[index], dtype=float)
+        return accel[:dim]
+
+    def remove_rigid_translation(self, HC, bV=None) -> None:
+        """Remove center-of-mass drift after a completed Lagrangian step."""
+        if self.last_inertial_masses is None:
+            return
+        points, velocities = self.read_hc_state(HC)
+        masses = np.maximum(np.asarray(self.last_inertial_masses, dtype=float), 1.0e-300)
+        mass_sum = max(float(np.sum(masses)), 1.0e-300)
+        center = np.sum(points * masses[:, None], axis=0) / mass_sum
+        mean_velocity = np.sum(velocities * masses[:, None], axis=0) / mass_sum
+        fixed_mask = self._fixed_mask(points.shape[0])
+        points[~fixed_mask] -= center[None, :]
+        velocities[~fixed_mask] -= mean_velocity[None, :]
+        velocities[fixed_mask] = 0.0
+        self.write_hc_state(HC, points, velocities, bV=bV)
+        self.mark_dirty()
+
+    def diagnostics(self, HC) -> dict[str, float]:
+        points, velocities = self.read_hc_state(HC)
+        tet_volumes, _matrix = tet_volume_matrix(points, self.tets)
+        target = self.tet_masses / np.maximum(self._density_by_tet(), 1.0e-300) if self.closure == "compressible" else self.reference_tet_volumes
+        nodal_mass = tet_volume_lumped_nodal_values(points.shape[0], self.tets, self.tet_masses)
+        nodal_volume = tet_volume_lumped_nodal_values(points.shape[0], self.tets, tet_volumes)
+        pressure = self.last_pressure_values if self.last_pressure_values is not None else np.zeros(self.tets.shape[0])
+        local_volume_rel = tet_volumes / np.maximum(target, 1.0e-300)
+        if self.phase_ids is not None and self.phase_densities:
+            tet_density_reference = self._density_by_tet()
+            nodal_density_reference = tet_volume_lumped_nodal_values(points.shape[0], self.tets, tet_density_reference * tet_volumes)
+            nodal_density_reference = nodal_density_reference / np.maximum(nodal_volume, 1.0e-300)
+        else:
+            nodal_density_reference = np.full(points.shape[0], float(self.density), dtype=float)
+        density_rel = nodal_mass / np.maximum(nodal_volume, 1.0e-300) / np.maximum(nodal_density_reference, 1.0e-300)
+        stats = {
+            "closure_pressure_pa": float(np.mean(pressure)) if np.asarray(pressure).size else 0.0,
+            "fheron_pressure_pa": float(self.last_fheron_pressure),
+            "vol_m3": float(np.sum(tet_volumes)),
+            "vol0_mesh_m3": float(np.sum(self.reference_tet_volumes)),
+            "vol_rel": float(np.sum(tet_volumes) / max(float(np.sum(self.reference_tet_volumes)), 1.0e-300)),
+            "local_volume_rel_max_abs": float(np.max(np.abs(local_volume_rel - 1.0))) if local_volume_rel.size else 0.0,
+            "nodal_density_rel_min": float(np.min(density_rel[nodal_volume > 0.0])) if np.any(nodal_volume > 0.0) else 1.0,
+            "nodal_density_rel_max": float(np.max(density_rel[nodal_volume > 0.0])) if np.any(nodal_volume > 0.0) else 1.0,
+            "total_mass_kg": float(np.sum(self.tet_masses)),
+            "max_speed_m_s": float(np.max(np.linalg.norm(velocities, axis=1))) if velocities.size else 0.0,
+            "solver_tet_count": float(self.tets.shape[0]),
+        }
+        stats.update(self.last_flux_stats)
+        stats.update(self.last_retopology_stats)
+        current_tet_set = {tuple(sorted(int(v) for v in tet)) for tet in self.tets}
+        union = self.reference_display_tet_set | current_tet_set
+        changed = self.reference_display_tet_set ^ current_tet_set
+        stats["display_tet_count"] = float(self.tets.shape[0])
+        stats["display_internal_face_count"] = float(len(tet_face_pairs(self.tets)))
+        stats["display_changed_tets"] = float(len(changed))
+        stats["display_changed_fraction"] = float(len(changed)) / max(float(len(union)), 1.0)
+        return stats
+
+
+def volume_gradient_pressure_acceleration(vertex, *, state: VolumeGradientPressureState, HC=None, dt=None, dim: int = 3, mu: float = 0.0) -> np.ndarray:
+    """Dynamic-integrator ``dudt_fn`` for tet-volume pressure closure."""
+    if HC is None:
+        HC = getattr(state, "HC", None)
+    return state.acceleration(vertex, HC=HC, dt=dt, dim=dim, mu=mu)
+
+
 
 # ---------------------------------------------------------------------------
 # Geometry: dual area vectors and dual volumes
@@ -707,7 +1212,14 @@ def dual_area_vector(v_i, v_j, HC, dim: int = 3) -> np.ndarray:
         return A_ij
 
     elif dim == 3:
-        return _dual_area_vector_3d_p_ij(v_i, v_j, HC)
+        try:
+            return _dual_area_vector_3d_p_ij(v_i, v_j, HC)
+        except ModuleNotFoundError:
+            # Compatibility fallback for HyperCT versions that do not expose
+            # the newer p_ij helper.  The pressure-reference benchmark itself
+            # uses B^T p, but existing stress-force callers still need a 3D
+            # dual-face area vector.
+            return _dual_area_vector_3d_e_star(v_i, v_j, HC)
 
     else:
         raise NotImplementedError(f"dual_area_vector not implemented for dim={dim}")
@@ -755,7 +1267,10 @@ def _dual_area_vector_3d_p_ij(v_i, v_j, HC) -> np.ndarray:
         # Connectivity walk incomplete — fall back to angular sort.
         # This happens for boundary-adjacent edges where dual vertices
         # have truncated connectivity.
-        from hyperct.ddg._dual_cell import _angular_sort_3d
+        try:
+            from hyperct.ddg._dual_cell import _angular_sort_3d
+        except ModuleNotFoundError:
+            return _dual_area_vector_3d_e_star(v_i, v_j, HC)
         sorted_ring = _angular_sort_3d(shared_list)
         if sorted_ring is not None and len(sorted_ring) >= 3:
             ring = sorted_ring

--- a/ddgclib/operators/stress.py
+++ b/ddgclib/operators/stress.py
@@ -63,13 +63,12 @@ def dual_area_vector(v_i, v_j, HC, dim: int = 3) -> np.ndarray:
     vertices; A_ij is the outward-facing normal with magnitude equal to the
     segment length.
 
-    In 3D the dual face is a polygon triangulated into small triangles by
-    e_star; each triangle contributes a vector area A_ijk = 0.5 * cross(e1, e2).
-    The total is A_ij = sum_k A_ijk, oriented outward from v_i using the test:
-
-        vec_to_i = v_i.x_a - vc.x_a   (from dual face toward parcel i)
-        if dot(A_ijk, vec_to_i) > 0:   (points inward)
-            A_ijk = -A_ijk              (flip to outward)
+    In 3D the dual face is the DEC p_ij polygon: tet barycenters interleaved
+    with face barycenters (x_i + x_j + x_k)/3.  This construction guarantees
+    linear precision (machine eps) for barycentric duals on any tetrahedral
+    mesh.  See :func:`_dual_area_vector_3d_p_ij`.  Falls back to the legacy
+    e_star fan-walk (:func:`_dual_area_vector_3d_e_star`) for boundary or
+    degenerate edges.
 
     Parameters
     ----------
@@ -96,6 +95,67 @@ def dual_area_vector(v_i, v_j, HC, dim: int = 3) -> np.ndarray:
         return np.array([np.sign(direction)])
 
     elif dim == 2:
+        # When periodic axes are set, always compute dual area from primal
+        # geometry using minimum-image coordinates.  compute_vd's dual
+        # vertex positions are wrong for any triangle that includes a
+        # periodic-face vertex with wrapped neighbors.
+        periodic_axes = getattr(HC, '_periodic_axes', None)
+        if periodic_axes:
+            periodic_bounds = HC._periodic_bounds
+            x_i = v_i.x_a[:2]
+
+            def _min_image(x_other):
+                result = x_other.copy()
+                for ax in periodic_axes:
+                    p = periodic_bounds[ax][1] - periodic_bounds[ax][0]
+                    delta = result[ax] - x_i[ax]
+                    result[ax] -= round(delta / p) * p
+                return result
+
+            x_j = _min_image(v_j.x_a[:2])
+            common = v_i.nn.intersection(v_j.nn)
+            if len(common) < 2:
+                # Boundary edge: use single triangle + edge midpoint
+                if len(common) < 1:
+                    return np.zeros(2)
+                v3 = list(common)[0]
+                x3 = _min_image(v3.x_a[:2])
+                bary = (x_i + x_j + x3) / 3.0
+                midpt = 0.5 * (x_i + x_j)
+                dual_edge = bary - midpt
+                A_ij = np.array([-dual_edge[1], dual_edge[0]])
+                vec_to_i = x_i - 0.5 * (bary + midpt)
+                if np.dot(A_ij, vec_to_i) > 0:
+                    A_ij = -A_ij
+                return A_ij
+            # Interior edge: pick two triangles (one on each side of edge).
+            # With ghost resolution, shared count can be >2. Use cross
+            # product sign to find one neighbor on each side.
+            edge_vec = x_j - x_i
+            left = None
+            right = None
+            for v3 in common:
+                x3 = _min_image(v3.x_a[:2])
+                cross = edge_vec[0] * (x3[1] - x_i[1]) - edge_vec[1] * (x3[0] - x_i[0])
+                if cross > 0 and left is None:
+                    left = x3
+                elif cross <= 0 and right is None:
+                    right = x3
+                if left is not None and right is not None:
+                    break
+            if left is None or right is None:
+                return np.zeros(2)
+            bary_l = (x_i + x_j + left) / 3.0
+            bary_r = (x_i + x_j + right) / 3.0
+            dual_edge = bary_l - bary_r
+            A_ij = np.array([-dual_edge[1], dual_edge[0]])
+            centroid = 0.5 * (bary_l + bary_r)
+            vec_to_i = x_i - centroid
+            if np.dot(A_ij, vec_to_i) > 0:
+                A_ij = -A_ij
+            return A_ij
+
+        # Standard (non-periodic) path
         vdnn = v_i.vd.intersection(v_j.vd)
         vd_list = list(vdnn)
         if len(vd_list) < 2:
@@ -113,23 +173,139 @@ def dual_area_vector(v_i, v_j, HC, dim: int = 3) -> np.ndarray:
         return A_ij
 
     elif dim == 3:
-        from hyperct.ddg import e_star as _e_star
-        A_ijk_arr = _e_star(v_i, v_j, HC, dim=3)  # shape (N, 3)
-        if not isinstance(A_ijk_arr, np.ndarray) or A_ijk_arr.size == 0:
-            return np.zeros(3)
-        # Orientation reference: dual vertex on the face
-        vc_12_pos = 0.5 * (v_j.x_a - v_i.x_a) + v_i.x_a
-        vc_12 = HC.Vd[tuple(vc_12_pos)]
-        vec_to_i = v_i.x_a - vc_12.x_a
-        A_ij = np.zeros(3)
-        for A_ijk in A_ijk_arr:
-            if np.dot(A_ijk, vec_to_i) > 0:  # points inward -> flip
-                A_ijk = -A_ijk
-            A_ij += A_ijk
-        return A_ij
+        return _dual_area_vector_3d_p_ij(v_i, v_j, HC)
 
     else:
         raise NotImplementedError(f"dual_area_vector not implemented for dim={dim}")
+
+
+def _dual_area_vector_3d_p_ij(v_i, v_j, HC) -> np.ndarray:
+    """3D dual area vector using the DEC p_ij face construction.
+
+    The dual face polygon interleaves **tet barycenters** with **face
+    barycenters** ``(x_i + x_j + x_k) / 3`` of the primal triangular
+    faces shared by consecutive tetrahedra around edge ``(i, j)``.
+
+    This gives linear precision (machine epsilon) for barycentric duals
+    on any tetrahedral mesh — a property that the simpler polygon of
+    tet-barycenters-only does not satisfy because the non-planar face
+    produces an incorrect area vector when triangulated without the
+    intermediate face-barycenter vertices.
+
+    Falls back to :func:`_dual_area_vector_3d_e_star` when the
+    ring-walk or common-neighbor lookup fails (boundary / degenerate
+    topologies).
+    """
+    shared_vd = v_i.vd.intersection(v_j.vd)
+    if len(shared_vd) < 3:
+        # Boundary or degenerate — fall back
+        return _dual_area_vector_3d_e_star(v_i, v_j, HC)
+
+    # --- Build ring order from dual vertex connectivity ---
+    shared_list = list(shared_vd)
+    ring = [shared_list[0]]
+    remaining = set(shared_list[1:])
+    while remaining:
+        curr = ring[-1]
+        nxt = None
+        for cand in remaining:
+            if cand in curr.nn:
+                nxt = cand
+                break
+        if nxt is None:
+            break
+        ring.append(nxt)
+        remaining.discard(nxt)
+
+    if len(ring) < len(shared_list):
+        # Connectivity walk incomplete — fall back to angular sort.
+        # This happens for boundary-adjacent edges where dual vertices
+        # have truncated connectivity.
+        from hyperct.ddg._dual_cell import _angular_sort_3d
+        sorted_ring = _angular_sort_3d(shared_list)
+        if sorted_ring is not None and len(sorted_ring) >= 3:
+            ring = sorted_ring
+        elif len(ring) < 3:
+            return _dual_area_vector_3d_e_star(v_i, v_j, HC)
+
+    # --- Common neighbors = opposite vertices of shared triangular faces ---
+    common_nbs = list(v_i.nn.intersection(v_j.nn))
+    if not common_nbs:
+        return _dual_area_vector_3d_e_star(v_i, v_j, HC)
+
+    x_i = v_i.x_a[:3]
+    x_j = v_j.x_a[:3]
+
+    # --- Build interleaved polygon: tet_bary, face_bary, ... ---
+    interleaved = []
+    for k in range(len(ring)):
+        tet_bary = ring[k].x_a[:3]
+        tet_next = ring[(k + 1) % len(ring)].x_a[:3]
+        interleaved.append(tet_bary)
+
+        # Find the face barycenter (x_i + x_j + x_k)/3 between these
+        # two consecutive tets.  The correct x_k is the common neighbor
+        # whose face barycenter lies closest to the midpoint of the two
+        # tet barycenters.
+        mid = 0.5 * (tet_bary + tet_next)
+        best_fb = None
+        best_dist = np.inf
+        for cn in common_nbs:
+            fb = (x_i + x_j + cn.x_a[:3]) / 3.0
+            dist = np.linalg.norm(fb - mid)
+            if dist < best_dist:
+                best_dist = dist
+                best_fb = fb
+        if best_fb is not None:
+            interleaved.append(best_fb)
+
+    polygon = np.array(interleaved)
+
+    # --- Compute area vector by centroid-fan triangulation ---
+    centroid = polygon.mean(axis=0)
+    A_ij = np.zeros(3)
+    n_pts = len(polygon)
+    for k in range(n_pts):
+        p1 = polygon[k]
+        p2 = polygon[(k + 1) % n_pts]
+        A_ij += 0.5 * np.cross(p1 - centroid, p2 - centroid)
+
+    # --- Orient outward from v_i ---
+    d_ij = x_j - x_i
+    if np.dot(A_ij, d_ij) < 0:
+        A_ij = -A_ij
+    return A_ij
+
+
+def _dual_area_vector_3d_e_star(v_i, v_j, HC) -> np.ndarray:
+    """3D dual area vector via the e_star fan-walk (legacy).
+
+    Uses the ``e_star`` fan-walk triangulation from the primal edge
+    midpoint through the shared dual vertices.  This was the original
+    implementation.  It does NOT satisfy linear precision for barycentric
+    duals on non-symmetric meshes because the non-planar face polygon
+    (tet barycenters only, without interleaved face barycenters) produces
+    an incorrect area vector.
+
+    Kept as fallback for boundary / degenerate topologies where the
+    p_ij ring-walk cannot be performed.
+    """
+    from hyperct.ddg import e_star as _e_star
+    try:
+        A_ijk_arr = _e_star(v_i, v_j, HC, dim=3)  # shape (N, 3)
+    except (IndexError, KeyError):
+        return np.zeros(3)
+    if not isinstance(A_ijk_arr, np.ndarray) or A_ijk_arr.size == 0:
+        return np.zeros(3)
+    vc_12_pos = 0.5 * (v_j.x_a - v_i.x_a) + v_i.x_a
+    vc_12 = HC.Vd[tuple(vc_12_pos)]
+    vec_to_i = v_i.x_a - vc_12.x_a
+    A_ij = np.zeros(3)
+    for A_ijk in A_ijk_arr:
+        if np.dot(A_ijk, vec_to_i) > 0:
+            A_ijk = -A_ijk
+        A_ij += A_ijk
+    return A_ij
 
 
 def dual_volume(v, HC, dim: int = 3) -> float:
@@ -160,9 +336,21 @@ def dual_volume(v, HC, dim: int = 3) -> float:
     -----
     # TODO: move to hyperct.ddg._operators (pure geometry, no physics)
     """
-    if dim <= 2:
-        from hyperct.ddg import d_area
-        return d_area(v)
+    if dim == 1:
+        # 1D dual cell = interval between the two dual vertices
+        vd_list = list(v.vd)
+        if len(vd_list) < 2:
+            # Boundary vertex with single dual vertex: half-edge
+            if len(vd_list) == 1 and v.nn:
+                v_j = next(iter(v.nn))
+                return 0.5 * abs(v_j.x_a[0] - v.x_a[0])
+            return 0.0
+        positions = [vd.x_a[0] for vd in vd_list]
+        return max(positions) - min(positions)
+
+    elif dim == 2:
+        from hyperct.ddg import dual_cell_area_2d
+        return dual_cell_area_2d(v, include_edge_midpoints=True)
 
     elif dim == 3:
         from hyperct.ddg import v_star as _v_star
@@ -204,7 +392,11 @@ def cache_dual_volumes(HC, dim: int = 3) -> None:
         Spatial dimension.
     """
     for v in HC.V:
-        v.dual_vol = dual_volume(v, HC, dim)
+        try:
+            v.dual_vol = dual_volume(v, HC, dim)
+        except (ValueError, IndexError):
+            # Degenerate vertex (e.g. domain corner with too few neighbors)
+            v.dual_vol = 0.0
 
 
 def _get_dual_vol(v, HC, dim: int = 3) -> float:
@@ -250,72 +442,19 @@ def velocity_difference_tensor(v, HC, dim: int = 3) -> np.ndarray:
         Integrated velocity difference tensor, shape ``(dim, dim)``.
         Component ``Du_i[a, b] = 0.5 * sum_j (u_j^a - u_i^a) * A_ij^b``.
     """
-    Du_i, _ = _velocity_difference_tensor_partial(v, HC, dim)
-    return Du_i
+    _cache = getattr(HC, '_edge_area_cache', None)
+    _vid = id(v) if _cache is not None else None
 
-
-def _velocity_difference_tensor_partial(v, HC, dim: int = 3):
-    """Boundary-safe integrated velocity difference tensor.
-
-    Uses all neighbors whose dual-area contribution can be evaluated, and
-    skips invalid/degenerate neighbors instead of raising.  This enables
-    partial-fan DDG reconstruction near boundaries or locally broken dual
-    connectivity.
-
-    Returns
-    -------
-    tuple[np.ndarray, list]
-        ``(Du_i, valid_neighbors)`` where ``Du_i`` is shape ``(dim, dim)``.
-    """
     Du_i = np.zeros((dim, dim))
-    valid_neighbors = []
     for v_j in v.nn:
-        try:
+        if _cache is not None and _vid in _cache and id(v_j) in _cache[_vid]:
+            A_ij = _cache[_vid][id(v_j)]
+        else:
             A_ij = dual_area_vector(v, v_j, HC, dim)
-        except (
-            KeyError,
-            IndexError,
-            ValueError,
-            RuntimeError,
-            ZeroDivisionError,
-            StopIteration,
-        ):
-            continue
-
-        A_ij = np.asarray(A_ij, dtype=float)
-        if A_ij.shape != (dim,) or not np.all(np.isfinite(A_ij)):
-            continue
-
-        delta_u = np.asarray(v_j.u[:dim] - v.u[:dim], dtype=float)
-        if delta_u.shape != (dim,) or not np.all(np.isfinite(delta_u)):
-            continue
-
+        delta_u = v_j.u[:dim] - v.u[:dim]
         Du_i += np.outer(delta_u, A_ij)
-        valid_neighbors.append(v_j)
-
     Du_i *= 0.5
-    return Du_i, valid_neighbors
-
-
-def _dual_volume_partial(v, HC, neighbors, dim: int = 3) -> float:
-    """Dual-volume approximation using only the supplied neighbor subset."""
-    if dim <= 2:
-        return _get_dual_vol(v, HC, dim)
-
-    from hyperct.ddg import v_star as _v_star
-
-    total_vol = 0.0
-    for v_j in neighbors:
-        try:
-            result = _v_star(v, v_j, HC, dim=3)
-            if isinstance(result, tuple) and len(result) == 2:
-                _, V_ij = result
-                total_vol += np.sum(np.abs(V_ij))
-            else:
-                total_vol += float(result)
-        except (KeyError, IndexError, ValueError, RuntimeError, ZeroDivisionError):
-            continue
-    return float(total_vol)
+    return Du_i
 
 
 def velocity_difference_tensor_pointwise(v, HC, dim: int = 3) -> np.ndarray:
@@ -338,14 +477,58 @@ def velocity_difference_tensor_pointwise(v, HC, dim: int = 3) -> np.ndarray:
     np.ndarray
         Pointwise velocity gradient, shape ``(dim, dim)``.
     """
-    Du_i, valid_neighbors = _velocity_difference_tensor_partial(v, HC, dim)
-    if not valid_neighbors:
-        return np.zeros((dim, dim))
-
-    Vol_i = _dual_volume_partial(v, HC, valid_neighbors, dim)
+    Vol_i = _get_dual_vol(v, HC, dim)
     if Vol_i < 1e-30:
         return np.zeros((dim, dim))
-    return Du_i / Vol_i
+    return velocity_difference_tensor(v, HC, dim) / Vol_i
+
+
+def scalar_gradient_integrated(
+    v,
+    HC,
+    dim: int = 3,
+    field_attr: str = 'f',
+) -> np.ndarray:
+    """Integrated gradient of a scalar field over the dual cell of v.
+
+    Computes the DDG volume-integrated quantity::
+
+        Df_i = 0.5 * sum_j (f_j - f_i) * A_ij
+
+    This is the scalar analog of :func:`velocity_difference_tensor`.
+    It approximates ``∫_{V_i} ∇f dV``.
+
+    Parameters
+    ----------
+    v : vertex object
+        Must have the scalar field attribute (default ``v.f``) and
+        ``v.nn``, ``v.vd`` populated.
+    HC : Complex
+        Simplicial complex with duals computed.
+    dim : int
+        Spatial dimension.
+    field_attr : str
+        Name of the scalar field attribute on vertices (default ``'f'``).
+
+    Returns
+    -------
+    np.ndarray
+        Integrated gradient vector, shape ``(dim,)``.
+    """
+    _cache = getattr(HC, '_edge_area_cache', None)
+    _vid = id(v) if _cache is not None else None
+
+    f_i = getattr(v, field_attr)
+    Df_i = np.zeros(dim)
+    for v_j in v.nn:
+        if _cache is not None and _vid in _cache and id(v_j) in _cache[_vid]:
+            A_ij = _cache[_vid][id(v_j)]
+        else:
+            A_ij = dual_area_vector(v, v_j, HC, dim)
+        delta_f = getattr(v_j, field_attr) - f_i
+        Df_i += delta_f * A_ij
+    Df_i *= 0.5
+    return Df_i
 
 
 def strain_rate(du: np.ndarray) -> np.ndarray:
@@ -448,13 +631,77 @@ def integrated_cauchy_stress(
     return -p * Vol_i * np.eye(dim) + 2.0 * mu * strain_rate(Du)
 
 
-def stress_force(
-    v,
-    dim: int = 3,
-    mu: float = 8.9e-4,
-    HC=None,
+def _resolve_pressure(v, pressure_model, HC, dim):
+    """Resolve the pressure for a single vertex.
+
+    Parameters
+    ----------
+    v : vertex object
+    pressure_model : None, callable, or EquationOfState
+        - ``None``: read ``v.p`` as-is (default, incompressible).
+        - callable ``fn(v) -> float``: externally defined pressure field.
+        - :class:`~ddgclib.eos.EquationOfState`: compute pressure from
+          density ``rho = v.m / dual_vol`` via the EOS.  Also updates
+          ``v.p`` and ``v.rho`` in-place so downstream code sees fresh
+          values.
+    HC : Complex
+    dim : int
+
+    Returns
+    -------
+    float
+        Pressure at the vertex.
+    """
+    if pressure_model is None:
+        p = v.p
+        return float(p) if np.ndim(p) == 0 else float(p[0])
+
+    if callable(pressure_model) and not hasattr(pressure_model, 'pressure'):
+        # Plain callable: fn(v) -> float
+        return float(pressure_model(v))
+
+    # EquationOfState: P = eos.pressure(m / dual_vol)
+    # Uses cached dual_vol (updated by _retopologize at each step).
+    vol = _get_dual_vol(v, HC, dim)
+    if vol < 1e-30:
+        return float(pressure_model.pressure(pressure_model.rho0))
+    rho = v.m / vol
+    p = float(pressure_model.pressure(rho))
+    # Update vertex in-place so other code (callbacks, diagnostics) sees it
+    v.rho = rho
+    v.p = p
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Factored flux primitives (shared by stress_force and multiphase_stress)
+# ---------------------------------------------------------------------------
+
+def pressure_flux(p_i: float, p_j: float, A_ij: np.ndarray) -> np.ndarray:
+    """Face-average pressure flux: F_p_ij = -0.5 * (p_i + p_j) * A_ij."""
+    return -0.5 * (p_i + p_j) * A_ij
+
+
+def viscous_flux(
+    mu: float,
+    delta_u: np.ndarray,
+    d_ij: np.ndarray,
+    A_ij: np.ndarray,
 ) -> np.ndarray:
-    """Integrated force on a parcel via face-centered fluxes.
+    """Face-centered viscous diffusion flux.
+
+    F_v_ij = (mu / |d_ij|) * delta_u * (d_hat . A_ij)
+    """
+    d_norm = float(np.linalg.norm(d_ij))
+    if d_norm < 1e-30:
+        return np.zeros_like(A_ij)
+    d_hat = d_ij / d_norm
+    return (mu / d_norm) * delta_u * np.dot(d_hat, A_ij)
+
+
+def stress_force(v, dim: int = 3, mu: float = 8.9e-4, HC=None,
+                 pressure_model=None) -> np.ndarray:
+    """Integrated force on FVM via face-centered fluxes (Stokes' theorem).
 
     For each dual flux plane between parcels i and j, the force has two
     contributions computed directly from edge data:
@@ -488,38 +735,42 @@ def stress_force(
         Dynamic viscosity [Pa.s].
     HC : Complex
         Simplicial complex with duals computed.
+    pressure_model : None, callable, or EquationOfState
+        Controls how vertex pressure is obtained:
+
+        - ``None`` (default): read ``v.p`` as-is (prescribed or constant).
+        - callable ``fn(v) -> float``: externally defined pressure field,
+          evaluated each time the force is computed.
+        - :class:`~ddgclib.eos.EquationOfState`: weakly compressible
+          pressure from density ``rho = m / dual_vol``.  Updates ``v.p``
+          and ``v.rho`` in-place.
+
     Returns
     -------
     np.ndarray
         Force vector, shape ``(dim,)``.
     """
+    p_i = _resolve_pressure(v, pressure_model, HC, dim)
+    u_i = v.u[:dim]
+    x_i = v.x_a[:dim]
+
+    # Use cached oriented edge area vectors when available (set by
+    # batch_e_star(..., orient=True) during retopologization).
+    _cache = getattr(HC, '_edge_area_cache', None)
+    _vid = id(v) if _cache is not None else None
+
     F = np.zeros(dim)
-    can_use_flux_terms = HC is not None and hasattr(v, "vd")
+    for v_j in v.nn:
+        if _cache is not None and _vid in _cache and id(v_j) in _cache[_vid]:
+            A_ij = _cache[_vid][id(v_j)]
+        else:
+            A_ij = dual_area_vector(v, v_j, HC, dim)
 
-    if can_use_flux_terms:
-        p_i = float(v.p) if np.ndim(v.p) == 0 else float(v.p[0])
-        u_i = v.u[:dim]
-        x_i = v.x_a[:dim]
-
-        for v_j in v.nn:
-            try:
-                A_ij = dual_area_vector(v, v_j, HC, dim)
-            except (KeyError, IndexError, ValueError, RuntimeError, ZeroDivisionError):
-                continue
-
-            # --- Pressure flux (face-average, conservative) ---
-            p_j = float(v_j.p) if np.ndim(v_j.p) == 0 else float(v_j.p[0])
-            F -= 0.5 * (p_i + p_j) * A_ij
-
-            # --- Viscous flux (face-centered diffusion) ---
-            delta_u = v_j.u[:dim] - u_i
-            d_ij = v_j.x_a[:dim] - x_i
-            d_norm = np.linalg.norm(d_ij)
-            if d_norm < 1e-30:
-                continue
-            d_hat = d_ij / d_norm
-            # mu * (grad u)_f . A = (mu/|d|) * du * (d_hat . A)
-            F += (mu / d_norm) * delta_u * np.dot(d_hat, A_ij)
+        p_j = _resolve_pressure(v_j, pressure_model, HC, dim)
+        delta_u = v_j.u[:dim] - u_i
+        d_ij = v_j.x_a[:dim] - x_i
+        F += pressure_flux(p_i, p_j, A_ij)
+        F += viscous_flux(mu, delta_u, d_ij, A_ij)
 
     return F
 
@@ -529,6 +780,7 @@ def stress_acceleration(
     dim: int = 3,
     mu: float = 8.9e-4,
     HC=None,
+    pressure_model=None,
 ) -> np.ndarray:
     """Acceleration from Cauchy stress: a_i = F_stress_i / m_i.
 
@@ -544,6 +796,13 @@ def stress_acceleration(
         dudt_fn = partial(stress_acceleration, dim=3, mu=1e-3, HC=HC)
         t = euler(HC, bV, dudt_fn, dt=1e-4, n_steps=100)
 
+    For weakly compressible flow with an equation of state::
+
+        from ddgclib.eos import TaitMurnaghan
+        eos = TaitMurnaghan(rho0=1000.0, P0=101325.0)
+        dudt_fn = partial(stress_acceleration, dim=2, mu=1e-3, HC=HC,
+                          pressure_model=eos)
+
     Parameters
     ----------
     v : vertex object
@@ -554,13 +813,16 @@ def stress_acceleration(
         Dynamic viscosity [Pa.s].
     HC : Complex
         Simplicial complex with duals computed.
+    pressure_model : None, callable, or EquationOfState
+        See :func:`stress_force`.
+
     Returns
     -------
     np.ndarray
         Acceleration vector, shape ``(dim,)``.
     """
-    F = stress_force(v, dim=dim, mu=mu, HC=HC)
-    return F / v.m
+    return stress_force(v, dim=dim, mu=mu, HC=HC,
+                        pressure_model=pressure_model) / v.m
 
 
 # Simplified alias for use as dudt_fn in dynamic integrators

--- a/ddgclib/operators/stress.py
+++ b/ddgclib/operators/stress.py
@@ -43,6 +43,540 @@ Constitutive relation TODOs
 
 import numpy as np
 
+# ---------------------------------------------------------------------------
+# Benchmark add-on operators: HC/FHeron droplet volume-pressure closure
+# ---------------------------------------------------------------------------
+
+def build_surface_hc_from_faces(points: np.ndarray, faces: np.ndarray):
+    """Build an HC surface graph from triangular interface connectivity.
+
+    Reference: the surface curvature force uses the ddgclib/HyperCT Heron
+    integrated mean-curvature vector, as described in the ddgclib
+    fundamentals and in Heron's discrete curvature construction.
+    """
+    from hyperct import Complex
+
+    HC = Complex(3, domain=None)
+    vertices = [HC.V[tuple(float(x) for x in point)] for point in np.asarray(points, dtype=float)]
+    for a, b, c in np.asarray(faces, dtype=int):
+        va, vb, vc = vertices[int(a)], vertices[int(b)], vertices[int(c)]
+        va.connect(vb)
+        vb.connect(vc)
+        vc.connect(va)
+    for vertex in vertices:
+        vertex.u = np.zeros(3, dtype=float)
+        vertex.p = 0.0
+        vertex.m = 1.0
+        vertex.phase = 0
+        vertex.boundary = False
+        vertex.is_interface = True
+    return HC, vertices
+
+
+def heron_surface_force_from_faces(
+    points: np.ndarray,
+    faces: np.ndarray,
+    gamma: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return nodal FHeron and Heron scalar dual area on a surface mesh.
+
+    Formula used by the benchmark:
+
+        F_i^Heron = -gamma (HN dA)_i
+
+    Reference: ddgclib Heron curvature operator / HyperCT surface graph.
+    The function is intentionally separate from ``stress_force`` because it is
+    an interface curvature force, not a bulk Cauchy stress flux.
+    """
+    from ddgclib._curvatures_heron import hndA_i
+
+    _HC, vertices = build_surface_hc_from_faces(points, faces)
+    forces = np.zeros((len(vertices), 3), dtype=float)
+    areas = np.zeros(len(vertices), dtype=float)
+    for i, vertex in enumerate(vertices):
+        hnda_i, area_i = hndA_i(vertex)
+        forces[i] = -float(gamma) * np.asarray(hnda_i[:3], dtype=float)
+        areas[i] = float(area_i)
+    return forces, areas
+
+
+def mesh_volume_from_faces(points: np.ndarray, faces: np.ndarray) -> float:
+    """Closed triangular surface volume by signed origin tetrahedra."""
+    pts = np.asarray(points, dtype=float)
+    volumes = [
+        abs(float(np.dot(pts[int(a)], np.cross(pts[int(b)], pts[int(c)])))) / 6.0
+        for a, b, c in np.asarray(faces, dtype=int)
+    ]
+    return float(np.sum(volumes))
+
+
+def vertex_area_vectors_from_faces(points: np.ndarray, faces: np.ndarray) -> np.ndarray:
+    """Lumped oriented boundary area vectors.
+
+    These vectors are used only for pressure-equivalent diagnostics.  The
+    dynamic pressure operator below uses tet-volume gradients.
+    """
+    pts = np.asarray(points, dtype=float)
+    area_vectors = np.zeros_like(pts, dtype=float)
+    for a, b, c in np.asarray(faces, dtype=int):
+        a_i, b_i, c_i = int(a), int(b), int(c)
+        pa, pb, pc = pts[a_i], pts[b_i], pts[c_i]
+        area_vec = 0.5 * np.cross(pb - pa, pc - pa)
+        centroid = (pa + pb + pc) / 3.0
+        if float(np.dot(area_vec, centroid)) < 0.0:
+            area_vec = -area_vec
+        share = area_vec / 3.0
+        area_vectors[a_i] += share
+        area_vectors[b_i] += share
+        area_vectors[c_i] += share
+    return area_vectors
+
+
+def pressure_equivalent_from_forces(forces: np.ndarray, area_vectors: np.ndarray) -> float:
+    """Least-squares scalar pressure balancing a surface force.
+
+    Formula:
+
+        p = -sum_i A_i . F_i / sum_i A_i . A_i
+    """
+    denom = float(np.sum(np.asarray(area_vectors, dtype=float) * np.asarray(area_vectors, dtype=float)))
+    if denom <= 0.0:
+        return 0.0
+    return -float(np.sum(np.asarray(area_vectors, dtype=float) * np.asarray(forces, dtype=float))) / denom
+
+
+def heron_forces_for_points(
+    points: np.ndarray,
+    faces: np.ndarray,
+    gamma: float,
+) -> tuple[np.ndarray, np.ndarray, float, float]:
+    """Return FHeron, area vectors, equivalent capillary pressure, volume."""
+    forces, _areas = heron_surface_force_from_faces(points, faces, gamma)
+    area_vectors = vertex_area_vectors_from_faces(points, faces)
+    pressure = pressure_equivalent_from_forces(forces, area_vectors)
+    return forces, area_vectors, pressure, mesh_volume_from_faces(points, faces)
+
+
+def tet_cell_volumes(points: np.ndarray, tets: np.ndarray) -> np.ndarray:
+    """Tetrahedron volumes for a simplicial volume mesh."""
+    pts = np.asarray(points, dtype=float)
+    tet_arr = np.asarray(tets, dtype=int)
+    p0 = pts[tet_arr[:, 0]]
+    p1 = pts[tet_arr[:, 1]]
+    p2 = pts[tet_arr[:, 2]]
+    p3 = pts[tet_arr[:, 3]]
+    triple = np.einsum("ij,ij->i", p1 - p0, np.cross(p2 - p0, p3 - p0))
+    return np.abs(triple) / 6.0
+
+
+def tet_volume_matrix(points: np.ndarray, tets: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Tet volumes and volume-gradient matrix B.
+
+    B[t, 3*i:3*i+3] = dV_t / dx_i, so B u is the discrete tet-volume
+    continuity operator.  This is the pressure operator used in the corrected
+    droplet benchmark.
+
+    References: Chorin (1968) and Temam projection methods for the role of
+    a pressure constraint; here the discrete volume gradient replaces a grid
+    divergence on the unstructured Lagrangian tet mesh.
+    """
+    pts = np.asarray(points, dtype=float)
+    tet_arr = np.asarray(tets, dtype=int)
+    volumes = np.zeros(tet_arr.shape[0], dtype=float)
+    matrix = np.zeros((tet_arr.shape[0], pts.shape[0] * 3), dtype=float)
+    for tet_idx, tet in enumerate(tet_arr):
+        i0, i1, i2, i3 = [int(i) for i in tet]
+        p0, p1, p2, p3 = pts[i0], pts[i1], pts[i2], pts[i3]
+        triple = float(np.dot(p1 - p0, np.cross(p2 - p0, p3 - p0)))
+        sign = 1.0 if triple >= 0.0 else -1.0
+        volumes[tet_idx] = abs(triple) / 6.0
+        g1 = sign * np.cross(p2 - p0, p3 - p0) / 6.0
+        g2 = sign * np.cross(p3 - p0, p1 - p0) / 6.0
+        g3 = sign * np.cross(p1 - p0, p2 - p0) / 6.0
+        g0 = -(g1 + g2 + g3)
+        for vertex_idx, gradient in ((i0, g0), (i1, g1), (i2, g2), (i3, g3)):
+            start = 3 * vertex_idx
+            matrix[tet_idx, start:start + 3] += gradient
+    return volumes, matrix
+
+
+def tet_volume_lumped_nodal_values(n_vertices: int, tets: np.ndarray, tet_values: np.ndarray) -> np.ndarray:
+    """Barycentric tet-volume lumping: each tet contributes value/4.
+
+    This is used after retopology to avoid HC-dual-volume jumps.  The sum of
+    nodal values is exactly the sum of tet values.
+    """
+    nodal = np.zeros(int(n_vertices), dtype=float)
+    for tet, value in zip(np.asarray(tets, dtype=int), np.asarray(tet_values, dtype=float)):
+        share = 0.25 * float(value)
+        for vertex_idx in tet:
+            nodal[int(vertex_idx)] += share
+    return nodal
+
+
+def lump_tet_masses(n_vertices: int, tets: np.ndarray, volumes: np.ndarray, rho: float) -> np.ndarray:
+    """Lump physical tet mass to vertices using barycentric tet-volume weights."""
+    return np.maximum(tet_volume_lumped_nodal_values(n_vertices, tets, float(rho) * np.asarray(volumes)), 1.0e-18)
+
+
+def mass_inverse_dof(masses: np.ndarray) -> np.ndarray:
+    """Repeat nodal inverse masses over x/y/z degrees of freedom."""
+    return np.repeat(1.0 / np.maximum(np.asarray(masses, dtype=float), 1.0e-300), 3)
+
+
+def local_volume_stiffness(matrix: np.ndarray, masses: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Return S = B M^-1 B^T and repeated inverse mass vector."""
+    inv_mass_dof = mass_inverse_dof(masses)
+    stiffness = (np.asarray(matrix, dtype=float) * inv_mass_dof[None, :]) @ np.asarray(matrix, dtype=float).T
+    return stiffness, inv_mass_dof
+
+
+def solve_regularized(matrix: np.ndarray, rhs: np.ndarray, *, relative: float = 1.0e-12) -> np.ndarray:
+    """Solve a possibly singular pressure system with light Tikhonov damping."""
+    lhs = np.asarray(matrix, dtype=float)
+    rhs_array = np.asarray(rhs, dtype=float)
+    scale = max(float(np.mean(np.abs(np.diag(lhs)))) if lhs.size else 0.0, 1.0e-30)
+    regularized = lhs + float(relative) * scale * np.eye(lhs.shape[0], dtype=float)
+    try:
+        return np.linalg.solve(regularized, rhs_array)
+    except np.linalg.LinAlgError:
+        return np.linalg.lstsq(regularized, rhs_array, rcond=1.0e-12)[0]
+
+
+def volume_gradient_pressure_matrix(volume_matrix: np.ndarray) -> np.ndarray:
+    """Map tet pressures to nodal forces with F^p = B^T p."""
+    return np.asarray(volume_matrix, dtype=float).T
+
+
+def compressible_eos_pressure_correction(
+    *,
+    velocities: np.ndarray,
+    nonpressure_forces: np.ndarray,
+    masses: np.ndarray,
+    tet_volumes: np.ndarray,
+    target_tet_volumes: np.ndarray,
+    reference_tet_volumes: np.ndarray,
+    volume_matrix: np.ndarray,
+    dt: float,
+    bulk_modulus: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Weak-compressible EOS pressure correction for tet volumes.
+
+    Solves:
+
+        (I + dt^2 D_K B M^-1 B^T) dp
+          = -D_K (V - Vtar + dt B u*)
+
+    Reference: pressure-based weakly compressible correction analogous to
+    coupled pressure-density solvers; the discrete B operator is the local
+    tet-volume continuity operator.
+    """
+    stiffness, inv_mass_dof = local_volume_stiffness(volume_matrix, masses)
+    u_star = np.asarray(velocities, dtype=float) + float(dt) * (
+        np.asarray(nonpressure_forces, dtype=float) / np.maximum(np.asarray(masses, dtype=float)[:, None], 1.0e-300)
+    )
+    compressibility = float(bulk_modulus) / np.maximum(np.asarray(reference_tet_volumes, dtype=float), 1.0e-300)
+    linear_error = (
+        np.asarray(tet_volumes, dtype=float)
+        - np.asarray(target_tet_volumes, dtype=float)
+        + float(dt) * (np.asarray(volume_matrix, dtype=float) @ u_star.reshape(-1))
+    )
+    system = np.eye(np.asarray(tet_volumes).shape[0]) + (compressibility[:, None] * float(dt) * float(dt)) * stiffness
+    rhs = -compressibility * linear_error
+    pressure_delta = solve_regularized(system, rhs)
+    velocity_vec = u_star.reshape(-1) + float(dt) * inv_mass_dof * (volume_gradient_pressure_matrix(volume_matrix) @ pressure_delta)
+    return velocity_vec.reshape(np.asarray(velocities).shape), pressure_delta
+
+
+def incompressible_volume_projection(
+    *,
+    velocities: np.ndarray,
+    nonpressure_forces: np.ndarray,
+    masses: np.ndarray,
+    tet_volumes: np.ndarray,
+    target_tet_volumes: np.ndarray,
+    volume_matrix: np.ndarray,
+    dt: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Local incompressible projection using B u^{n+1}=target_rates.
+
+    Reference: Chorin (1968), Temam projection methods.  This implementation
+    uses tet volume gradients, so the projected vertex velocity satisfies the
+    local discrete volume/continuity constraint.
+    """
+    inv_mass_dof = mass_inverse_dof(masses)
+    pressure_matrix = volume_gradient_pressure_matrix(volume_matrix)
+    target_rates = -(np.asarray(tet_volumes, dtype=float) - np.asarray(target_tet_volumes, dtype=float)) / float(dt)
+    velocity_vec = np.asarray(velocities, dtype=float).reshape(-1)
+    nonpressure_vec = np.asarray(nonpressure_forces, dtype=float).reshape(-1)
+    stiffness = (np.asarray(volume_matrix, dtype=float) * inv_mass_dof[None, :]) @ pressure_matrix
+    rhs = (
+        (target_rates - np.asarray(volume_matrix, dtype=float) @ velocity_vec) / float(dt)
+        - np.asarray(volume_matrix, dtype=float) @ (inv_mass_dof * nonpressure_vec)
+    )
+    pressure_values = solve_regularized(stiffness, rhs)
+    total_forces = np.asarray(nonpressure_forces, dtype=float) + (pressure_matrix @ pressure_values).reshape(np.asarray(velocities).shape)
+    projected = np.asarray(velocities, dtype=float) + float(dt) * (
+        inv_mass_dof * total_forces.reshape(-1)
+    ).reshape(np.asarray(velocities).shape)
+    return projected, pressure_values
+
+
+def tet_face_pairs(tets: np.ndarray) -> list[tuple[np.ndarray, int, int]]:
+    """Return internal tet faces as ``(face_vertices, left_tet, right_tet)``."""
+    face_map: dict[tuple[int, int, int], list[int]] = {}
+    for tet_idx, tet in enumerate(np.asarray(tets, dtype=int)):
+        a, b, c, d = [int(index) for index in tet]
+        for face in ((a, b, c), (a, b, d), (a, c, d), (b, c, d)):
+            face_map.setdefault(tuple(sorted(face)), []).append(tet_idx)
+    return [
+        (np.asarray(face, dtype=int), int(owners[0]), int(owners[1]))
+        for face, owners in face_map.items()
+        if len(owners) == 2
+    ]
+
+
+def tet_face_ale_fluxes(
+    points: np.ndarray,
+    velocities: np.ndarray,
+    tets: np.ndarray,
+    face_pairs: list[tuple[np.ndarray, int, int]],
+    tet_masses: np.ndarray,
+    reference_tet_masses: np.ndarray,
+    tet_volumes: np.ndarray,
+    dt: float,
+    *,
+    reference_density: float,
+    sound_speed: float,
+    mass_floor_fraction: float = 0.35,
+    mass_update_coupling: float = 0.02,
+    momentum_force_coupling: float = 0.0,
+    density_change_limit: float | None = None,
+    flux_cfl_limit: float = 0.25,
+    flux_scheme: str = "upwind",
+    face_flux_mode: str = "cell-average",
+) -> tuple[np.ndarray, np.ndarray, dict[str, float]]:
+    """Internal ALE face mass/momentum flux on a tet mesh.
+
+    References: Hirt, Amsden & Cook (1974) ALE formulation; Toro (2009) for
+    upwind/Rusanov numerical fluxes.  For ``face_flux_mode='lagrangian'`` the
+    mesh-face velocity equals the material-face velocity, so internal material
+    flux is zero; this is the physical setting for #5/#6/#11/#12.
+    """
+    if flux_scheme not in {"upwind", "rusanov"}:
+        raise ValueError("flux_scheme must be 'upwind' or 'rusanov'")
+    if face_flux_mode not in {"cell-average", "lagrangian"}:
+        raise ValueError("face_flux_mode must be 'cell-average' or 'lagrangian'")
+
+    n_tets = np.asarray(tets, dtype=int).shape[0]
+    cell_centers = np.mean(np.asarray(points, dtype=float)[np.asarray(tets, dtype=int)], axis=1)
+    cell_velocities = np.mean(np.asarray(velocities, dtype=float)[np.asarray(tets, dtype=int)], axis=1)
+    cell_density = np.asarray(tet_masses, dtype=float) / np.maximum(np.asarray(tet_volumes, dtype=float), 1.0e-300)
+    dm_dt = np.zeros(n_tets, dtype=float)
+    cell_force = np.zeros((n_tets, 3), dtype=float)
+    mass_flux_l1 = 0.0
+    max_abs_mass_flux = 0.0
+    momentum_flux_l1 = 0.0
+    volume_flux_l1 = 0.0
+
+    for face_vertices, left, right in face_pairs:
+        pa, pb, pc = np.asarray(points, dtype=float)[face_vertices]
+        area_vec = 0.5 * np.cross(pb - pa, pc - pa)
+        center_delta = cell_centers[right] - cell_centers[left]
+        if float(np.dot(area_vec, center_delta)) < 0.0:
+            area_vec = -area_vec
+        area = float(np.linalg.norm(area_vec))
+        if area <= 0.0:
+            continue
+        normal = area_vec / area
+        mesh_face_velocity = np.mean(np.asarray(velocities, dtype=float)[face_vertices], axis=0)
+        left_velocity = cell_velocities[left]
+        right_velocity = cell_velocities[right]
+        left_density = float(cell_density[left])
+        right_density = float(cell_density[right])
+
+        if face_flux_mode == "lagrangian":
+            relative_volume_flux = 0.0
+            mass_flux = 0.0
+            momentum_flux = np.zeros(3, dtype=float)
+        elif flux_scheme == "rusanov":
+            left_relative_normal = float(np.dot(left_velocity - mesh_face_velocity, normal))
+            right_relative_normal = float(np.dot(right_velocity - mesh_face_velocity, normal))
+            max_wave_speed = max(
+                abs(left_relative_normal) + float(sound_speed),
+                abs(right_relative_normal) + float(sound_speed),
+                1.0e-30,
+            )
+            mass_flux = area * (
+                0.5 * (left_density * left_relative_normal + right_density * right_relative_normal)
+                - 0.5 * max_wave_speed * (right_density - left_density)
+            )
+            momentum_flux = area * (
+                0.5 * (left_density * left_velocity * left_relative_normal + right_density * right_velocity * right_relative_normal)
+                - 0.5 * max_wave_speed * (right_density * right_velocity - left_density * left_velocity)
+            )
+            relative_volume_flux = mass_flux / max(0.5 * (left_density + right_density), 1.0e-300)
+        else:
+            fluid_face_velocity = 0.5 * (left_velocity + right_velocity)
+            relative_volume_flux = float(np.dot(fluid_face_velocity - mesh_face_velocity, area_vec))
+            if relative_volume_flux >= 0.0:
+                density = left_density
+                upwind_velocity = left_velocity
+            else:
+                density = right_density
+                upwind_velocity = right_velocity
+            mass_flux = density * relative_volume_flux
+            momentum_flux = mass_flux * upwind_velocity
+
+        dm_dt[left] -= mass_flux
+        dm_dt[right] += mass_flux
+        cell_force[left] -= momentum_flux
+        cell_force[right] += momentum_flux
+        mass_flux_l1 += abs(float(mass_flux))
+        max_abs_mass_flux = max(max_abs_mass_flux, abs(float(mass_flux)))
+        momentum_flux_l1 += float(np.linalg.norm(momentum_flux))
+        volume_flux_l1 += abs(float(relative_volume_flux))
+
+    effective_dm_dt = float(mass_update_coupling) * dm_dt
+    effective_cell_force = float(momentum_force_coupling) * cell_force
+    scale = 1.0
+    mass_delta = float(dt) * effective_dm_dt
+    mass_abs_delta = np.abs(mass_delta)
+    if flux_cfl_limit > 0.0 and np.any(mass_abs_delta > 0.0):
+        cfl_scale = np.min(
+            float(flux_cfl_limit) * np.asarray(tet_masses, dtype=float)[mass_abs_delta > 0.0]
+            / mass_abs_delta[mass_abs_delta > 0.0]
+        )
+        scale = min(scale, max(0.0, float(cfl_scale)))
+    floors = float(mass_floor_fraction) * np.asarray(reference_tet_masses, dtype=float)
+    proposed = np.asarray(tet_masses, dtype=float) + mass_delta
+    floor_bad = proposed < floors
+    if np.any(floor_bad):
+        denom = -mass_delta[floor_bad]
+        valid = denom > 0.0
+        if np.any(valid):
+            floor_scale = np.min((np.asarray(tet_masses)[floor_bad][valid] - floors[floor_bad][valid]) / denom[valid])
+            scale = min(scale, max(0.0, float(floor_scale)))
+    if density_change_limit is not None and density_change_limit > 0.0:
+        lower_masses = (1.0 - float(density_change_limit)) * float(reference_density) * np.maximum(tet_volumes, 1.0e-300)
+        upper_masses = (1.0 + float(density_change_limit)) * float(reference_density) * np.maximum(tet_volumes, 1.0e-300)
+        increasing = (mass_delta > 0.0) & (proposed > upper_masses)
+        if np.any(increasing):
+            density_scale = np.min((upper_masses[increasing] - np.asarray(tet_masses)[increasing]) / mass_delta[increasing])
+            scale = min(scale, max(0.0, float(density_scale)))
+        decreasing = (mass_delta < 0.0) & (proposed < lower_masses)
+        if np.any(decreasing):
+            density_scale = np.min((lower_masses[decreasing] - np.asarray(tet_masses)[decreasing]) / mass_delta[decreasing])
+            scale = min(scale, max(0.0, float(density_scale)))
+
+    effective_dm_dt *= scale
+    effective_cell_force *= scale
+    updated_masses = np.maximum(np.asarray(tet_masses, dtype=float) + float(dt) * effective_dm_dt, floors)
+    nodal_flux_force = np.zeros_like(np.asarray(points, dtype=float))
+    for tet, force in zip(np.asarray(tets, dtype=int), effective_cell_force):
+        for vertex_idx in tet:
+            nodal_flux_force[int(vertex_idx)] += 0.25 * force
+    stats = {
+        "mass_flux_l1_kg_s": float(mass_flux_l1),
+        "mass_flux_max_kg_s": float(max_abs_mass_flux),
+        "momentum_flux_l1_n": float(momentum_flux_l1),
+        "volume_flux_l1_m3_s": float(volume_flux_l1),
+        "flux_limiter_scale": float(scale),
+        "mass_update_coupling": float(mass_update_coupling),
+        "momentum_force_coupling": float(momentum_force_coupling),
+        "density_change_limit": float(density_change_limit) if density_change_limit is not None else 0.0,
+        "flux_cfl_limit": float(flux_cfl_limit),
+        "flux_scheme_rusanov": 1.0 if flux_scheme == "rusanov" else 0.0,
+        "face_flux_lagrangian": 1.0 if face_flux_mode == "lagrangian" else 0.0,
+    }
+    return updated_masses, nodal_flux_force, stats
+
+
+def delaunay_retriangulate_points(
+    points: np.ndarray,
+    fallback_tets: np.ndarray,
+    *,
+    qhull_options: str = "Qbb Qc",
+    min_volume_fraction: float = 0.1,
+) -> np.ndarray:
+    """Fresh Delaunay tet list for active retopology.
+
+    Reference: Delaunay retopology changes connectivity.  The benchmark
+    recomputes B=dV/dx and remaps tet mass/target volume from the new tet
+    volume list to avoid HC-dual-volume density jumps after flips.
+    """
+    try:
+        from scipy.spatial import Delaunay
+
+        triangulation = Delaunay(np.asarray(points, dtype=float), qhull_options=qhull_options)
+        raw_tets = np.asarray(triangulation.simplices, dtype=int)
+        valid = np.all(raw_tets < np.asarray(points).shape[0], axis=1)
+        raw_tets = raw_tets[valid]
+        if raw_tets.size == 0:
+            return np.asarray(fallback_tets, dtype=int).copy()
+        volumes = tet_cell_volumes(points, raw_tets)
+        positive = volumes[volumes > 0.0]
+        min_volume = float(min_volume_fraction) * float(np.median(positive)) if positive.size else 0.0
+        filtered = raw_tets[volumes > min_volume]
+        if filtered.size == 0:
+            return np.asarray(fallback_tets, dtype=int).copy()
+        return np.asarray(filtered, dtype=int)
+    except Exception:
+        return np.asarray(fallback_tets, dtype=int).copy()
+
+
+def active_retopology_tet_remap(
+    points: np.ndarray,
+    current_tets: np.ndarray,
+    *,
+    density: float | None = None,
+    target_total_mass: float | None = None,
+    target_total_volume: float | None = None,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, dict[str, float]]:
+    """Rebuild tets and remap mass/target volumes after retopology.
+
+    This is the controlled benchmark workaround for the HC dual-volume jump:
+    after a connectivity flip, use the new tet volumes directly and assign
+    m_t = rho V_t, V_t^tar = V_t.  It is not a conservative old-dual/new-dual
+    overlap remap.
+    """
+    old_sorted = {tuple(sorted(int(i) for i in tet)) for tet in np.asarray(current_tets, dtype=int)}
+    new_tets = delaunay_retriangulate_points(points, current_tets)
+    new_sorted = {tuple(sorted(int(i) for i in tet)) for tet in np.asarray(new_tets, dtype=int)}
+    changed = len(old_sorted.symmetric_difference(new_sorted))
+    new_volumes = tet_cell_volumes(points, new_tets)
+    current_volume = float(np.sum(new_volumes))
+    if current_volume <= 1.0e-300:
+        return np.asarray(current_tets, dtype=int).copy(), new_volumes, new_volumes, {
+            "retriangulation_active": 1.0,
+            "display_tet_count": float(np.asarray(current_tets).shape[0]),
+            "display_internal_face_count": float(len(tet_face_pairs(current_tets))),
+            "display_changed_tets": 0.0,
+            "display_changed_fraction": 0.0,
+        }
+    if target_total_mass is not None:
+        target_density = float(target_total_mass) / current_volume
+    elif density is not None:
+        target_density = float(density)
+    else:
+        raise ValueError("density or target_total_mass must be provided")
+    target_volume_scale = (
+        float(target_total_volume) / current_volume
+        if target_total_volume is not None
+        else 1.0
+    )
+    reference_tet_volumes = target_volume_scale * new_volumes
+    tet_masses = target_density * new_volumes
+    stats = {
+        "retriangulation_active": 1.0,
+        "display_tet_count": float(new_tets.shape[0]),
+        "display_internal_face_count": float(len(tet_face_pairs(new_tets))),
+        "display_changed_tets": float(changed),
+        "display_changed_fraction": float(changed) / max(float(len(old_sorted) + len(new_sorted)), 1.0),
+    }
+    return new_tets, reference_tet_volumes, tet_masses, stats
+
+
 
 # ---------------------------------------------------------------------------
 # Geometry: dual area vectors and dual volumes

--- a/ddgclib/operators/stress.py
+++ b/ddgclib/operators/stress.py
@@ -43,1045 +43,6 @@ Constitutive relation TODOs
 
 import numpy as np
 
-# ---------------------------------------------------------------------------
-# Benchmark add-on operators: HC/FHeron droplet volume-pressure closure
-# ---------------------------------------------------------------------------
-
-def build_surface_hc_from_faces(points: np.ndarray, faces: np.ndarray):
-    """Build an HC surface graph from triangular interface connectivity.
-
-    Reference: the surface curvature force uses the ddgclib/HyperCT Heron
-    integrated mean-curvature vector, as described in the ddgclib
-    fundamentals and in Heron's discrete curvature construction.
-    """
-    from hyperct import Complex
-
-    HC = Complex(3, domain=None)
-    vertices = [HC.V[tuple(float(x) for x in point)] for point in np.asarray(points, dtype=float)]
-    for a, b, c in np.asarray(faces, dtype=int):
-        va, vb, vc = vertices[int(a)], vertices[int(b)], vertices[int(c)]
-        va.connect(vb)
-        vb.connect(vc)
-        vc.connect(va)
-    for vertex in vertices:
-        vertex.u = np.zeros(3, dtype=float)
-        vertex.p = 0.0
-        vertex.m = 1.0
-        vertex.phase = 0
-        vertex.boundary = False
-        vertex.is_interface = True
-    return HC, vertices
-
-
-def heron_surface_force_from_faces(
-    points: np.ndarray,
-    faces: np.ndarray,
-    gamma: float,
-) -> tuple[np.ndarray, np.ndarray]:
-    """Return nodal FHeron and Heron scalar dual area on a surface mesh.
-
-    Formula used by the benchmark:
-
-        F_i^Heron = -gamma (HN dA)_i
-
-    Reference: ddgclib Heron curvature operator / HyperCT surface graph.
-    The function is intentionally separate from ``stress_force`` because it is
-    an interface curvature force, not a bulk Cauchy stress flux.
-    """
-    from ddgclib._curvatures_heron import hndA_i
-
-    _HC, vertices = build_surface_hc_from_faces(points, faces)
-    forces = np.zeros((len(vertices), 3), dtype=float)
-    areas = np.zeros(len(vertices), dtype=float)
-    for i, vertex in enumerate(vertices):
-        hnda_i, area_i = hndA_i(vertex)
-        forces[i] = -float(gamma) * np.asarray(hnda_i[:3], dtype=float)
-        areas[i] = float(area_i)
-    return forces, areas
-
-
-def mesh_volume_from_faces(points: np.ndarray, faces: np.ndarray) -> float:
-    """Closed triangular surface volume by signed origin tetrahedra."""
-    pts = np.asarray(points, dtype=float)
-    volumes = [
-        abs(float(np.dot(pts[int(a)], np.cross(pts[int(b)], pts[int(c)])))) / 6.0
-        for a, b, c in np.asarray(faces, dtype=int)
-    ]
-    return float(np.sum(volumes))
-
-
-def vertex_area_vectors_from_faces(points: np.ndarray, faces: np.ndarray) -> np.ndarray:
-    """Lumped oriented boundary area vectors.
-
-    These vectors are used only for pressure-equivalent diagnostics.  The
-    dynamic pressure operator below uses tet-volume gradients.
-    """
-    pts = np.asarray(points, dtype=float)
-    area_vectors = np.zeros_like(pts, dtype=float)
-    for a, b, c in np.asarray(faces, dtype=int):
-        a_i, b_i, c_i = int(a), int(b), int(c)
-        pa, pb, pc = pts[a_i], pts[b_i], pts[c_i]
-        area_vec = 0.5 * np.cross(pb - pa, pc - pa)
-        centroid = (pa + pb + pc) / 3.0
-        if float(np.dot(area_vec, centroid)) < 0.0:
-            area_vec = -area_vec
-        share = area_vec / 3.0
-        area_vectors[a_i] += share
-        area_vectors[b_i] += share
-        area_vectors[c_i] += share
-    return area_vectors
-
-
-def pressure_equivalent_from_forces(forces: np.ndarray, area_vectors: np.ndarray) -> float:
-    """Least-squares scalar pressure balancing a surface force.
-
-    Formula:
-
-        p = -sum_i A_i . F_i / sum_i A_i . A_i
-    """
-    denom = float(np.sum(np.asarray(area_vectors, dtype=float) * np.asarray(area_vectors, dtype=float)))
-    if denom <= 0.0:
-        return 0.0
-    return -float(np.sum(np.asarray(area_vectors, dtype=float) * np.asarray(forces, dtype=float))) / denom
-
-
-def heron_forces_for_points(
-    points: np.ndarray,
-    faces: np.ndarray,
-    gamma: float,
-) -> tuple[np.ndarray, np.ndarray, float, float]:
-    """Return FHeron, area vectors, equivalent capillary pressure, volume."""
-    forces, _areas = heron_surface_force_from_faces(points, faces, gamma)
-    area_vectors = vertex_area_vectors_from_faces(points, faces)
-    pressure = pressure_equivalent_from_forces(forces, area_vectors)
-    return forces, area_vectors, pressure, mesh_volume_from_faces(points, faces)
-
-
-def tet_cell_volumes(points: np.ndarray, tets: np.ndarray) -> np.ndarray:
-    """Tetrahedron volumes for a simplicial volume mesh."""
-    pts = np.asarray(points, dtype=float)
-    tet_arr = np.asarray(tets, dtype=int)
-    p0 = pts[tet_arr[:, 0]]
-    p1 = pts[tet_arr[:, 1]]
-    p2 = pts[tet_arr[:, 2]]
-    p3 = pts[tet_arr[:, 3]]
-    triple = np.einsum("ij,ij->i", p1 - p0, np.cross(p2 - p0, p3 - p0))
-    return np.abs(triple) / 6.0
-
-
-def tet_volume_matrix(points: np.ndarray, tets: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
-    """Tet volumes and volume-gradient matrix B.
-
-    B[t, 3*i:3*i+3] = dV_t / dx_i, so B u is the discrete tet-volume
-    continuity operator.  This is the pressure operator used in the corrected
-    droplet benchmark.
-
-    References: Chorin (1968) and Temam projection methods for the role of
-    a pressure constraint; here the discrete volume gradient replaces a grid
-    divergence on the unstructured Lagrangian tet mesh.
-    """
-    pts = np.asarray(points, dtype=float)
-    tet_arr = np.asarray(tets, dtype=int)
-    volumes = np.zeros(tet_arr.shape[0], dtype=float)
-    matrix = np.zeros((tet_arr.shape[0], pts.shape[0] * 3), dtype=float)
-    for tet_idx, tet in enumerate(tet_arr):
-        i0, i1, i2, i3 = [int(i) for i in tet]
-        p0, p1, p2, p3 = pts[i0], pts[i1], pts[i2], pts[i3]
-        triple = float(np.dot(p1 - p0, np.cross(p2 - p0, p3 - p0)))
-        sign = 1.0 if triple >= 0.0 else -1.0
-        volumes[tet_idx] = abs(triple) / 6.0
-        g1 = sign * np.cross(p2 - p0, p3 - p0) / 6.0
-        g2 = sign * np.cross(p3 - p0, p1 - p0) / 6.0
-        g3 = sign * np.cross(p1 - p0, p2 - p0) / 6.0
-        g0 = -(g1 + g2 + g3)
-        for vertex_idx, gradient in ((i0, g0), (i1, g1), (i2, g2), (i3, g3)):
-            start = 3 * vertex_idx
-            matrix[tet_idx, start:start + 3] += gradient
-    return volumes, matrix
-
-
-def tet_volume_lumped_nodal_values(n_vertices: int, tets: np.ndarray, tet_values: np.ndarray) -> np.ndarray:
-    """Barycentric tet-volume lumping: each tet contributes value/4.
-
-    This is used after retopology to avoid HC-dual-volume jumps.  The sum of
-    nodal values is exactly the sum of tet values.
-    """
-    nodal = np.zeros(int(n_vertices), dtype=float)
-    for tet, value in zip(np.asarray(tets, dtype=int), np.asarray(tet_values, dtype=float)):
-        share = 0.25 * float(value)
-        for vertex_idx in tet:
-            nodal[int(vertex_idx)] += share
-    return nodal
-
-
-def lump_tet_masses(n_vertices: int, tets: np.ndarray, volumes: np.ndarray, rho: float) -> np.ndarray:
-    """Lump physical tet mass to vertices using barycentric tet-volume weights."""
-    return np.maximum(tet_volume_lumped_nodal_values(n_vertices, tets, float(rho) * np.asarray(volumes)), 1.0e-18)
-
-
-def mass_inverse_dof(masses: np.ndarray) -> np.ndarray:
-    """Repeat nodal inverse masses over x/y/z degrees of freedom."""
-    return np.repeat(1.0 / np.maximum(np.asarray(masses, dtype=float), 1.0e-300), 3)
-
-
-def local_volume_stiffness(matrix: np.ndarray, masses: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
-    """Return S = B M^-1 B^T and repeated inverse mass vector."""
-    inv_mass_dof = mass_inverse_dof(masses)
-    stiffness = (np.asarray(matrix, dtype=float) * inv_mass_dof[None, :]) @ np.asarray(matrix, dtype=float).T
-    return stiffness, inv_mass_dof
-
-
-def solve_regularized(matrix: np.ndarray, rhs: np.ndarray, *, relative: float = 1.0e-12) -> np.ndarray:
-    """Solve a possibly singular pressure system with light Tikhonov damping."""
-    lhs = np.asarray(matrix, dtype=float)
-    rhs_array = np.asarray(rhs, dtype=float)
-    scale = max(float(np.mean(np.abs(np.diag(lhs)))) if lhs.size else 0.0, 1.0e-30)
-    regularized = lhs + float(relative) * scale * np.eye(lhs.shape[0], dtype=float)
-    try:
-        return np.linalg.solve(regularized, rhs_array)
-    except np.linalg.LinAlgError:
-        return np.linalg.lstsq(regularized, rhs_array, rcond=1.0e-12)[0]
-
-
-def volume_gradient_pressure_matrix(volume_matrix: np.ndarray) -> np.ndarray:
-    """Map tet pressures to nodal forces with F^p = B^T p."""
-    return np.asarray(volume_matrix, dtype=float).T
-
-
-def compressible_eos_pressure_correction(
-    *,
-    velocities: np.ndarray,
-    nonpressure_forces: np.ndarray,
-    masses: np.ndarray,
-    tet_volumes: np.ndarray,
-    target_tet_volumes: np.ndarray,
-    reference_tet_volumes: np.ndarray,
-    volume_matrix: np.ndarray,
-    dt: float,
-    bulk_modulus: float,
-) -> tuple[np.ndarray, np.ndarray]:
-    """Weak-compressible EOS pressure correction for tet volumes.
-
-    Solves:
-
-        (I + dt^2 D_K B M^-1 B^T) dp
-          = -D_K (V - Vtar + dt B u*)
-
-    Reference: pressure-based weakly compressible correction analogous to
-    coupled pressure-density solvers; the discrete B operator is the local
-    tet-volume continuity operator.
-    """
-    stiffness, inv_mass_dof = local_volume_stiffness(volume_matrix, masses)
-    u_star = np.asarray(velocities, dtype=float) + float(dt) * (
-        np.asarray(nonpressure_forces, dtype=float) / np.maximum(np.asarray(masses, dtype=float)[:, None], 1.0e-300)
-    )
-    compressibility = float(bulk_modulus) / np.maximum(np.asarray(reference_tet_volumes, dtype=float), 1.0e-300)
-    linear_error = (
-        np.asarray(tet_volumes, dtype=float)
-        - np.asarray(target_tet_volumes, dtype=float)
-        + float(dt) * (np.asarray(volume_matrix, dtype=float) @ u_star.reshape(-1))
-    )
-    system = np.eye(np.asarray(tet_volumes).shape[0]) + (compressibility[:, None] * float(dt) * float(dt)) * stiffness
-    rhs = -compressibility * linear_error
-    pressure_delta = solve_regularized(system, rhs)
-    velocity_vec = u_star.reshape(-1) + float(dt) * inv_mass_dof * (volume_gradient_pressure_matrix(volume_matrix) @ pressure_delta)
-    return velocity_vec.reshape(np.asarray(velocities).shape), pressure_delta
-
-
-def incompressible_volume_projection(
-    *,
-    velocities: np.ndarray,
-    nonpressure_forces: np.ndarray,
-    masses: np.ndarray,
-    tet_volumes: np.ndarray,
-    target_tet_volumes: np.ndarray,
-    volume_matrix: np.ndarray,
-    dt: float,
-) -> tuple[np.ndarray, np.ndarray]:
-    """Local incompressible projection using B u^{n+1}=target_rates.
-
-    Reference: Chorin (1968), Temam projection methods.  This implementation
-    uses tet volume gradients, so the projected vertex velocity satisfies the
-    local discrete volume/continuity constraint.
-    """
-    inv_mass_dof = mass_inverse_dof(masses)
-    pressure_matrix = volume_gradient_pressure_matrix(volume_matrix)
-    target_rates = -(np.asarray(tet_volumes, dtype=float) - np.asarray(target_tet_volumes, dtype=float)) / float(dt)
-    velocity_vec = np.asarray(velocities, dtype=float).reshape(-1)
-    nonpressure_vec = np.asarray(nonpressure_forces, dtype=float).reshape(-1)
-    stiffness = (np.asarray(volume_matrix, dtype=float) * inv_mass_dof[None, :]) @ pressure_matrix
-    rhs = (
-        (target_rates - np.asarray(volume_matrix, dtype=float) @ velocity_vec) / float(dt)
-        - np.asarray(volume_matrix, dtype=float) @ (inv_mass_dof * nonpressure_vec)
-    )
-    pressure_values = solve_regularized(stiffness, rhs)
-    total_forces = np.asarray(nonpressure_forces, dtype=float) + (pressure_matrix @ pressure_values).reshape(np.asarray(velocities).shape)
-    projected = np.asarray(velocities, dtype=float) + float(dt) * (
-        inv_mass_dof * total_forces.reshape(-1)
-    ).reshape(np.asarray(velocities).shape)
-    return projected, pressure_values
-
-
-def tet_face_pairs(tets: np.ndarray) -> list[tuple[np.ndarray, int, int]]:
-    """Return internal tet faces as ``(face_vertices, left_tet, right_tet)``."""
-    face_map: dict[tuple[int, int, int], list[int]] = {}
-    for tet_idx, tet in enumerate(np.asarray(tets, dtype=int)):
-        a, b, c, d = [int(index) for index in tet]
-        for face in ((a, b, c), (a, b, d), (a, c, d), (b, c, d)):
-            face_map.setdefault(tuple(sorted(face)), []).append(tet_idx)
-    return [
-        (np.asarray(face, dtype=int), int(owners[0]), int(owners[1]))
-        for face, owners in face_map.items()
-        if len(owners) == 2
-    ]
-
-
-def tet_face_ale_fluxes(
-    points: np.ndarray,
-    velocities: np.ndarray,
-    tets: np.ndarray,
-    face_pairs: list[tuple[np.ndarray, int, int]],
-    tet_masses: np.ndarray,
-    reference_tet_masses: np.ndarray,
-    tet_volumes: np.ndarray,
-    dt: float,
-    *,
-    reference_density: float,
-    sound_speed: float,
-    mass_floor_fraction: float = 0.35,
-    mass_update_coupling: float = 0.02,
-    momentum_force_coupling: float = 0.0,
-    density_change_limit: float | None = None,
-    flux_cfl_limit: float = 0.25,
-    flux_scheme: str = "upwind",
-    face_flux_mode: str = "cell-average",
-) -> tuple[np.ndarray, np.ndarray, dict[str, float]]:
-    """Internal ALE face mass/momentum flux on a tet mesh.
-
-    References: Hirt, Amsden & Cook (1974) ALE formulation; Toro (2009) for
-    upwind/Rusanov numerical fluxes.  For ``face_flux_mode='lagrangian'`` the
-    mesh-face velocity equals the material-face velocity, so internal material
-    flux is zero; this is the physical setting for #5/#6/#11/#12.
-    """
-    if flux_scheme not in {"upwind", "rusanov"}:
-        raise ValueError("flux_scheme must be 'upwind' or 'rusanov'")
-    if face_flux_mode not in {"cell-average", "lagrangian"}:
-        raise ValueError("face_flux_mode must be 'cell-average' or 'lagrangian'")
-
-    n_tets = np.asarray(tets, dtype=int).shape[0]
-    cell_centers = np.mean(np.asarray(points, dtype=float)[np.asarray(tets, dtype=int)], axis=1)
-    cell_velocities = np.mean(np.asarray(velocities, dtype=float)[np.asarray(tets, dtype=int)], axis=1)
-    cell_density = np.asarray(tet_masses, dtype=float) / np.maximum(np.asarray(tet_volumes, dtype=float), 1.0e-300)
-    dm_dt = np.zeros(n_tets, dtype=float)
-    cell_force = np.zeros((n_tets, 3), dtype=float)
-    mass_flux_l1 = 0.0
-    max_abs_mass_flux = 0.0
-    momentum_flux_l1 = 0.0
-    volume_flux_l1 = 0.0
-
-    for face_vertices, left, right in face_pairs:
-        pa, pb, pc = np.asarray(points, dtype=float)[face_vertices]
-        area_vec = 0.5 * np.cross(pb - pa, pc - pa)
-        center_delta = cell_centers[right] - cell_centers[left]
-        if float(np.dot(area_vec, center_delta)) < 0.0:
-            area_vec = -area_vec
-        area = float(np.linalg.norm(area_vec))
-        if area <= 0.0:
-            continue
-        normal = area_vec / area
-        mesh_face_velocity = np.mean(np.asarray(velocities, dtype=float)[face_vertices], axis=0)
-        left_velocity = cell_velocities[left]
-        right_velocity = cell_velocities[right]
-        left_density = float(cell_density[left])
-        right_density = float(cell_density[right])
-
-        if face_flux_mode == "lagrangian":
-            relative_volume_flux = 0.0
-            mass_flux = 0.0
-            momentum_flux = np.zeros(3, dtype=float)
-        elif flux_scheme == "rusanov":
-            left_relative_normal = float(np.dot(left_velocity - mesh_face_velocity, normal))
-            right_relative_normal = float(np.dot(right_velocity - mesh_face_velocity, normal))
-            max_wave_speed = max(
-                abs(left_relative_normal) + float(sound_speed),
-                abs(right_relative_normal) + float(sound_speed),
-                1.0e-30,
-            )
-            mass_flux = area * (
-                0.5 * (left_density * left_relative_normal + right_density * right_relative_normal)
-                - 0.5 * max_wave_speed * (right_density - left_density)
-            )
-            momentum_flux = area * (
-                0.5 * (left_density * left_velocity * left_relative_normal + right_density * right_velocity * right_relative_normal)
-                - 0.5 * max_wave_speed * (right_density * right_velocity - left_density * left_velocity)
-            )
-            relative_volume_flux = mass_flux / max(0.5 * (left_density + right_density), 1.0e-300)
-        else:
-            fluid_face_velocity = 0.5 * (left_velocity + right_velocity)
-            relative_volume_flux = float(np.dot(fluid_face_velocity - mesh_face_velocity, area_vec))
-            if relative_volume_flux >= 0.0:
-                density = left_density
-                upwind_velocity = left_velocity
-            else:
-                density = right_density
-                upwind_velocity = right_velocity
-            mass_flux = density * relative_volume_flux
-            momentum_flux = mass_flux * upwind_velocity
-
-        dm_dt[left] -= mass_flux
-        dm_dt[right] += mass_flux
-        cell_force[left] -= momentum_flux
-        cell_force[right] += momentum_flux
-        mass_flux_l1 += abs(float(mass_flux))
-        max_abs_mass_flux = max(max_abs_mass_flux, abs(float(mass_flux)))
-        momentum_flux_l1 += float(np.linalg.norm(momentum_flux))
-        volume_flux_l1 += abs(float(relative_volume_flux))
-
-    effective_dm_dt = float(mass_update_coupling) * dm_dt
-    effective_cell_force = float(momentum_force_coupling) * cell_force
-    scale = 1.0
-    mass_delta = float(dt) * effective_dm_dt
-    mass_abs_delta = np.abs(mass_delta)
-    if flux_cfl_limit > 0.0 and np.any(mass_abs_delta > 0.0):
-        cfl_scale = np.min(
-            float(flux_cfl_limit) * np.asarray(tet_masses, dtype=float)[mass_abs_delta > 0.0]
-            / mass_abs_delta[mass_abs_delta > 0.0]
-        )
-        scale = min(scale, max(0.0, float(cfl_scale)))
-    floors = float(mass_floor_fraction) * np.asarray(reference_tet_masses, dtype=float)
-    proposed = np.asarray(tet_masses, dtype=float) + mass_delta
-    floor_bad = proposed < floors
-    if np.any(floor_bad):
-        denom = -mass_delta[floor_bad]
-        valid = denom > 0.0
-        if np.any(valid):
-            floor_scale = np.min((np.asarray(tet_masses)[floor_bad][valid] - floors[floor_bad][valid]) / denom[valid])
-            scale = min(scale, max(0.0, float(floor_scale)))
-    if density_change_limit is not None and density_change_limit > 0.0:
-        lower_masses = (1.0 - float(density_change_limit)) * float(reference_density) * np.maximum(tet_volumes, 1.0e-300)
-        upper_masses = (1.0 + float(density_change_limit)) * float(reference_density) * np.maximum(tet_volumes, 1.0e-300)
-        increasing = (mass_delta > 0.0) & (proposed > upper_masses)
-        if np.any(increasing):
-            density_scale = np.min((upper_masses[increasing] - np.asarray(tet_masses)[increasing]) / mass_delta[increasing])
-            scale = min(scale, max(0.0, float(density_scale)))
-        decreasing = (mass_delta < 0.0) & (proposed < lower_masses)
-        if np.any(decreasing):
-            density_scale = np.min((lower_masses[decreasing] - np.asarray(tet_masses)[decreasing]) / mass_delta[decreasing])
-            scale = min(scale, max(0.0, float(density_scale)))
-
-    effective_dm_dt *= scale
-    effective_cell_force *= scale
-    updated_masses = np.maximum(np.asarray(tet_masses, dtype=float) + float(dt) * effective_dm_dt, floors)
-    nodal_flux_force = np.zeros_like(np.asarray(points, dtype=float))
-    for tet, force in zip(np.asarray(tets, dtype=int), effective_cell_force):
-        for vertex_idx in tet:
-            nodal_flux_force[int(vertex_idx)] += 0.25 * force
-    stats = {
-        "mass_flux_l1_kg_s": float(mass_flux_l1),
-        "mass_flux_max_kg_s": float(max_abs_mass_flux),
-        "momentum_flux_l1_n": float(momentum_flux_l1),
-        "volume_flux_l1_m3_s": float(volume_flux_l1),
-        "flux_limiter_scale": float(scale),
-        "mass_update_coupling": float(mass_update_coupling),
-        "momentum_force_coupling": float(momentum_force_coupling),
-        "density_change_limit": float(density_change_limit) if density_change_limit is not None else 0.0,
-        "flux_cfl_limit": float(flux_cfl_limit),
-        "flux_scheme_rusanov": 1.0 if flux_scheme == "rusanov" else 0.0,
-        "face_flux_lagrangian": 1.0 if face_flux_mode == "lagrangian" else 0.0,
-    }
-    return updated_masses, nodal_flux_force, stats
-
-
-def delaunay_retriangulate_points(
-    points: np.ndarray,
-    fallback_tets: np.ndarray,
-    *,
-    qhull_options: str = "Qbb Qc",
-    min_volume_fraction: float = 0.1,
-) -> np.ndarray:
-    """Fresh Delaunay tet list for active retopology.
-
-    Reference: Delaunay retopology changes connectivity.  The benchmark
-    recomputes B=dV/dx and remaps tet mass/target volume from the new tet
-    volume list to avoid HC-dual-volume density jumps after flips.
-    """
-    try:
-        from scipy.spatial import Delaunay
-
-        triangulation = Delaunay(np.asarray(points, dtype=float), qhull_options=qhull_options)
-        raw_tets = np.asarray(triangulation.simplices, dtype=int)
-        valid = np.all(raw_tets < np.asarray(points).shape[0], axis=1)
-        raw_tets = raw_tets[valid]
-        if raw_tets.size == 0:
-            return np.asarray(fallback_tets, dtype=int).copy()
-        volumes = tet_cell_volumes(points, raw_tets)
-        positive = volumes[volumes > 0.0]
-        min_volume = float(min_volume_fraction) * float(np.median(positive)) if positive.size else 0.0
-        filtered = raw_tets[volumes > min_volume]
-        if filtered.size == 0:
-            return np.asarray(fallback_tets, dtype=int).copy()
-        return np.asarray(filtered, dtype=int)
-    except Exception:
-        return np.asarray(fallback_tets, dtype=int).copy()
-
-
-def active_retopology_tet_remap(
-    points: np.ndarray,
-    current_tets: np.ndarray,
-    *,
-    density: float | None = None,
-    target_total_mass: float | None = None,
-    target_total_volume: float | None = None,
-) -> tuple[np.ndarray, np.ndarray, np.ndarray, dict[str, float]]:
-    """Rebuild tets and remap mass/target volumes after retopology.
-
-    This is the controlled benchmark workaround for the HC dual-volume jump:
-    after a connectivity flip, use the new tet volumes directly and assign
-    m_t = rho V_t, V_t^tar = V_t.  It is not a conservative old-dual/new-dual
-    overlap remap.
-    """
-    old_sorted = {tuple(sorted(int(i) for i in tet)) for tet in np.asarray(current_tets, dtype=int)}
-    new_tets = delaunay_retriangulate_points(points, current_tets)
-    new_sorted = {tuple(sorted(int(i) for i in tet)) for tet in np.asarray(new_tets, dtype=int)}
-    changed = len(old_sorted.symmetric_difference(new_sorted))
-    new_volumes = tet_cell_volumes(points, new_tets)
-    current_volume = float(np.sum(new_volumes))
-    if current_volume <= 1.0e-300:
-        return np.asarray(current_tets, dtype=int).copy(), new_volumes, new_volumes, {
-            "retriangulation_active": 1.0,
-            "display_tet_count": float(np.asarray(current_tets).shape[0]),
-            "display_internal_face_count": float(len(tet_face_pairs(current_tets))),
-            "display_changed_tets": 0.0,
-            "display_changed_fraction": 0.0,
-        }
-    if target_total_mass is not None:
-        target_density = float(target_total_mass) / current_volume
-    elif density is not None:
-        target_density = float(density)
-    else:
-        raise ValueError("density or target_total_mass must be provided")
-    target_volume_scale = (
-        float(target_total_volume) / current_volume
-        if target_total_volume is not None
-        else 1.0
-    )
-    reference_tet_volumes = target_volume_scale * new_volumes
-    tet_masses = target_density * new_volumes
-    stats = {
-        "retriangulation_active": 1.0,
-        "display_tet_count": float(new_tets.shape[0]),
-        "display_internal_face_count": float(len(tet_face_pairs(new_tets))),
-        "display_changed_tets": float(changed),
-        "display_changed_fraction": float(changed) / max(float(len(old_sorted) + len(new_sorted)), 1.0),
-    }
-    return new_tets, reference_tet_volumes, tet_masses, stats
-
-
-def _tet_phase_retopology_remap(
-    points: np.ndarray,
-    current_tets: np.ndarray,
-    current_phases: np.ndarray,
-    *,
-    phase_densities: dict[int, float],
-) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, dict[str, float]]:
-    """Rebuild a phase-labelled tet list and reset tet mass/target volumes.
-
-    Each new Delaunay tet is assigned the phase of the nearest old tet center.
-    This compact remap is used by the oscillating-droplet pressure-reference
-    benchmark to make the pressure operator insensitive to HC dual-volume jumps
-    caused by Delaunay flips.
-    """
-    pts = np.asarray(points, dtype=float)
-    old_tets = np.asarray(current_tets, dtype=int)
-    old_phases = np.asarray(current_phases, dtype=int)
-    old_centers = np.mean(pts[old_tets], axis=1)
-    new_tets = delaunay_retriangulate_points(pts, old_tets)
-    new_centers = np.mean(pts[new_tets], axis=1)
-    new_phases = np.zeros(new_tets.shape[0], dtype=int)
-    for tet_idx, center in enumerate(new_centers):
-        nearest = int(np.argmin(np.sum((old_centers - center) ** 2, axis=1)))
-        new_phases[tet_idx] = int(old_phases[nearest])
-    new_volumes = tet_cell_volumes(pts, new_tets)
-    rho = np.asarray([float(phase_densities[int(phase)]) for phase in new_phases], dtype=float)
-    tet_masses = rho * new_volumes
-    old_sorted = {tuple(sorted(int(v) for v in tet)) for tet in old_tets}
-    new_sorted = {tuple(sorted(int(v) for v in tet)) for tet in new_tets}
-    changed = len(old_sorted.symmetric_difference(new_sorted))
-    stats = {
-        "retriangulation_active": 1.0,
-        "display_tet_count": float(new_tets.shape[0]),
-        "display_internal_face_count": float(len(tet_face_pairs(new_tets))),
-        "display_changed_tets": float(changed),
-        "display_changed_fraction": float(changed) / max(float(len(old_sorted) + len(new_sorted)), 1.0),
-    }
-    return new_tets, new_phases, new_volumes, tet_masses, stats
-
-
-class VolumeGradientPressureState:
-    """Cached tet-volume pressure operator for dynamic integrators.
-
-    This state is the pressure-reference drop-in for the face-average pressure
-    flux in :func:`stress_force`.  It keeps the standard vertex update
-
-        du_i/dt = F_i / m_i,     dx_i/dt = u_i
-
-    but computes the pressure force from tet-volume gradients,
-
-        B[t, 3*i:3*i+3] = dV_t / dx_i,        F^p = B^T p.
-
-    The compressible branch solves the EOS/continuity correction
-
-        (I + dt^2 D_K B M^{-1} B^T) dp
-          = -D_K (V - V_tar + dt B u*),
-
-    while the incompressible branch solves the local projection enforcing
-    ``B u^{n+1} = -(V - V_tar)/dt``.  References: Chorin (1968) projection
-    method; Hirt, Amsden & Cook (1974) ALE formulation; Toro (2009) Riemann
-    fluxes.  The Heron surface force is the ddgclib/HyperCT HC curvature force.
-    """
-
-    vertex_index_attr = "_volume_gradient_index"
-
-    def __init__(
-        self,
-        *,
-        tets: np.ndarray,
-        surface_indices: np.ndarray,
-        surface_faces: np.ndarray,
-        gamma: float,
-        density: float,
-        bulk_modulus: float | np.ndarray,
-        closure: str,
-        reference_tet_volumes: np.ndarray,
-        tet_masses: np.ndarray,
-        base_tet_pressures: float | np.ndarray,
-        dt: float,
-        inertia_scale: float = 1.0,
-        inertial_mass_addition: np.ndarray | None = None,
-        damping_rate: float = 0.0,
-        fixed_indices: np.ndarray | None = None,
-        phase_ids: np.ndarray | None = None,
-        phase_densities: dict[int, float] | None = None,
-        phase_bulk_moduli: dict[int, float] | None = None,
-        phase_base_pressures: dict[int, float] | None = None,
-        active_retopology: bool = False,
-        mass_flux_coupling: float = 0.0,
-        momentum_flux_coupling: float = 0.0,
-        density_change_limit: float | None = None,
-        flux_cfl_limit: float = 0.25,
-        flux_scheme: str = "upwind",
-        face_flux_mode: str = "lagrangian",
-        flux_timing: str = "pre-pressure",
-        mass_floor_fraction: float = 0.35,
-        sound_speed: float | None = None,
-        incompressible_target_mode: str = "reference",
-    ) -> None:
-        if closure not in {"compressible", "incompressible"}:
-            raise ValueError("closure must be 'compressible' or 'incompressible'")
-        if flux_timing not in {"pre-pressure", "post-pressure"}:
-            raise ValueError("flux_timing must be 'pre-pressure' or 'post-pressure'")
-        if incompressible_target_mode not in {"reference", "mass"}:
-            raise ValueError("incompressible_target_mode must be 'reference' or 'mass'")
-        self.tets = np.asarray(tets, dtype=int).copy()
-        self.surface_indices = np.asarray(surface_indices, dtype=int).copy()
-        self.surface_faces = np.asarray(surface_faces, dtype=int).copy()
-        self.gamma = float(gamma)
-        self.density = float(density)
-        self.bulk_modulus = np.asarray(bulk_modulus, dtype=float)
-        self.closure = closure
-        self.reference_tet_volumes = np.asarray(reference_tet_volumes, dtype=float).copy()
-        self.tet_masses = np.asarray(tet_masses, dtype=float).copy()
-        self.reference_tet_masses = self.tet_masses.copy()
-        self.base_tet_pressures = np.asarray(base_tet_pressures, dtype=float)
-        self.dt = float(dt)
-        self.inertia_scale = float(inertia_scale)
-        self.inertial_mass_addition = (
-            None if inertial_mass_addition is None else np.asarray(inertial_mass_addition, dtype=float).copy()
-        )
-        self.damping_rate = float(damping_rate)
-        self.fixed_indices = np.asarray(fixed_indices if fixed_indices is not None else [], dtype=int)
-        self.phase_ids = None if phase_ids is None else np.asarray(phase_ids, dtype=int).copy()
-        self.phase_densities = dict(phase_densities or {})
-        self.phase_bulk_moduli = dict(phase_bulk_moduli or {})
-        self.phase_base_pressures = dict(phase_base_pressures or {})
-        self.active_retopology = bool(active_retopology)
-        self.mass_flux_coupling = float(mass_flux_coupling)
-        self.momentum_flux_coupling = float(momentum_flux_coupling)
-        self.density_change_limit = density_change_limit
-        self.flux_cfl_limit = float(flux_cfl_limit)
-        self.flux_scheme = flux_scheme
-        self.face_flux_mode = face_flux_mode
-        self.flux_timing = flux_timing
-        self.mass_floor_fraction = float(mass_floor_fraction)
-        self.sound_speed = float(sound_speed) if sound_speed is not None else float(np.sqrt(float(np.max(self.bulk_modulus)) / self.density))
-        self.incompressible_target_mode = incompressible_target_mode
-        self.reference_total_mass = float(np.sum(self.tet_masses))
-        self.reference_total_volume = float(np.sum(self.reference_tet_volumes))
-        self.reference_display_tet_set = {tuple(sorted(int(v) for v in tet)) for tet in self.tets}
-        self.reference_nodal_volumes: np.ndarray | None = None
-        self.face_pairs = tet_face_pairs(self.tets)
-        self.accelerations: np.ndarray | None = None
-        self.last_new_velocities: np.ndarray | None = None
-        self.last_inertial_masses: np.ndarray | None = None
-        self.last_tet_volumes: np.ndarray | None = None
-        self.last_pressure_values: np.ndarray | None = None
-        self.last_fheron_pressure = 0.0
-        self.last_flux_stats = self._empty_flux_stats()
-        self.last_retopology_stats = self._empty_retopology_stats()
-        self.dirty = True
-
-    def _empty_flux_stats(self) -> dict[str, float]:
-        return {
-            "mass_flux_l1_kg_s": 0.0,
-            "mass_flux_max_kg_s": 0.0,
-            "momentum_flux_l1_n": 0.0,
-            "volume_flux_l1_m3_s": 0.0,
-            "flux_limiter_scale": 1.0,
-            "mass_update_coupling": float(self.mass_flux_coupling),
-            "momentum_force_coupling": float(self.momentum_flux_coupling),
-            "density_change_limit": float(self.density_change_limit) if self.density_change_limit is not None else 0.0,
-            "flux_cfl_limit": float(self.flux_cfl_limit),
-            "face_flux_lagrangian": 1.0 if self.face_flux_mode == "lagrangian" else 0.0,
-        }
-
-    def _empty_retopology_stats(self) -> dict[str, float]:
-        return {
-            "retriangulation_active": 1.0 if self.active_retopology else 0.0,
-            "display_tet_count": float(self.tets.shape[0]),
-            "display_internal_face_count": float(len(self.face_pairs)),
-            "display_changed_tets": 0.0,
-            "display_changed_fraction": 0.0,
-        }
-
-    def mark_dirty(self) -> None:
-        self.dirty = True
-
-    def read_hc_state(self, HC) -> tuple[np.ndarray, np.ndarray]:
-        n_vertices = 1 + max(int(getattr(v, self.vertex_index_attr)) for v in HC.V)
-        points = np.zeros((n_vertices, 3), dtype=float)
-        velocities = np.zeros((n_vertices, 3), dtype=float)
-        seen = np.zeros(n_vertices, dtype=bool)
-        for vertex in HC.V:
-            index = int(getattr(vertex, self.vertex_index_attr))
-            points[index] = np.asarray(vertex.x_a[:3], dtype=float)
-            velocities[index] = np.asarray(getattr(vertex, "u", np.zeros(3))[:3], dtype=float)
-            seen[index] = True
-        if not np.all(seen):
-            missing = np.flatnonzero(~seen)
-            raise ValueError(f"HC is missing volume-gradient vertex indices: {missing[:8]}")
-        return points, velocities
-
-    def write_hc_state(self, HC, points: np.ndarray, velocities: np.ndarray, bV=None) -> None:
-        boundary = set() if bV is None else bV
-        for vertex in list(HC.V):
-            index = int(getattr(vertex, self.vertex_index_attr))
-            vertex.u[:3] = np.asarray(velocities[index], dtype=float)
-            if vertex in boundary:
-                boundary.remove(vertex)
-                HC.V.move(vertex, tuple(np.asarray(points[index], dtype=float)))
-                boundary.add(vertex)
-            else:
-                HC.V.move(vertex, tuple(np.asarray(points[index], dtype=float)))
-
-    def retopologize_callback(self, HC, bV, dim, **_kwargs) -> None:
-        """Dynamic-integrator retopology hook.
-
-        The HyperCT vertices remain the ODE state.  This hook rebuilds only the
-        tet list, tet masses, target volumes, and cached pressure topology so
-        the next ``dudt_fn`` call uses the new Delaunay pressure operator.
-        """
-        if not self.active_retopology:
-            self.mark_dirty()
-            return
-        points, _velocities = self.read_hc_state(HC)
-        if self.phase_ids is None:
-            new_tets, new_reference_volumes, new_masses, stats = active_retopology_tet_remap(
-                points,
-                self.tets,
-                target_total_mass=self.reference_total_mass,
-                target_total_volume=self.reference_total_volume,
-            )
-            self.tets = np.asarray(new_tets, dtype=int)
-            self.reference_tet_volumes = np.asarray(new_reference_volumes, dtype=float)
-            self.tet_masses = np.asarray(new_masses, dtype=float)
-        else:
-            new_tets, new_phases, new_reference_volumes, new_masses, stats = _tet_phase_retopology_remap(
-                points,
-                self.tets,
-                self.phase_ids,
-                phase_densities=self.phase_densities,
-            )
-            self.tets = np.asarray(new_tets, dtype=int)
-            self.phase_ids = np.asarray(new_phases, dtype=int)
-            self.reference_tet_volumes = np.asarray(new_reference_volumes, dtype=float)
-            self.tet_masses = np.asarray(new_masses, dtype=float)
-        self.reference_tet_masses = self.tet_masses.copy()
-        self.face_pairs = tet_face_pairs(self.tets)
-        self.last_retopology_stats = stats
-        self.mark_dirty()
-
-    def _fixed_mask(self, n_vertices: int) -> np.ndarray:
-        mask = np.zeros(int(n_vertices), dtype=bool)
-        valid = self.fixed_indices[(self.fixed_indices >= 0) & (self.fixed_indices < n_vertices)]
-        mask[valid] = True
-        return mask
-
-    def _nodal_masses(self, n_vertices: int) -> np.ndarray:
-        nodal_mass = tet_volume_lumped_nodal_values(n_vertices, self.tets, self.tet_masses)
-        if self.inertial_mass_addition is not None:
-            nodal_mass = nodal_mass + np.asarray(self.inertial_mass_addition, dtype=float)
-        return np.maximum(float(self.inertia_scale) * nodal_mass, 1.0e-18)
-
-    def _inverse_mass_dof(self, masses: np.ndarray, fixed_mask: np.ndarray) -> np.ndarray:
-        inv_mass = np.repeat(1.0 / np.maximum(np.asarray(masses, dtype=float), 1.0e-300), 3)
-        inv_mass[np.repeat(np.asarray(fixed_mask, dtype=bool), 3)] = 0.0
-        return inv_mass
-
-    def _bulk_by_tet(self) -> np.ndarray:
-        if self.phase_ids is not None and self.phase_bulk_moduli:
-            return np.asarray([float(self.phase_bulk_moduli[int(phase)]) for phase in self.phase_ids], dtype=float)
-        if self.bulk_modulus.shape == ():
-            return np.full(self.tets.shape[0], float(self.bulk_modulus), dtype=float)
-        if self.bulk_modulus.shape[0] != self.tets.shape[0]:
-            return np.full(self.tets.shape[0], float(np.mean(self.bulk_modulus)), dtype=float)
-        return np.asarray(self.bulk_modulus, dtype=float)
-
-    def _base_pressures(self, reference_pressure: float) -> np.ndarray:
-        if self.phase_ids is not None and self.phase_base_pressures:
-            return np.asarray([float(self.phase_base_pressures.get(int(phase), 0.0)) for phase in self.phase_ids], dtype=float)
-        if self.base_tet_pressures.shape == ():
-            return np.full(self.tets.shape[0], float(self.base_tet_pressures), dtype=float)
-        if self.base_tet_pressures.shape[0] == self.tets.shape[0]:
-            return np.asarray(self.base_tet_pressures, dtype=float)
-        return np.full(self.tets.shape[0], float(reference_pressure), dtype=float)
-
-    def _density_by_tet(self) -> np.ndarray:
-        if self.phase_ids is not None and self.phase_densities:
-            return np.asarray([float(self.phase_densities[int(phase)]) for phase in self.phase_ids], dtype=float)
-        return np.full(self.tets.shape[0], float(self.density), dtype=float)
-
-    def _project_volume_velocity(
-        self,
-        velocities: np.ndarray,
-        volume_matrix: np.ndarray,
-        inv_mass_dof: np.ndarray,
-        target_rates: np.ndarray,
-    ) -> np.ndarray:
-        velocity_vec = np.asarray(velocities, dtype=float).reshape(-1)
-        stiffness = (np.asarray(volume_matrix, dtype=float) * np.asarray(inv_mass_dof, dtype=float)[None, :]) @ np.asarray(volume_matrix, dtype=float).T
-        rhs = np.asarray(volume_matrix, dtype=float) @ velocity_vec - np.asarray(target_rates, dtype=float)
-        multipliers = solve_regularized(stiffness, rhs)
-        projected = velocity_vec - np.asarray(inv_mass_dof, dtype=float) * (np.asarray(volume_matrix, dtype=float).T @ multipliers)
-        return projected.reshape(np.asarray(velocities).shape)
-
-    def prepare(self, HC, dt: float | None = None) -> None:
-        if not self.dirty and self.accelerations is not None:
-            return
-        step_dt = float(self.dt if dt is None else dt)
-        points, velocities = self.read_hc_state(HC)
-        n_vertices = points.shape[0]
-        tet_volumes, volume_matrix = tet_volume_matrix(points, self.tets)
-        fixed_mask = self._fixed_mask(n_vertices)
-        inertial_masses = self._nodal_masses(n_vertices)
-        inv_mass_dof = self._inverse_mass_dof(inertial_masses, fixed_mask)
-
-        flux_forces = np.zeros_like(points)
-        if self.flux_timing == "pre-pressure":
-            self.tet_masses, flux_forces, self.last_flux_stats = tet_face_ale_fluxes(
-                points,
-                velocities,
-                self.tets,
-                self.face_pairs,
-                self.tet_masses,
-                self.reference_tet_masses,
-                tet_volumes,
-                step_dt,
-                reference_density=self.density,
-                sound_speed=self.sound_speed,
-                mass_floor_fraction=self.mass_floor_fraction,
-                mass_update_coupling=self.mass_flux_coupling,
-                momentum_force_coupling=self.momentum_flux_coupling,
-                density_change_limit=self.density_change_limit,
-                flux_cfl_limit=self.flux_cfl_limit,
-                flux_scheme=self.flux_scheme,
-                face_flux_mode=self.face_flux_mode,
-            )
-            inertial_masses = self._nodal_masses(n_vertices)
-            inv_mass_dof = self._inverse_mass_dof(inertial_masses, fixed_mask)
-        else:
-            self.last_flux_stats = self._empty_flux_stats()
-
-        surface_forces, _surface_area_vectors, fheron_pressure, _surface_volume = heron_forces_for_points(
-            points[self.surface_indices],
-            self.surface_faces,
-            self.gamma,
-        )
-        self.last_fheron_pressure = float(fheron_pressure)
-        forces = np.zeros_like(points)
-        forces[self.surface_indices] += surface_forces
-        damping_forces = -float(self.damping_rate) * inertial_masses[:, None] * velocities
-        # This is the key pressure-reference choice.  The continuity residual
-        # and pressure force both use tet volumes, so after retopology the
-        # solver reacts to physical tet-volume error, not to HC dual-volume
-        # jumps caused by connectivity flips.
-        if self.closure == "compressible" or self.incompressible_target_mode == "mass":
-            target_tet_volumes = self.tet_masses / np.maximum(self._density_by_tet(), 1.0e-300)
-        else:
-            target_tet_volumes = self.reference_tet_volumes
-        pressure_matrix = volume_gradient_pressure_matrix(volume_matrix)
-
-        if self.closure == "compressible":
-            # Weak-compressible EOS correction:
-            #   (I + dt^2 D_K B M^-1 B^T) dp
-            #     = -D_K (V - Vtar + dt B u*)
-            # The pressure force is B^T p, which is adjoint to the same B that
-            # measures volume/continuity.  This adjoint pairing is what makes
-            # the Rayleigh response stable after retopology.
-            base_pressures = self._base_pressures(fheron_pressure)
-            nonpressure = forces + (pressure_matrix @ base_pressures).reshape(points.shape) + damping_forces + flux_forces
-            u_star = velocities + step_dt * (inv_mass_dof * nonpressure.reshape(-1)).reshape(points.shape)
-            u_star[fixed_mask] = 0.0
-            bulk_by_tet = self._bulk_by_tet()
-            compressibility = bulk_by_tet / np.maximum(self.reference_tet_volumes, 1.0e-300)
-            stiffness = (volume_matrix * inv_mass_dof[None, :]) @ pressure_matrix
-            linear_error = tet_volumes - target_tet_volumes + step_dt * (volume_matrix @ u_star.reshape(-1))
-            system = np.eye(self.tets.shape[0]) + (compressibility[:, None] * step_dt * step_dt) * stiffness
-            rhs = -compressibility * linear_error
-            pressure_delta = solve_regularized(system, rhs)
-            new_velocities = (
-                u_star.reshape(-1) + step_dt * inv_mass_dof * (pressure_matrix @ pressure_delta)
-            ).reshape(points.shape)
-            new_velocities[fixed_mask] = 0.0
-            self.last_pressure_values = base_pressures + pressure_delta
-        else:
-            # Local incompressible projection:
-            #   B u^{n+1} = -(V - Vtar)/dt
-            # This is the tet-volume analogue of a Chorin/Temam projection on
-            # a moving Lagrangian mesh.
-            target_rates = -(tet_volumes - target_tet_volumes) / step_dt
-            velocity_vec = velocities.reshape(-1)
-            nonpressure_vec = (forces + damping_forces + flux_forces).reshape(-1)
-            stiffness = (volume_matrix * inv_mass_dof[None, :]) @ pressure_matrix
-            rhs = (target_rates - volume_matrix @ velocity_vec) / step_dt - volume_matrix @ (inv_mass_dof * nonpressure_vec)
-            pressure_values = solve_regularized(stiffness, rhs)
-            total_forces = forces + (pressure_matrix @ pressure_values).reshape(points.shape) + damping_forces + flux_forces
-            new_velocities = velocities + step_dt * (inv_mass_dof * total_forces.reshape(-1)).reshape(points.shape)
-            new_velocities = self._project_volume_velocity(new_velocities, volume_matrix, inv_mass_dof, target_rates)
-            new_velocities[fixed_mask] = 0.0
-            self.last_pressure_values = pressure_values
-
-        if self.flux_timing == "post-pressure":
-            self.tet_masses, post_flux_forces, self.last_flux_stats = tet_face_ale_fluxes(
-                points,
-                new_velocities,
-                self.tets,
-                self.face_pairs,
-                self.tet_masses,
-                self.reference_tet_masses,
-                tet_volumes,
-                step_dt,
-                reference_density=self.density,
-                sound_speed=self.sound_speed,
-                mass_floor_fraction=self.mass_floor_fraction,
-                mass_update_coupling=self.mass_flux_coupling,
-                momentum_force_coupling=self.momentum_flux_coupling,
-                density_change_limit=self.density_change_limit,
-                flux_cfl_limit=self.flux_cfl_limit,
-                flux_scheme=self.flux_scheme,
-                face_flux_mode=self.face_flux_mode,
-            )
-            if self.momentum_flux_coupling:
-                post_masses = self._nodal_masses(n_vertices)
-                post_inv = self._inverse_mass_dof(post_masses, fixed_mask)
-                new_velocities = new_velocities + step_dt * (post_inv * post_flux_forces.reshape(-1)).reshape(points.shape)
-                new_velocities[fixed_mask] = 0.0
-
-        self.last_new_velocities = new_velocities
-        self.last_inertial_masses = inertial_masses
-        self.last_tet_volumes = tet_volumes
-        self.reference_nodal_volumes = tet_volume_lumped_nodal_values(n_vertices, self.tets, self.reference_tet_volumes)
-        self.accelerations = (new_velocities - velocities) / step_dt
-        self.dirty = False
-
-    def acceleration(self, vertex, *, HC=None, dt: float | None = None, dim: int = 3, mu: float = 0.0) -> np.ndarray:
-        """Return the cached acceleration for one vertex.
-
-        ``mu`` is accepted for API compatibility with ``dudt_i``.  The benchmark
-        pressure-reference runs set viscosity to zero so the pressure closure can
-        be compared directly with Rayleigh's inviscid oscillation frequency.
-        """
-        if HC is None:
-            raise ValueError("HC must be passed through the state or dudt wrapper")
-        if mu not in (0, 0.0):
-            raise NotImplementedError("VolumeGradientPressureState benchmark runs require mu=0")
-        self.prepare(HC, dt=dt)
-        index = int(getattr(vertex, self.vertex_index_attr))
-        accel = np.asarray(self.accelerations[index], dtype=float)
-        return accel[:dim]
-
-    def remove_rigid_translation(self, HC, bV=None) -> None:
-        """Remove center-of-mass drift after a completed Lagrangian step."""
-        if self.last_inertial_masses is None:
-            return
-        points, velocities = self.read_hc_state(HC)
-        masses = np.maximum(np.asarray(self.last_inertial_masses, dtype=float), 1.0e-300)
-        mass_sum = max(float(np.sum(masses)), 1.0e-300)
-        center = np.sum(points * masses[:, None], axis=0) / mass_sum
-        mean_velocity = np.sum(velocities * masses[:, None], axis=0) / mass_sum
-        fixed_mask = self._fixed_mask(points.shape[0])
-        points[~fixed_mask] -= center[None, :]
-        velocities[~fixed_mask] -= mean_velocity[None, :]
-        velocities[fixed_mask] = 0.0
-        self.write_hc_state(HC, points, velocities, bV=bV)
-        self.mark_dirty()
-
-    def diagnostics(self, HC) -> dict[str, float]:
-        points, velocities = self.read_hc_state(HC)
-        tet_volumes, _matrix = tet_volume_matrix(points, self.tets)
-        target = self.tet_masses / np.maximum(self._density_by_tet(), 1.0e-300) if self.closure == "compressible" else self.reference_tet_volumes
-        nodal_mass = tet_volume_lumped_nodal_values(points.shape[0], self.tets, self.tet_masses)
-        nodal_volume = tet_volume_lumped_nodal_values(points.shape[0], self.tets, tet_volumes)
-        pressure = self.last_pressure_values if self.last_pressure_values is not None else np.zeros(self.tets.shape[0])
-        local_volume_rel = tet_volumes / np.maximum(target, 1.0e-300)
-        if self.phase_ids is not None and self.phase_densities:
-            tet_density_reference = self._density_by_tet()
-            nodal_density_reference = tet_volume_lumped_nodal_values(points.shape[0], self.tets, tet_density_reference * tet_volumes)
-            nodal_density_reference = nodal_density_reference / np.maximum(nodal_volume, 1.0e-300)
-        else:
-            nodal_density_reference = np.full(points.shape[0], float(self.density), dtype=float)
-        density_rel = nodal_mass / np.maximum(nodal_volume, 1.0e-300) / np.maximum(nodal_density_reference, 1.0e-300)
-        stats = {
-            "closure_pressure_pa": float(np.mean(pressure)) if np.asarray(pressure).size else 0.0,
-            "fheron_pressure_pa": float(self.last_fheron_pressure),
-            "vol_m3": float(np.sum(tet_volumes)),
-            "vol0_mesh_m3": float(np.sum(self.reference_tet_volumes)),
-            "vol_rel": float(np.sum(tet_volumes) / max(float(np.sum(self.reference_tet_volumes)), 1.0e-300)),
-            "local_volume_rel_max_abs": float(np.max(np.abs(local_volume_rel - 1.0))) if local_volume_rel.size else 0.0,
-            "nodal_density_rel_min": float(np.min(density_rel[nodal_volume > 0.0])) if np.any(nodal_volume > 0.0) else 1.0,
-            "nodal_density_rel_max": float(np.max(density_rel[nodal_volume > 0.0])) if np.any(nodal_volume > 0.0) else 1.0,
-            "total_mass_kg": float(np.sum(self.tet_masses)),
-            "max_speed_m_s": float(np.max(np.linalg.norm(velocities, axis=1))) if velocities.size else 0.0,
-            "solver_tet_count": float(self.tets.shape[0]),
-        }
-        stats.update(self.last_flux_stats)
-        stats.update(self.last_retopology_stats)
-        current_tet_set = {tuple(sorted(int(v) for v in tet)) for tet in self.tets}
-        union = self.reference_display_tet_set | current_tet_set
-        changed = self.reference_display_tet_set ^ current_tet_set
-        stats["display_tet_count"] = float(self.tets.shape[0])
-        stats["display_internal_face_count"] = float(len(tet_face_pairs(self.tets)))
-        stats["display_changed_tets"] = float(len(changed))
-        stats["display_changed_fraction"] = float(len(changed)) / max(float(len(union)), 1.0)
-        return stats
-
-
-def volume_gradient_pressure_acceleration(vertex, *, state: VolumeGradientPressureState, HC=None, dt=None, dim: int = 3, mu: float = 0.0) -> np.ndarray:
-    """Dynamic-integrator ``dudt_fn`` for tet-volume pressure closure."""
-    if HC is None:
-        HC = getattr(state, "HC", None)
-    return state.acceleration(vertex, HC=HC, dt=dt, dim=dim, mu=mu)
-
-
 
 # ---------------------------------------------------------------------------
 # Geometry: dual area vectors and dual volumes
@@ -1102,12 +63,13 @@ def dual_area_vector(v_i, v_j, HC, dim: int = 3) -> np.ndarray:
     vertices; A_ij is the outward-facing normal with magnitude equal to the
     segment length.
 
-    In 3D the dual face is the DEC p_ij polygon: tet barycenters interleaved
-    with face barycenters (x_i + x_j + x_k)/3.  This construction guarantees
-    linear precision (machine eps) for barycentric duals on any tetrahedral
-    mesh.  See :func:`_dual_area_vector_3d_p_ij`.  Falls back to the legacy
-    e_star fan-walk (:func:`_dual_area_vector_3d_e_star`) for boundary or
-    degenerate edges.
+    In 3D the dual face is a polygon triangulated into small triangles by
+    e_star; each triangle contributes a vector area A_ijk = 0.5 * cross(e1, e2).
+    The total is A_ij = sum_k A_ijk, oriented outward from v_i using the test:
+
+        vec_to_i = v_i.x_a - vc.x_a   (from dual face toward parcel i)
+        if dot(A_ijk, vec_to_i) > 0:   (points inward)
+            A_ijk = -A_ijk              (flip to outward)
 
     Parameters
     ----------
@@ -1134,67 +96,6 @@ def dual_area_vector(v_i, v_j, HC, dim: int = 3) -> np.ndarray:
         return np.array([np.sign(direction)])
 
     elif dim == 2:
-        # When periodic axes are set, always compute dual area from primal
-        # geometry using minimum-image coordinates.  compute_vd's dual
-        # vertex positions are wrong for any triangle that includes a
-        # periodic-face vertex with wrapped neighbors.
-        periodic_axes = getattr(HC, '_periodic_axes', None)
-        if periodic_axes:
-            periodic_bounds = HC._periodic_bounds
-            x_i = v_i.x_a[:2]
-
-            def _min_image(x_other):
-                result = x_other.copy()
-                for ax in periodic_axes:
-                    p = periodic_bounds[ax][1] - periodic_bounds[ax][0]
-                    delta = result[ax] - x_i[ax]
-                    result[ax] -= round(delta / p) * p
-                return result
-
-            x_j = _min_image(v_j.x_a[:2])
-            common = v_i.nn.intersection(v_j.nn)
-            if len(common) < 2:
-                # Boundary edge: use single triangle + edge midpoint
-                if len(common) < 1:
-                    return np.zeros(2)
-                v3 = list(common)[0]
-                x3 = _min_image(v3.x_a[:2])
-                bary = (x_i + x_j + x3) / 3.0
-                midpt = 0.5 * (x_i + x_j)
-                dual_edge = bary - midpt
-                A_ij = np.array([-dual_edge[1], dual_edge[0]])
-                vec_to_i = x_i - 0.5 * (bary + midpt)
-                if np.dot(A_ij, vec_to_i) > 0:
-                    A_ij = -A_ij
-                return A_ij
-            # Interior edge: pick two triangles (one on each side of edge).
-            # With ghost resolution, shared count can be >2. Use cross
-            # product sign to find one neighbor on each side.
-            edge_vec = x_j - x_i
-            left = None
-            right = None
-            for v3 in common:
-                x3 = _min_image(v3.x_a[:2])
-                cross = edge_vec[0] * (x3[1] - x_i[1]) - edge_vec[1] * (x3[0] - x_i[0])
-                if cross > 0 and left is None:
-                    left = x3
-                elif cross <= 0 and right is None:
-                    right = x3
-                if left is not None and right is not None:
-                    break
-            if left is None or right is None:
-                return np.zeros(2)
-            bary_l = (x_i + x_j + left) / 3.0
-            bary_r = (x_i + x_j + right) / 3.0
-            dual_edge = bary_l - bary_r
-            A_ij = np.array([-dual_edge[1], dual_edge[0]])
-            centroid = 0.5 * (bary_l + bary_r)
-            vec_to_i = x_i - centroid
-            if np.dot(A_ij, vec_to_i) > 0:
-                A_ij = -A_ij
-            return A_ij
-
-        # Standard (non-periodic) path
         vdnn = v_i.vd.intersection(v_j.vd)
         vd_list = list(vdnn)
         if len(vd_list) < 2:
@@ -1212,149 +113,23 @@ def dual_area_vector(v_i, v_j, HC, dim: int = 3) -> np.ndarray:
         return A_ij
 
     elif dim == 3:
-        try:
-            return _dual_area_vector_3d_p_ij(v_i, v_j, HC)
-        except ModuleNotFoundError:
-            # Compatibility fallback for HyperCT versions that do not expose
-            # the newer p_ij helper.  The pressure-reference benchmark itself
-            # uses B^T p, but existing stress-force callers still need a 3D
-            # dual-face area vector.
-            return _dual_area_vector_3d_e_star(v_i, v_j, HC)
+        from hyperct.ddg import e_star as _e_star
+        A_ijk_arr = _e_star(v_i, v_j, HC, dim=3)  # shape (N, 3)
+        if not isinstance(A_ijk_arr, np.ndarray) or A_ijk_arr.size == 0:
+            return np.zeros(3)
+        # Orientation reference: dual vertex on the face
+        vc_12_pos = 0.5 * (v_j.x_a - v_i.x_a) + v_i.x_a
+        vc_12 = HC.Vd[tuple(vc_12_pos)]
+        vec_to_i = v_i.x_a - vc_12.x_a
+        A_ij = np.zeros(3)
+        for A_ijk in A_ijk_arr:
+            if np.dot(A_ijk, vec_to_i) > 0:  # points inward -> flip
+                A_ijk = -A_ijk
+            A_ij += A_ijk
+        return A_ij
 
     else:
         raise NotImplementedError(f"dual_area_vector not implemented for dim={dim}")
-
-
-def _dual_area_vector_3d_p_ij(v_i, v_j, HC) -> np.ndarray:
-    """3D dual area vector using the DEC p_ij face construction.
-
-    The dual face polygon interleaves **tet barycenters** with **face
-    barycenters** ``(x_i + x_j + x_k) / 3`` of the primal triangular
-    faces shared by consecutive tetrahedra around edge ``(i, j)``.
-
-    This gives linear precision (machine epsilon) for barycentric duals
-    on any tetrahedral mesh — a property that the simpler polygon of
-    tet-barycenters-only does not satisfy because the non-planar face
-    produces an incorrect area vector when triangulated without the
-    intermediate face-barycenter vertices.
-
-    Falls back to :func:`_dual_area_vector_3d_e_star` when the
-    ring-walk or common-neighbor lookup fails (boundary / degenerate
-    topologies).
-    """
-    shared_vd = v_i.vd.intersection(v_j.vd)
-    if len(shared_vd) < 3:
-        # Boundary or degenerate — fall back
-        return _dual_area_vector_3d_e_star(v_i, v_j, HC)
-
-    # --- Build ring order from dual vertex connectivity ---
-    shared_list = list(shared_vd)
-    ring = [shared_list[0]]
-    remaining = set(shared_list[1:])
-    while remaining:
-        curr = ring[-1]
-        nxt = None
-        for cand in remaining:
-            if cand in curr.nn:
-                nxt = cand
-                break
-        if nxt is None:
-            break
-        ring.append(nxt)
-        remaining.discard(nxt)
-
-    if len(ring) < len(shared_list):
-        # Connectivity walk incomplete — fall back to angular sort.
-        # This happens for boundary-adjacent edges where dual vertices
-        # have truncated connectivity.
-        try:
-            from hyperct.ddg._dual_cell import _angular_sort_3d
-        except ModuleNotFoundError:
-            return _dual_area_vector_3d_e_star(v_i, v_j, HC)
-        sorted_ring = _angular_sort_3d(shared_list)
-        if sorted_ring is not None and len(sorted_ring) >= 3:
-            ring = sorted_ring
-        elif len(ring) < 3:
-            return _dual_area_vector_3d_e_star(v_i, v_j, HC)
-
-    # --- Common neighbors = opposite vertices of shared triangular faces ---
-    common_nbs = list(v_i.nn.intersection(v_j.nn))
-    if not common_nbs:
-        return _dual_area_vector_3d_e_star(v_i, v_j, HC)
-
-    x_i = v_i.x_a[:3]
-    x_j = v_j.x_a[:3]
-
-    # --- Build interleaved polygon: tet_bary, face_bary, ... ---
-    interleaved = []
-    for k in range(len(ring)):
-        tet_bary = ring[k].x_a[:3]
-        tet_next = ring[(k + 1) % len(ring)].x_a[:3]
-        interleaved.append(tet_bary)
-
-        # Find the face barycenter (x_i + x_j + x_k)/3 between these
-        # two consecutive tets.  The correct x_k is the common neighbor
-        # whose face barycenter lies closest to the midpoint of the two
-        # tet barycenters.
-        mid = 0.5 * (tet_bary + tet_next)
-        best_fb = None
-        best_dist = np.inf
-        for cn in common_nbs:
-            fb = (x_i + x_j + cn.x_a[:3]) / 3.0
-            dist = np.linalg.norm(fb - mid)
-            if dist < best_dist:
-                best_dist = dist
-                best_fb = fb
-        if best_fb is not None:
-            interleaved.append(best_fb)
-
-    polygon = np.array(interleaved)
-
-    # --- Compute area vector by centroid-fan triangulation ---
-    centroid = polygon.mean(axis=0)
-    A_ij = np.zeros(3)
-    n_pts = len(polygon)
-    for k in range(n_pts):
-        p1 = polygon[k]
-        p2 = polygon[(k + 1) % n_pts]
-        A_ij += 0.5 * np.cross(p1 - centroid, p2 - centroid)
-
-    # --- Orient outward from v_i ---
-    d_ij = x_j - x_i
-    if np.dot(A_ij, d_ij) < 0:
-        A_ij = -A_ij
-    return A_ij
-
-
-def _dual_area_vector_3d_e_star(v_i, v_j, HC) -> np.ndarray:
-    """3D dual area vector via the e_star fan-walk (legacy).
-
-    Uses the ``e_star`` fan-walk triangulation from the primal edge
-    midpoint through the shared dual vertices.  This was the original
-    implementation.  It does NOT satisfy linear precision for barycentric
-    duals on non-symmetric meshes because the non-planar face polygon
-    (tet barycenters only, without interleaved face barycenters) produces
-    an incorrect area vector.
-
-    Kept as fallback for boundary / degenerate topologies where the
-    p_ij ring-walk cannot be performed.
-    """
-    from hyperct.ddg import e_star as _e_star
-    try:
-        A_ijk_arr = _e_star(v_i, v_j, HC, dim=3)  # shape (N, 3)
-    except (IndexError, KeyError):
-        return np.zeros(3)
-    if not isinstance(A_ijk_arr, np.ndarray) or A_ijk_arr.size == 0:
-        return np.zeros(3)
-    vc_12_pos = 0.5 * (v_j.x_a - v_i.x_a) + v_i.x_a
-    vc_12 = HC.Vd[tuple(vc_12_pos)]
-    vec_to_i = v_i.x_a - vc_12.x_a
-    A_ij = np.zeros(3)
-    for A_ijk in A_ijk_arr:
-        if np.dot(A_ijk, vec_to_i) > 0:
-            A_ijk = -A_ijk
-        A_ij += A_ijk
-    return A_ij
 
 
 def dual_volume(v, HC, dim: int = 3) -> float:
@@ -1385,21 +160,9 @@ def dual_volume(v, HC, dim: int = 3) -> float:
     -----
     # TODO: move to hyperct.ddg._operators (pure geometry, no physics)
     """
-    if dim == 1:
-        # 1D dual cell = interval between the two dual vertices
-        vd_list = list(v.vd)
-        if len(vd_list) < 2:
-            # Boundary vertex with single dual vertex: half-edge
-            if len(vd_list) == 1 and v.nn:
-                v_j = next(iter(v.nn))
-                return 0.5 * abs(v_j.x_a[0] - v.x_a[0])
-            return 0.0
-        positions = [vd.x_a[0] for vd in vd_list]
-        return max(positions) - min(positions)
-
-    elif dim == 2:
-        from hyperct.ddg import dual_cell_area_2d
-        return dual_cell_area_2d(v, include_edge_midpoints=True)
+    if dim <= 2:
+        from hyperct.ddg import d_area
+        return d_area(v)
 
     elif dim == 3:
         from hyperct.ddg import v_star as _v_star
@@ -1441,11 +204,7 @@ def cache_dual_volumes(HC, dim: int = 3) -> None:
         Spatial dimension.
     """
     for v in HC.V:
-        try:
-            v.dual_vol = dual_volume(v, HC, dim)
-        except (ValueError, IndexError):
-            # Degenerate vertex (e.g. domain corner with too few neighbors)
-            v.dual_vol = 0.0
+        v.dual_vol = dual_volume(v, HC, dim)
 
 
 def _get_dual_vol(v, HC, dim: int = 3) -> float:
@@ -1491,19 +250,72 @@ def velocity_difference_tensor(v, HC, dim: int = 3) -> np.ndarray:
         Integrated velocity difference tensor, shape ``(dim, dim)``.
         Component ``Du_i[a, b] = 0.5 * sum_j (u_j^a - u_i^a) * A_ij^b``.
     """
-    _cache = getattr(HC, '_edge_area_cache', None)
-    _vid = id(v) if _cache is not None else None
-
-    Du_i = np.zeros((dim, dim))
-    for v_j in v.nn:
-        if _cache is not None and _vid in _cache and id(v_j) in _cache[_vid]:
-            A_ij = _cache[_vid][id(v_j)]
-        else:
-            A_ij = dual_area_vector(v, v_j, HC, dim)
-        delta_u = v_j.u[:dim] - v.u[:dim]
-        Du_i += np.outer(delta_u, A_ij)
-    Du_i *= 0.5
+    Du_i, _ = _velocity_difference_tensor_partial(v, HC, dim)
     return Du_i
+
+
+def _velocity_difference_tensor_partial(v, HC, dim: int = 3):
+    """Boundary-safe integrated velocity difference tensor.
+
+    Uses all neighbors whose dual-area contribution can be evaluated, and
+    skips invalid/degenerate neighbors instead of raising.  This enables
+    partial-fan DDG reconstruction near boundaries or locally broken dual
+    connectivity.
+
+    Returns
+    -------
+    tuple[np.ndarray, list]
+        ``(Du_i, valid_neighbors)`` where ``Du_i`` is shape ``(dim, dim)``.
+    """
+    Du_i = np.zeros((dim, dim))
+    valid_neighbors = []
+    for v_j in v.nn:
+        try:
+            A_ij = dual_area_vector(v, v_j, HC, dim)
+        except (
+            KeyError,
+            IndexError,
+            ValueError,
+            RuntimeError,
+            ZeroDivisionError,
+            StopIteration,
+        ):
+            continue
+
+        A_ij = np.asarray(A_ij, dtype=float)
+        if A_ij.shape != (dim,) or not np.all(np.isfinite(A_ij)):
+            continue
+
+        delta_u = np.asarray(v_j.u[:dim] - v.u[:dim], dtype=float)
+        if delta_u.shape != (dim,) or not np.all(np.isfinite(delta_u)):
+            continue
+
+        Du_i += np.outer(delta_u, A_ij)
+        valid_neighbors.append(v_j)
+
+    Du_i *= 0.5
+    return Du_i, valid_neighbors
+
+
+def _dual_volume_partial(v, HC, neighbors, dim: int = 3) -> float:
+    """Dual-volume approximation using only the supplied neighbor subset."""
+    if dim <= 2:
+        return _get_dual_vol(v, HC, dim)
+
+    from hyperct.ddg import v_star as _v_star
+
+    total_vol = 0.0
+    for v_j in neighbors:
+        try:
+            result = _v_star(v, v_j, HC, dim=3)
+            if isinstance(result, tuple) and len(result) == 2:
+                _, V_ij = result
+                total_vol += np.sum(np.abs(V_ij))
+            else:
+                total_vol += float(result)
+        except (KeyError, IndexError, ValueError, RuntimeError, ZeroDivisionError):
+            continue
+    return float(total_vol)
 
 
 def velocity_difference_tensor_pointwise(v, HC, dim: int = 3) -> np.ndarray:
@@ -1526,58 +338,14 @@ def velocity_difference_tensor_pointwise(v, HC, dim: int = 3) -> np.ndarray:
     np.ndarray
         Pointwise velocity gradient, shape ``(dim, dim)``.
     """
-    Vol_i = _get_dual_vol(v, HC, dim)
+    Du_i, valid_neighbors = _velocity_difference_tensor_partial(v, HC, dim)
+    if not valid_neighbors:
+        return np.zeros((dim, dim))
+
+    Vol_i = _dual_volume_partial(v, HC, valid_neighbors, dim)
     if Vol_i < 1e-30:
         return np.zeros((dim, dim))
-    return velocity_difference_tensor(v, HC, dim) / Vol_i
-
-
-def scalar_gradient_integrated(
-    v,
-    HC,
-    dim: int = 3,
-    field_attr: str = 'f',
-) -> np.ndarray:
-    """Integrated gradient of a scalar field over the dual cell of v.
-
-    Computes the DDG volume-integrated quantity::
-
-        Df_i = 0.5 * sum_j (f_j - f_i) * A_ij
-
-    This is the scalar analog of :func:`velocity_difference_tensor`.
-    It approximates ``∫_{V_i} ∇f dV``.
-
-    Parameters
-    ----------
-    v : vertex object
-        Must have the scalar field attribute (default ``v.f``) and
-        ``v.nn``, ``v.vd`` populated.
-    HC : Complex
-        Simplicial complex with duals computed.
-    dim : int
-        Spatial dimension.
-    field_attr : str
-        Name of the scalar field attribute on vertices (default ``'f'``).
-
-    Returns
-    -------
-    np.ndarray
-        Integrated gradient vector, shape ``(dim,)``.
-    """
-    _cache = getattr(HC, '_edge_area_cache', None)
-    _vid = id(v) if _cache is not None else None
-
-    f_i = getattr(v, field_attr)
-    Df_i = np.zeros(dim)
-    for v_j in v.nn:
-        if _cache is not None and _vid in _cache and id(v_j) in _cache[_vid]:
-            A_ij = _cache[_vid][id(v_j)]
-        else:
-            A_ij = dual_area_vector(v, v_j, HC, dim)
-        delta_f = getattr(v_j, field_attr) - f_i
-        Df_i += delta_f * A_ij
-    Df_i *= 0.5
-    return Df_i
+    return Du_i / Vol_i
 
 
 def strain_rate(du: np.ndarray) -> np.ndarray:
@@ -1680,77 +448,13 @@ def integrated_cauchy_stress(
     return -p * Vol_i * np.eye(dim) + 2.0 * mu * strain_rate(Du)
 
 
-def _resolve_pressure(v, pressure_model, HC, dim):
-    """Resolve the pressure for a single vertex.
-
-    Parameters
-    ----------
-    v : vertex object
-    pressure_model : None, callable, or EquationOfState
-        - ``None``: read ``v.p`` as-is (default, incompressible).
-        - callable ``fn(v) -> float``: externally defined pressure field.
-        - :class:`~ddgclib.eos.EquationOfState`: compute pressure from
-          density ``rho = v.m / dual_vol`` via the EOS.  Also updates
-          ``v.p`` and ``v.rho`` in-place so downstream code sees fresh
-          values.
-    HC : Complex
-    dim : int
-
-    Returns
-    -------
-    float
-        Pressure at the vertex.
-    """
-    if pressure_model is None:
-        p = v.p
-        return float(p) if np.ndim(p) == 0 else float(p[0])
-
-    if callable(pressure_model) and not hasattr(pressure_model, 'pressure'):
-        # Plain callable: fn(v) -> float
-        return float(pressure_model(v))
-
-    # EquationOfState: P = eos.pressure(m / dual_vol)
-    # Uses cached dual_vol (updated by _retopologize at each step).
-    vol = _get_dual_vol(v, HC, dim)
-    if vol < 1e-30:
-        return float(pressure_model.pressure(pressure_model.rho0))
-    rho = v.m / vol
-    p = float(pressure_model.pressure(rho))
-    # Update vertex in-place so other code (callbacks, diagnostics) sees it
-    v.rho = rho
-    v.p = p
-    return p
-
-
-# ---------------------------------------------------------------------------
-# Factored flux primitives (shared by stress_force and multiphase_stress)
-# ---------------------------------------------------------------------------
-
-def pressure_flux(p_i: float, p_j: float, A_ij: np.ndarray) -> np.ndarray:
-    """Face-average pressure flux: F_p_ij = -0.5 * (p_i + p_j) * A_ij."""
-    return -0.5 * (p_i + p_j) * A_ij
-
-
-def viscous_flux(
-    mu: float,
-    delta_u: np.ndarray,
-    d_ij: np.ndarray,
-    A_ij: np.ndarray,
+def stress_force(
+    v,
+    dim: int = 3,
+    mu: float = 8.9e-4,
+    HC=None,
 ) -> np.ndarray:
-    """Face-centered viscous diffusion flux.
-
-    F_v_ij = (mu / |d_ij|) * delta_u * (d_hat . A_ij)
-    """
-    d_norm = float(np.linalg.norm(d_ij))
-    if d_norm < 1e-30:
-        return np.zeros_like(A_ij)
-    d_hat = d_ij / d_norm
-    return (mu / d_norm) * delta_u * np.dot(d_hat, A_ij)
-
-
-def stress_force(v, dim: int = 3, mu: float = 8.9e-4, HC=None,
-                 pressure_model=None) -> np.ndarray:
-    """Integrated force on FVM via face-centered fluxes (Stokes' theorem).
+    """Integrated force on a parcel via face-centered fluxes.
 
     For each dual flux plane between parcels i and j, the force has two
     contributions computed directly from edge data:
@@ -1784,42 +488,38 @@ def stress_force(v, dim: int = 3, mu: float = 8.9e-4, HC=None,
         Dynamic viscosity [Pa.s].
     HC : Complex
         Simplicial complex with duals computed.
-    pressure_model : None, callable, or EquationOfState
-        Controls how vertex pressure is obtained:
-
-        - ``None`` (default): read ``v.p`` as-is (prescribed or constant).
-        - callable ``fn(v) -> float``: externally defined pressure field,
-          evaluated each time the force is computed.
-        - :class:`~ddgclib.eos.EquationOfState`: weakly compressible
-          pressure from density ``rho = m / dual_vol``.  Updates ``v.p``
-          and ``v.rho`` in-place.
-
     Returns
     -------
     np.ndarray
         Force vector, shape ``(dim,)``.
     """
-    p_i = _resolve_pressure(v, pressure_model, HC, dim)
-    u_i = v.u[:dim]
-    x_i = v.x_a[:dim]
-
-    # Use cached oriented edge area vectors when available (set by
-    # batch_e_star(..., orient=True) during retopologization).
-    _cache = getattr(HC, '_edge_area_cache', None)
-    _vid = id(v) if _cache is not None else None
-
     F = np.zeros(dim)
-    for v_j in v.nn:
-        if _cache is not None and _vid in _cache and id(v_j) in _cache[_vid]:
-            A_ij = _cache[_vid][id(v_j)]
-        else:
-            A_ij = dual_area_vector(v, v_j, HC, dim)
+    can_use_flux_terms = HC is not None and hasattr(v, "vd")
 
-        p_j = _resolve_pressure(v_j, pressure_model, HC, dim)
-        delta_u = v_j.u[:dim] - u_i
-        d_ij = v_j.x_a[:dim] - x_i
-        F += pressure_flux(p_i, p_j, A_ij)
-        F += viscous_flux(mu, delta_u, d_ij, A_ij)
+    if can_use_flux_terms:
+        p_i = float(v.p) if np.ndim(v.p) == 0 else float(v.p[0])
+        u_i = v.u[:dim]
+        x_i = v.x_a[:dim]
+
+        for v_j in v.nn:
+            try:
+                A_ij = dual_area_vector(v, v_j, HC, dim)
+            except (KeyError, IndexError, ValueError, RuntimeError, ZeroDivisionError):
+                continue
+
+            # --- Pressure flux (face-average, conservative) ---
+            p_j = float(v_j.p) if np.ndim(v_j.p) == 0 else float(v_j.p[0])
+            F -= 0.5 * (p_i + p_j) * A_ij
+
+            # --- Viscous flux (face-centered diffusion) ---
+            delta_u = v_j.u[:dim] - u_i
+            d_ij = v_j.x_a[:dim] - x_i
+            d_norm = np.linalg.norm(d_ij)
+            if d_norm < 1e-30:
+                continue
+            d_hat = d_ij / d_norm
+            # mu * (grad u)_f . A = (mu/|d|) * du * (d_hat . A)
+            F += (mu / d_norm) * delta_u * np.dot(d_hat, A_ij)
 
     return F
 
@@ -1829,7 +529,6 @@ def stress_acceleration(
     dim: int = 3,
     mu: float = 8.9e-4,
     HC=None,
-    pressure_model=None,
 ) -> np.ndarray:
     """Acceleration from Cauchy stress: a_i = F_stress_i / m_i.
 
@@ -1845,13 +544,6 @@ def stress_acceleration(
         dudt_fn = partial(stress_acceleration, dim=3, mu=1e-3, HC=HC)
         t = euler(HC, bV, dudt_fn, dt=1e-4, n_steps=100)
 
-    For weakly compressible flow with an equation of state::
-
-        from ddgclib.eos import TaitMurnaghan
-        eos = TaitMurnaghan(rho0=1000.0, P0=101325.0)
-        dudt_fn = partial(stress_acceleration, dim=2, mu=1e-3, HC=HC,
-                          pressure_model=eos)
-
     Parameters
     ----------
     v : vertex object
@@ -1862,16 +554,13 @@ def stress_acceleration(
         Dynamic viscosity [Pa.s].
     HC : Complex
         Simplicial complex with duals computed.
-    pressure_model : None, callable, or EquationOfState
-        See :func:`stress_force`.
-
     Returns
     -------
     np.ndarray
         Acceleration vector, shape ``(dim,)``.
     """
-    return stress_force(v, dim=dim, mu=mu, HC=HC,
-                        pressure_model=pressure_model) / v.m
+    F = stress_force(v, dim=dim, mu=mu, HC=HC)
+    return F / v.m
 
 
 # Simplified alias for use as dudt_fn in dynamic integrators


### PR DESCRIPTION
Adds an oscillating-droplet pressure-reference benchmark under `cases_dynamic/oscillating_droplet_p_ref`, including the 20260604 PPT deck, reproduction scripts for cases #1-#12, ddgclib-backed dynamic-integrator validations for #5/#6/#11/#12, and a README with equations, references, commands, and validation numbers.

Implements Stefan's requested volume-gradient pressure replacement as a non-breaking operator path:

- `VolumeGradientPressureState` and `volume_gradient_pressure_acceleration` in `ddgclib/operators/stress.py`
- `MultiphaseVolumeGradientPressureState` and `multiphase_volume_gradient_pressure_acceleration` in `ddgclib/operators/multiphase_stress.py`
- pressure force `F_i^p = sum_{t contains i} p_t B_{t,i}` with `B_{t,i} = dV_t/dx_i`
- weak-compressible EOS correction and local incompressible projection using the same tet-volume operator `B`
- ALE material-face flux diagnostics, with the physical Lagrangian case giving zero internal mass flux

Why this is needed:

The upstream oscillating-droplet retopology can change HC local dual volumes after a Delaunay flip. If density/pressure is read from that changing HC dual volume, a connectivity change is interpreted as physical compression, causing artificial density/pressure jumps and wrong oscillation frequency. This benchmark instead rebuilds tet volumes, the volume-gradient matrix, target tet volumes, and lumped nodal masses after retopology, so pressure reacts to the same tet-volume error that it corrects.

Two-phase retopology validation:

#11/#12 use a liquid+gas mesh, actively retriangulate the full liquid+gas vertex cloud, reclassify new tets by persistent Lagrangian vertex phase, and rebuild the liquid EOS/projection pressure operator from the liquid tet subset. The validation rows report more than 1000 changed combined tets while the `a2(t)` response remains close to Rayleigh theory.

Validation:

- `python3 -m py_compile` on the modified operator files and new dynamic-integrator/render scripts
- #11 dynamic run: final `a2 = 0.02830`, Rayleigh `a2 = 0.02989`, changed tets `1084`
- #12 dynamic run: final `a2 = 0.02830`, Rayleigh `a2 = 0.02989`, changed tets `1060`
